### PR TITLE
Add GoldShore worker scaffolds

### DIFF
--- a/apps/api-worker/package.json
+++ b/apps/api-worker/package.json
@@ -1,19 +1,18 @@
 {
   "name": "@goldshore/api",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "main": "src/index.ts",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --config wrangler.toml",
-    "deploy": "wrangler deploy src/index.ts --config wrangler.toml",
-    "build": "wrangler deploy src/index.ts --dry-run --outdir=dist --config wrangler.toml"
+    "dev": "wrangler dev src/index.ts",
+    "deploy": "wrangler deploy",
+    "build": "wrangler deploy --dry-run --outdir=dist"
   },
   "dependencies": {
-    "hono": "^4.6.0"
+    "hono": "^4.0.0"
   },
   "devDependencies": {
-    "wrangler": "^3.92.0",
-    "@cloudflare/workers-types": "^4.20241112.0",
-    "typescript": "^5.9.3"
+    "wrangler": "^3.101.0",
+    "typescript": "^5.4.0",
+    "@cloudflare/workers-types": "^4.20240512.0"
   }
 }

--- a/apps/api-worker/src/index.ts
+++ b/apps/api-worker/src/index.ts
@@ -1,27 +1,17 @@
 import { Hono } from "hono";
+import health from "./routes/health";
+import user from "./routes/user";
+import system from "./routes/system";
 
-type Bindings = {
-  KV: KVNamespace;
-  ASSETS: R2Bucket;
-  DB: D1Database;
-  AI: any; // Using 'any' to be safe, or 'Ai' if sure. Scaffold used 'Ai'.
-};
+const app = new Hono();
 
-const app = new Hono<{ Bindings: Bindings }>();
+// health
+app.route("/health", health);
 
-app.get("/health", (c) => c.json({ ok: true, service: "gs-api" }));
+// user
+app.route("/user", user);
 
-app.get("/v1/hello", (c) =>
-  c.json({
-    message: "Hello from gs-api",
-    time: new Date().toISOString()
-  })
-);
-
-// Merged routes from previous work
-app.get('/v1/users', (c) => c.json({ users: ['user1', 'user2'] }))
-app.get('/v1/agents', (c) => c.json({ agents: ['agent-alpha', 'agent-beta'] }))
-app.get('/v1/models', (c) => c.json({ models: ['gpt-4', 'claude-3'] }))
-app.get('/v1/logs', (c) => c.json({ logs: ['log1', 'log2'] }))
+// system
+app.route("/system", system);
 
 export default app;

--- a/apps/api-worker/src/routes/ai.ts
+++ b/apps/api-worker/src/routes/ai.ts
@@ -1,9 +1,0 @@
-import { Hono } from "hono";
-
-const ai = new Hono();
-
-ai.get("/", async (c) => {
-  return c.json({ message: "AI route" });
-});
-
-export default ai;

--- a/apps/api-worker/src/routes/health.ts
+++ b/apps/api-worker/src/routes/health.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 
 const health = new Hono();
-health.get("/", (c) => c.json({ status: "ok", service: "gs-api" }));
+
+health.get("/", (c) => {
+  return c.json({ status: "ok", service: "gs-api" });
+});
 
 export default health;

--- a/apps/api-worker/src/routes/system.ts
+++ b/apps/api-worker/src/routes/system.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+
+const system = new Hono();
+
+system.get("/info", (c) => {
+  return c.json({
+    service: "gs-api",
+    timestamp: Date.now(),
+  });
+});
+
+export default system;

--- a/apps/api-worker/src/routes/user.ts
+++ b/apps/api-worker/src/routes/user.ts
@@ -1,0 +1,10 @@
+import { Hono } from "hono";
+
+const user = new Hono();
+
+user.get("/:id", async (c) => {
+  const id = c.req.param("id");
+  return c.json({ user: id, msg: "User endpoint working" });
+});
+
+export default user;

--- a/apps/api-worker/src/routes/users.ts
+++ b/apps/api-worker/src/routes/users.ts
@@ -1,9 +1,0 @@
-import { Hono } from "hono";
-
-const users = new Hono();
-
-users.get("/", async (c) => {
-  return c.json([{ id: 1, email: "admin@goldshore.ai" }]);
-});
-
-export default users;

--- a/apps/api-worker/wrangler.toml
+++ b/apps/api-worker/wrangler.toml
@@ -3,17 +3,17 @@ main = "src/index.ts"
 compatibility_date = "2024-11-01"
 
 [[kv_namespaces]]
-binding = "KV"
-id = "gs_api_kv_001"
+binding = "GS_KV"
+id = "gs_api_kv_prod_001"
 
 [[r2_buckets]]
