### PR TITLE
Align Cloudflare Pages workflows with gs naming

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: astro-gs-admin
+          projectName: gs-admin
           directory: apps/admin/dist
           branch: main

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: astro-gs-web
+          projectName: gs-web
           directory: apps/web/dist
           branch: main

--- a/.github/workflows/preview-admin.yml
+++ b/.github/workflows/preview-admin.yml
@@ -45,6 +45,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: astro-gs-admin
+          projectName: preview-admin
           directory: apps/admin/dist
           branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -45,6 +45,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: astro-gs-web
+          projectName: preview-web
           directory: apps/web/dist
           branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- update Cloudflare Pages deployment workflows to target the gs-* production projects
- point preview workflows at preview-specific Cloudflare Pages projects instead of astro-prefixed names

## Testing
- not run (workflow-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693de5a0cae48331b0f17e4904b4c3c9)