### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-api-worker.yml
+++ b/.github/workflows/deploy-api-worker.yml
@@ -1,5 +1,8 @@
 name: Deploy API Worker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/goldshore/astro-goldshore/security/code-scanning/4](https://github.com/goldshore/astro-goldshore/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow, limiting the GITHUB_TOKEN to only the minimal set of permissions needed. In this workflow none of the steps require write access to the repository, so setting `contents: read` is appropriate and aligns with the principle of least privilege. This can be accomplished by adding the following at the top level of the workflow, directly after (or before) the `on:` declaration. No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