-binding = "ASSETS"
+binding = "GS_ASSETS"
 bucket_name = "gs-api-assets"
 
 [[d1_databases]]
-binding = "DB"
-database_name = "gs_prod"
-database_id = "gs_prod_db_001"
+binding = "GS_DB"
+database_name = "gs_database"
+database_id = "gs_database_id_001"
 
 [ai]
 binding = "AI"

--- a/apps/control-worker/package.json
+++ b/apps/control-worker/package.json
@@ -1,19 +1,18 @@
 {
-  "name": "@goldshore/control-worker",
-  "version": "0.0.1",
+  "name": "@goldshore/control",
+  "version": "0.1.0",
   "private": true,
-  "main": "src/index.ts",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev src/index.ts",
     "deploy": "wrangler deploy",
-    "build": "wrangler deploy --dry-run --outdir=dist"
+    "run-task": "wrangler dev src/index.ts --test-scheduled"
   },
   "dependencies": {
-    "@goldshore/utils": "workspace:*"
+    "hono": "^4.0.0"
   },
   "devDependencies": {
-    "wrangler": "^3.0.0",
-    "typescript": "^5.0.0",
-    "@cloudflare/workers-types": "^4.0.0"
+    "wrangler": "^3.101.0",
+    "typescript": "^5.4.0",
+    "@cloudflare/workers-types": "^4"
   }
 }

--- a/apps/control-worker/src/index.ts
+++ b/apps/control-worker/src/index.ts
@@ -1,14 +1,27 @@
-import { syncDNS } from "./tasks/syncDNS";
-import { rotateKeys } from "./tasks/rotateKeys";
+import { Hono } from "hono";
+import * as DNS from "./libs/dns";
+import * as Workers from "./libs/workers";
+import * as Pages from "./libs/pages";
+import * as Access from "./libs/access";
+import type { ControlEnv } from "./libs/types";
 
-export interface Env {
-  CONTROL_LOGS: KVNamespace;
-}
+const app = new Hono<{ Bindings: ControlEnv }>();
 
-export default {
-  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {
-    await env.CONTROL_LOGS.put(Date.now().toString(), "control-run");
-    await syncDNS(env);
-    await rotateKeys(env);
-  }
-};
+app.get("/", (c) => c.json({ service: "gs-control", ok: true }));
+
+app.post("/dns/apply", async (c) => {
+  const result = await DNS.sync(c.env);
+  return c.json(result);
+});
+
+app.post("/workers/reconcile", async (c) => {
+  const result = await Workers.reconcile(c.env);
+  return c.json(result);
+});
+
+app.post("/pages/deploy", async (c) => {
+  const result = await Pages.deploy(c.env);
+  return c.json(result);
+});
+
+export default app;

--- a/apps/control-worker/src/libs/access.ts
+++ b/apps/control-worker/src/libs/access.ts
@@ -1,0 +1,12 @@
+import type { ControlEnv } from "./types";
+
+export async function apply(env: ControlEnv) {
+  const logKey = `access-apply-${Date.now()}`;
+  await env.CONTROL_LOGS.put(logKey, "access-apply");
+
+  return {
+    ok: true,
+    action: "access-apply",
+    loggedAt: logKey
+  };
+}

--- a/apps/control-worker/src/libs/dns.ts
+++ b/apps/control-worker/src/libs/dns.ts
@@ -1,0 +1,12 @@
+import type { ControlEnv } from "./types";
+
+export async function sync(env: ControlEnv) {
+  const logKey = `dns-sync-${Date.now()}`;
+  await env.CONTROL_LOGS.put(logKey, "dns-sync-run");
+
+  return {
+    ok: true,
+    action: "dns-sync",
+    loggedAt: logKey
+  };
+}

--- a/apps/control-worker/src/libs/pages.ts
+++ b/apps/control-worker/src/libs/pages.ts
@@ -1,0 +1,12 @@
+import type { ControlEnv } from "./types";
+
+export async function deploy(env: ControlEnv) {
+  const logKey = `pages-deploy-${Date.now()}`;
+  await env.CONTROL_LOGS.put(logKey, "pages-deploy");
+
+  return {
+    ok: true,
+    action: "pages-deploy",
+    loggedAt: logKey
+  };
+}

--- a/apps/control-worker/src/libs/types.ts
+++ b/apps/control-worker/src/libs/types.ts
@@ -1,0 +1,6 @@
+export interface ControlEnv {
+  CONTROL_LOGS: KVNamespace;
+  STATE: R2Bucket;
+  API: Fetcher;
+  GATEWAY: Fetcher;
+}

