### PR TITLE
Fix layout imports for web build

### DIFF
--- a/apps/admin/src/layouts/AdminLayout.astro
+++ b/apps/admin/src/layouts/AdminLayout.astro
@@ -1,5 +1,5 @@
 ---
-import '@goldshore/theme/tokens.css';
+import '@goldshore/theme/tokens';
 
 interface Props {
 	title: string;

--- a/apps/admin/src/pages/admin/overview.astro
+++ b/apps/admin/src/pages/admin/overview.astro
@@ -1,5 +1,5 @@
 ---
-import AdminLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import AdminLayout from '../../layouts/AdminLayout.astro';
 import GSButton from '@packages/ui/GSButton.astro';
 
 // Initial UI state

--- a/apps/admin/src/pages/admin/system.astro
+++ b/apps/admin/src/pages/admin/system.astro
@@ -1,5 +1,5 @@
 ---
-import AdminLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import AdminLayout from '../../layouts/AdminLayout.astro';
 ---
 <AdminLayout title="System | GoldShore Admin">
     <section class="max-w-5xl mx-auto py-24 px-6">

--- a/apps/admin/src/pages/admin/users.astro
+++ b/apps/admin/src/pages/admin/users.astro
@@ -1,5 +1,5 @@
 ---
-import AdminLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import AdminLayout from '../../layouts/AdminLayout.astro';
 ---
 <AdminLayout title="Users | GoldShore Admin">
     <section class="max-w-5xl mx-auto py-24 px-6">

--- a/apps/admin/src/pages/admin/workers.astro
+++ b/apps/admin/src/pages/admin/workers.astro
@@ -1,5 +1,5 @@
 ---
-import AdminLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import AdminLayout from '../../layouts/AdminLayout.astro';
 ---
 <AdminLayout title="Workers | GoldShore Admin">
     <section class="max-w-5xl mx-auto py-24 px-6">

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import '@packages/theme/tokens.css';
+import '@goldshore/theme/tokens';
 const { title = "GoldShore Labs" } = Astro.props;
 ---
 <!DOCTYPE html>

--- a/apps/web/src/layouts/MarketingLayout.astro
+++ b/apps/web/src/layouts/MarketingLayout.astro
@@ -2,21 +2,6 @@
 import '@goldshore/theme';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
-const { title } = Astro.props;
----
-
-<html>
-  <head>
-    <title>{title}</title>
-  </head>
-  <body>
-    <Nav />
-    <main><slot /></main>
-    <Footer />
-  </body>
-</html>
-import Nav from '../components/Nav.astro';
-import Footer from '../components/Footer.astro';
 const { title = 'GoldShore' } = Astro.props;
 ---
 

--- a/apps/web/src/pages/about.astro
+++ b/apps/web/src/pages/about.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="About | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">

--- a/apps/web/src/pages/app/dashboard.astro
+++ b/apps/web/src/pages/app/dashboard.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Dashboard | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">

--- a/apps/web/src/pages/app/logs.astro
+++ b/apps/web/src/pages/app/logs.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Logs | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">

--- a/apps/web/src/pages/app/profile.astro
+++ b/apps/web/src/pages/app/profile.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Profile | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">

--- a/apps/web/src/pages/app/settings.astro
+++ b/apps/web/src/pages/app/settings.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Settings | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">

--- a/apps/web/src/pages/contact.astro
+++ b/apps/web/src/pages/contact.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Contact | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6 space-y-4">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import '@goldshore/theme/tokens.css';
+import '@goldshore/theme/tokens';
 
 // Goldshore Landing Page
 // Aesthetic: Military x Tech, Sports Car, Utility

--- a/apps/web/src/pages/legal/privacy.astro
+++ b/apps/web/src/pages/legal/privacy.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Privacy Policy | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6 space-y-4">

--- a/apps/web/src/pages/legal/terms.astro
+++ b/apps/web/src/pages/legal/terms.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Terms of Service | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6 space-y-4">

--- a/apps/web/src/pages/pricing.astro
+++ b/apps/web/src/pages/pricing.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '@apps/web/src/layouts/BaseLayout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="Pricing | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,4 +1,4 @@
-@import "@theme/tokens.css";
+@import "@goldshore/theme/tokens";
 
 :root {
   font-family: var(--font-body, sans-serif);


### PR DESCRIPTION
## Summary
- fix marketing layout frontmatter and theme token imports
- switch web and admin pages to use correct relative layout paths
- ensure theme tokens are imported via published export for builds

## Testing
- pnpm --filter @goldshore/web build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3357d2708331bf108b00b0120aa5)