### PR TITLE
Fix trading page frontmatter syntax

### DIFF
--- a/apps/admin/src/pages/trading/index.astro
+++ b/apps/admin/src/pages/trading/index.astro
@@ -1,5 +1,7 @@
+---
 import AdminLayout from '../../layouts/AdminLayout.astro';
 import { Card, GSButton } from '@goldshore/ui';
+
 ---
 
 <AdminLayout title="Trading">


### PR DESCRIPTION
## Summary
- move trading page imports into the Astro frontmatter block
- add missing closing frontmatter delimiter to resolve compiler error

## Testing
- pnpm --filter admin build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694048cbeedc833184a7e4766a5eceaf)