--- a/apps/control-worker/src/libs/workers.ts
+++ b/apps/control-worker/src/libs/workers.ts
@@ -1,0 +1,12 @@
+import type { ControlEnv } from "./types";
+
+export async function reconcile(env: ControlEnv) {
+  const logKey = `workers-reconcile-${Date.now()}`;
+  await env.CONTROL_LOGS.put(logKey, "workers-reconcile");
+
+  return {
+    ok: true,
+    action: "workers-reconcile",
+    loggedAt: logKey
+  };
+}

--- a/apps/control-worker/src/tasks/rotateKeys.ts
+++ b/apps/control-worker/src/tasks/rotateKeys.ts
@@ -1,5 +1,0 @@
-import { Env } from "../index";
-
-export async function rotateKeys(env: Env) {
-  console.log("Rotating API keys (todo)");
-}

--- a/apps/control-worker/src/tasks/syncDNS.ts
+++ b/apps/control-worker/src/tasks/syncDNS.ts
@@ -1,8 +1,0 @@
-import { Env } from "../index";
-
-export async function syncDNS(env: Env) {
-  // Example DNS sync logic
-  // const res = await env.API.fetch("https://api.goldshore.ai/health");
-  // return res.ok;
-  console.log("Syncing DNS...");
-}

--- a/apps/control-worker/tsconfig.json
+++ b/apps/control-worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/control-worker/wrangler.toml
+++ b/apps/control-worker/wrangler.toml
@@ -1,10 +1,21 @@
 name = "gs-control"
 main = "src/index.ts"
-compatibility_date = "2024-01-01"
-
-[observability]
-enabled = true
+compatibility_date = "2024-12-01"
 
 [[kv_namespaces]]
 binding = "CONTROL_LOGS"
-id = "CONTROL_LOGS_ID" # Replace with actual ID in production
+id = "gs_control_logs_001"
+
+[[r2_buckets]]
+binding = "STATE"
+bucket_name = "gs-control-state"
+
+[[services]]
+binding = "API"
+service = "gs-api"
+environment = "production"
+
+[[services]]
+binding = "GATEWAY"
+service = "gs-gateway"
+environment = "production"

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -1,19 +1,18 @@
 {
   "name": "@goldshore/gateway",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
-  "main": "src/index.ts",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --config wrangler.toml",
-    "deploy": "wrangler deploy src/index.ts --config wrangler.toml",
-    "build": "wrangler deploy src/index.ts --dry-run --outdir=dist --config wrangler.toml"
+    "dev": "wrangler dev src/index.ts",
+    "deploy": "wrangler deploy",
+    "build": "wrangler deploy --dry-run --outdir=dist"
   },
   "dependencies": {
-    "hono": "^4.6.0"
+    "hono": "^4.0.0"
   },
   "devDependencies": {
-    "wrangler": "^3.92.0",
-    "@cloudflare/workers-types": "^4.20241112.0",
-    "typescript": "^5.9.3"
+    "wrangler": "^3.101.0",
+    "@cloudflare/workers-types": "^4",
+    "typescript": "^5.4.0"
   }
 }

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -1,20 +1,18 @@
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 
-type Bindings = {
-  API: Fetcher; // service binding to gs-api
-  AI: any;
-};
+const app = new Hono();
 
-const app = new Hono<{ Bindings: Bindings }>();
+app.get("/", (c) => c.json({ service: "gs-gateway", ok: true }));
 
-app.use('*', cors());
-
-app.get("/health", (c) => c.json({ ok: true, service: "gs-gateway" }));
-
-// Forward all requests to API (matching wiring requirement gw.goldshore.ai/* -> API)
-app.all("*", async (c) => {
-  return c.env.API.fetch(c.req.raw);
+// forward all API calls
+app.all("/api/*", async (c) => {
+  const path = c.req.path.replace("/api", "");
+  const response = await fetch(`https://api.goldshore.ai${path}`, {
+    method: c.req.method,
+    headers: c.req.header(),
+    body: c.req.raw.body
+  });
+  return response;
 });
 
 export default app;

--- a/apps/gateway/wrangler.toml
+++ b/apps/gateway/wrangler.toml
@@ -1,5 +1,6 @@
 name = "gs-gateway"
-compatibility_date = "2024-01-01"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
 
 [[services]]
 binding = "API"
@@ -8,6 +9,3 @@ environment = "production"
 
 [ai]
 binding = "AI"
-
-[observability]
-enabled = true


### PR DESCRIPTION
## Summary
- align the gs-api worker with the provided Hono routing structure and updated Wrangler bindings
- refresh the gs-gateway worker to proxy /api traffic and match the new configuration expectations
- scaffold the gs-control automation worker with new libraries, routes, and TypeScript configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a73aefe4883319fcecb2e45b2224f)