### PR TITLE
Add SENTINEL agent scaffolding and automation workflows

### DIFF
--- a/.Jules/journal/palette.md
+++ b/.Jules/journal/palette.md
@@ -1,0 +1,6 @@
+# Palette Journal
+
+Use this file to capture notes from scheduled Palette runs:
+- Which components/layouts were touched.
+- Screenshots or verification notes.
+- Follow-up tasks handed to humans or other agents.

--- a/.Jules/journal/sentinel.md
+++ b/.Jules/journal/sentinel.md
@@ -1,0 +1,6 @@
+# SENTINEL Journal
+
+Use this file to log SENTINEL runs (PR scans, autofix attempts, and summaries). Include:
+- Date/time and trigger (PR link or scheduled run).
+- What checks ran and their status.
+- Any patches applied or suggested.

--- a/.Jules/run-conflict-sweeper.jsagent
+++ b/.Jules/run-conflict-sweeper.jsagent
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * CONFLICT-SWEEPER bootstrapper
+ * - surfaces the conflict resolution prompt
+ * - offers a Jules API example if a key is present
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = process.cwd();
+const promptPath = path.join(repoRoot, 'AI', 'prompts', 'conflict-sweeper.md');
+
+function readPrompt() {
+  if (!fs.existsSync(promptPath)) {
+    console.error(`Prompt not found at ${promptPath}`);
+    process.exit(1);
+  }
+  return fs.readFileSync(promptPath, 'utf8');
+}
+
+function printHeader(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+function emitCurlExample() {
+  const apiKey = process.env.JULES_API_KEY || '';
+  if (!apiKey) {
+    console.log('JULES_API_KEY not provided; printing prompt for manual use.');
+    return;
+  }
+
+  const payload = {
+    displayName: 'CONFLICT-SWEEPER',
+    prompt: readPrompt(),
+  };
+
+  console.log('Curl example:');
+  console.log(
+    `curl -X POST https://jules.googleapis.com/v1alpha/sessions \\\n  -H "X-Goog-Api-Key: ${apiKey}" \\\n  -H "Content-Type: application/json" \\\n  -d '${JSON.stringify(payload)}'`
+  );
+}
+
+function main() {
+  printHeader('Conflict Sweeper prompt');
+  console.log(readPrompt());
+  printHeader('Usage');
+  console.log('- Run nightly or on-demand to clear merge conflicts.');
+  console.log('- Pair with lockfile discipline checks to prevent thrash.');
+  emitCurlExample();
+}
+
+main();

--- a/.Jules/run-palette.jsagent
+++ b/.Jules/run-palette.jsagent
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Palette bootstrapper for scheduled micro-UX sweeps.
+ * - prints the Theme Skinner guidance
+ * - delegates to run-palette.js when available
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = process.cwd();
+const paletteScript = path.join(repoRoot, '.Jules', 'run-palette.js');
+const promptPath = path.join(repoRoot, 'AI', 'prompts', 'theme-skinner.md');
+
+function readPrompt() {
+  if (!fs.existsSync(promptPath)) {
+    console.error(`Prompt not found at ${promptPath}`);
+    process.exit(1);
+  }
+  return fs.readFileSync(promptPath, 'utf8');
+}
+
+function tryRunPaletteScript() {
+  if (!fs.existsSync(paletteScript)) {
+    console.log('Palette script not found; printing prompt only.');
+    return;
+  }
+
+  console.log(`Invoking ${paletteScript} ...`);
+  const result = spawnSync('node', [paletteScript], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.warn('Palette script exited with a non-zero status; continue with prompt output.');
+  }
+}
+
+function main() {
+  console.log('\n=== Palette prompt ===');
+  console.log(readPrompt());
+  console.log('\n=== Execution ===');
+  console.log('- Attempts to run .Jules/run-palette.js if present; otherwise acts as documentation.');
+  tryRunPaletteScript();
+}
+
+main();

--- a/.Jules/run-sentinel.jsagent
+++ b/.Jules/run-sentinel.jsagent
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * SENTINEL bootstrapper
+ * - surfaces the PR Doctor prompt
+ * - provides a ready-to-use Jules API curl snippet when JULES_API_KEY is present
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = process.cwd();
+const promptPath = path.join(repoRoot, 'AI', 'prompts', 'pr-doctor.md');
+
+function readPrompt() {
+  if (!fs.existsSync(promptPath)) {
+    console.error(`Prompt not found at ${promptPath}`);
+    process.exit(1);
+  }
+  return fs.readFileSync(promptPath, 'utf8');
+}
+
+function printHeader(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+function emitCurlExample() {
+  const apiKey = process.env.JULES_API_KEY || '';
+  const branch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME || '';
+
+  if (!apiKey) {
+    console.log('JULES_API_KEY not provided; printing prompt for manual use.');
+    return;
+  }
+
+  const sessionName = branch ? `SENTINEL-${branch}` : 'SENTINEL-ad-hoc';
+  const payload = {
+    displayName: sessionName,
+    prompt: readPrompt(),
+  };
+
+  console.log('Curl example (replace <repo> path if needed):');
+  console.log(
+    `curl -X POST https://jules.googleapis.com/v1alpha/sessions \\\n  -H "X-Goog-Api-Key: ${apiKey}" \\\n  -H "Content-Type: application/json" \\\n  -d '${JSON.stringify(payload)}'`
+  );
+}
+
+function main() {
+  printHeader('SENTINEL prompt');
+  console.log(readPrompt());
+  printHeader('Usage');
+  console.log('- Run from CI on pull_request or nightly to surface diagnostics.');
+  console.log('- The prompt below is designed for safe, mechanical fixes.');
+  emitCurlExample();
+}
+
+main();

--- a/.github/workflows/conflict-sweeper-nightly.yml
+++ b/.github/workflows/conflict-sweeper-nightly.yml
@@ -1,0 +1,26 @@
+name: Conflict Sweeper (Nightly)
+
+on:
+  schedule:
+    - cron: "15 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  conflict-sweeper:
+    name: Rebase and mergeability sweep
+    runs-on: ubuntu-latest
+    env:
+      JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6b156bde92b7f4e0528cf49d
+        with:
+          node-version: 20
+      - name: Preview CONFLICT-SWEEPER prompt
+        run: node ./.Jules/run-conflict-sweeper.jsagent

--- a/.github/workflows/palette-daily.yml
+++ b/.github/workflows/palette-daily.yml
@@ -1,0 +1,26 @@
+name: Palette (Daily)
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  palette-daily:
+    name: Daily Palette sweep
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6b156bde92b7f4e0528cf49d
+        with:
+          node-version: 20
+      - name: Run Palette bootstrap
+        run: node ./.Jules/run-palette.jsagent

--- a/.github/workflows/sentinel-nightly.yml
+++ b/.github/workflows/sentinel-nightly.yml
@@ -1,0 +1,26 @@
+name: SENTINEL (Nightly)
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sentinel-nightly:
+    name: Nightly SENTINEL scan
+    runs-on: ubuntu-latest
+    env:
+      JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6b156bde92b7f4e0528cf49d
+        with:
+          node-version: 20
+      - name: Preview nightly SENTINEL prompt
+        run: node ./.Jules/run-sentinel.jsagent

--- a/.github/workflows/sentinel-pr.yml
+++ b/.github/workflows/sentinel-pr.yml
@@ -1,0 +1,25 @@
+name: SENTINEL (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sentinel-pr-check:
+    name: Run SENTINEL guardrails
+    runs-on: ubuntu-latest
+    env:
+      JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6b156bde92b7f4e0528cf49d
+        with:
+          node-version: 20
+      - name: Preview SENTINEL prompt
+        run: node ./.Jules/run-sentinel.jsagent

--- a/AI/agents/bolt.md
+++ b/AI/agents/bolt.md
@@ -1,0 +1,12 @@
+# Bolt (Fast-path automation)
+
+**Lane:** High-speed automation and glue tasks between agents.
+
+**Primary objectives**
+- Kick off Jules sessions or CLI runs in response to CI/regression signals.
+- Aggregate logs and surface quick diagnostics when failures are trivial.
+- Hand off to SENTINEL or CONFLICT-SWEEPER when deeper analysis is required.
+
+**Operational notes**
+- Keep actions reversible; avoid making repository-wide mutations without confirmation.
+- Prefer short-lived branches that carry a single mechanical fix.

--- a/AI/agents/curator.md
+++ b/AI/agents/curator.md
@@ -1,0 +1,12 @@
+# Curator (Reports and knowledge capture)
+
+**Lane:** Documentation, status dashboards, and mergeability insights.
+
+**Primary objectives**
+- Collect outputs from SENTINEL, CONFLICT-SWEEPER, and Palette runs.
+- Maintain short Markdown briefs for humans (what changed, what is blocked, next steps).
+- Track mergeability and lockfile drift status to reduce conflict storms.
+
+**Operational notes**
+- Store run notes under `.Jules/journal/` for reproducibility.
+- Keep summaries concise and link to the originating workflow run or Jules session when possible.

--- a/AI/agents/palette.md
+++ b/AI/agents/palette.md
@@ -1,0 +1,13 @@
+# Palette (Micro-UX sweeps)
+
+**Lane:** Small, high-safety UX improvements across web/admin surfaces.
+
+**Primary objectives**
+- Apply minimal UI/a11y quality-of-life fixes (e.g., skip links, focus states, contrast touch-ups).
+- Keep per-run changes narrowly scoped and easy to review.
+- Document what changed, why it is safe, and how to verify manually.
+
+**Operational notes**
+- Runs as a scheduled/lightweight task so it does not compete with conflict resolution work.
+- Pair with `AI/prompts/theme-skinner.md` for style-guided changes when requested.
+- Prefer opening a PR rather than force-pushing to existing feature branches.

--- a/AI/agents/sentinel.md
+++ b/AI/agents/sentinel.md
@@ -1,0 +1,18 @@
+# SENTINEL (Repo Doctor)
+
+**Lane:** Diagnostics and safe autofix for branches and pull requests.
+
+**Primary objectives**
+- Scan branches/PRs for the agreed failure signatures (unpinned GitHub Action tags, duplicate Astro components, missing modules/imports, missing Env typing, unreachable TODOs).
+- Produce a concise report with file+line references.
+- Apply mechanical/safe fixes only; keep diffs small and reversible.
+- Run repo checks (pnpm lint/test/build/tsc) when possible and summarize results.
+
+**Operational notes**
+- Treat this as the default gate for PR hygiene; prefer commenting once with a clear checklist.
+- When a fix is safe, push to the PR branch; otherwise, post an actionable patch suggestion.
+- Favor commit-SHA pinning for workflows to avoid drift.
+
+**Triggering guidance**
+- Run on pull_request events and scheduled/nightly sweeps via GitHub Actions.
+- For manual sessions, use the PR Doctor prompt in `AI/prompts/pr-doctor.md`.

--- a/AI/prompts/conflict-sweeper.md
+++ b/AI/prompts/conflict-sweeper.md
@@ -1,0 +1,17 @@
+# Conflict Sweeper
+
+You are CONFLICT-SWEEPER.
+
+Goal: make every open PR mergeable with minimal disruption.
+
+Steps:
+1) List open PRs and detect which are non-mergeable (conflicts).
+2) For each conflicted PR:
+   - Rebase onto main (or merge main) using the repo’s preferred strategy.
+   - Resolve conflicts with a clear source-of-truth decision:
+     * Prefer main for lockfile unless PR introduces new deps.
+     * Prefer PR for feature code unless it breaks build.
+3) If pnpm-lock conflicts are huge:
+   - Recreate lockfile from scratch on top of rebased branch using pnpm install at repo root.
+4) Run lint/test/build.
+5) Push updates to each PR branch and comment a concise report.

