### PR TITLE
Use pnpm for Netlify builds and file-linked workspace deps

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "astro": "^5.15.9",
     "@astrojs/cloudflare": "^12.6.11",
-    "@goldshore/ui": "workspace:*",
-    "@goldshore/theme": "workspace:*"
+    "@goldshore/ui": "file:../../packages/ui",
+    "@goldshore/theme": "file:../../packages/theme"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -8,7 +8,7 @@
     "build": "wrangler deploy --dry-run --outdir=dist"
   },
   "dependencies": {
-    "@goldshore/auth": "workspace:*",
+    "@goldshore/auth": "file:../../packages/auth",
     "hono": "^4.0.0"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "astro": "^5.15.9",
-    "@goldshore/theme": "workspace:*",
-    "@goldshore/ui": "workspace:*",
+    "@goldshore/theme": "file:../../packages/theme",
+    "@goldshore/ui": "file:../../packages/ui",
     "@astrojs/cloudflare": "^11.0.1"
   }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build"
+
+[build.environment]
+  NETLIFY_USE_PNPM = "true"
+  PNPM_FLAGS = "--frozen-lockfile"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,10 +65,10 @@ importers:
         specifier: latest
         version: 12.6.12(@types/node@25.0.1)(astro@5.16.5)(tsx@4.21.0)(yaml@2.8.2)
       '@goldshore/theme':
-        specifier: workspace:*
+        specifier: file:../../packages/theme
         version: link:../../packages/theme
       '@goldshore/ui':
-        specifier: workspace:*
+        specifier: file:../../packages/ui
         version: link:../../packages/ui
       astro:
         specifier: ^5.15.9
@@ -113,7 +113,7 @@ importers:
   apps/gateway:
     dependencies:
       '@goldshore/auth':
-        specifier: workspace:*
+        specifier: file:../../packages/auth
         version: link:../../packages/auth
       hono:
         specifier: ^4.0.0
@@ -149,10 +149,10 @@ importers:
         specifier: latest
         version: 12.6.12(@types/node@25.0.1)(astro@5.16.5)(tsx@4.21.0)(yaml@2.8.2)
       '@goldshore/theme':
-        specifier: workspace:*
+        specifier: file:../../packages/theme
         version: link:../../packages/theme
       '@goldshore/ui':
-        specifier: workspace:*
+        specifier: file:../../packages/ui
         version: link:../../packages/ui
       astro:
         specifier: ^5.15.9


### PR DESCRIPTION
## Summary
- add a Netlify build config that installs and builds with pnpm using the existing lockfile
- switch workspace dependencies in app package.json files to file-based links compatible with npm/pnpm
- align the pnpm lockfile with the new dependency specifiers

## Testing
- Not run (network-restricted environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404a071ce48331aed8da42d302efd6)