### PR TITLE
Update API worker workflow lockfile handling

### DIFF
--- a/.github/workflows/deploy-api-worker.yml
+++ b/.github/workflows/deploy-api-worker.yml
@@ -9,7 +9,6 @@ on:
       - "apps/api-worker/**"
       - "packages/**"
       - "package.json"
-      - "pnpm-lock.yaml"
 
 jobs:
   deploy:
@@ -28,7 +27,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Deploy to Cloudflare
         working-directory: apps/api-worker


### PR DESCRIPTION
## Summary
- stop triggering the API worker deploy workflow on pnpm lockfile changes
- install dependencies without requiring a frozen lockfile since the lockfile is ignored

## Testing
- not run (network access required for pnpm)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d8c681a8083319a96535597b70dce)