--- a/AI/prompts/pr-doctor.md
+++ b/AI/prompts/pr-doctor.md
@@ -1,0 +1,17 @@
+# PR Doctor (SENTINEL)
+
+You are SENTINEL. Target: this repo and current PR branch.
+
+Goal: produce a minimal patch that fixes CI failures and prevents conflict propagation.
+
+Do:
+- Pin any GitHub Actions 'uses:' lines to commit SHA.
+- Fix Astro file structure errors (multiple components / duplicate HTML blocks).
+- Fix missing imports/modules and missing Env types.
+- Remove or relocate unreachable TODOs (do not change runtime behavior).
+- Keep changes small and safe. Prefer mechanical fixes.
+
+Then:
+- Run repo lint/test/build commands appropriate to this monorepo (pnpm).
+- Summarize what was fixed, what remains, and which commands were run.
+- Update the PR branch with commits (or open a PR if needed).

--- a/AI/prompts/theme-skinner.md
+++ b/AI/prompts/theme-skinner.md
@@ -1,0 +1,8 @@
+# Theme Skinner
+
+Use this prompt when applying stylistic or theme-wide adjustments requested by design.
+
+- Follow the active design tokens and Tailwind configuration for the affected app.
+- Keep cosmetic changes minimal per run; avoid mixing with conflict-resolution tasks.
+- Document any visual shifts and add screenshots when changing components.
+- Prefer deterministic transforms (search/replace for class names, shared component updates) over hand-editing scattered files.


### PR DESCRIPTION
## Summary
- add SENTINEL, Palette, Bolt, and Curator agent briefs with supporting prompts
- add Jules bootstrap scripts and journals to run sentinel, conflict sweeper, and palette lanes
- wire new GitHub Actions for PR and scheduled runs to surface the prompts

## Testing
- node ./.Jules/run-sentinel.jsagent


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dc6ec97bc83318615939d460d7c30)