### PR TITLE
Adjust Access policy for api.goldshore.ai

### DIFF
--- a/infra/cloudflare/desired-state.yaml
+++ b/infra/cloudflare/desired-state.yaml
@@ -46,12 +46,12 @@ cloudflare:
           require:
             - identity_provider: "github"
 
-      - name: "GoldShore-API-ZT"
+      - name: "GoldShore-API-Bypass"
         domain: "api.goldshore.ai"
-        action: "service_auth"
+        action: "bypass"
         rules:
           include:
-            - any_valid_service_token: true
+            - everyone: true
 
   pages:
     projects:


### PR DESCRIPTION
## Summary
- change Cloudflare Access policy for api.goldshore.ai to bypass protection so the API can serve public requests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404afa3c308331be5070f50bb451c8)