### PR TITLE
Remove duplicate developer docs route collision

### DIFF
--- a/apps/web/src/pages/developer/docs.astro
+++ b/apps/web/src/pages/developer/docs.astro
@@ -1,9 +1,0 @@
----
----
-<html lang="en">
-<head><title>GoldShore Developer - Docs</title></head>
-<body>
-  <h1>Developer Docs</h1>
-  <p>Placeholder for developer docs page.</p>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- remove the redundant /developer/docs placeholder page that conflicted with the structured docs route
- keep the layout-backed developer documentation index as the single source for the docs path

## Testing
- pnpm -C apps/web build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404654caf883319377c46c6aea6e21)