### PR TITLE
Add merge conflict detection script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages/*"
   ],
   "scripts": {
+    "check:conflicts": "node scripts/check-conflicts.js",
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
     "lint": "turbo run lint",

--- a/scripts/check-conflicts.js
+++ b/scripts/check-conflicts.js
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const files = execSync('git ls-files', { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean);
+
+const findings = [];
+
+files.forEach((file) => {
+  const content = readFileSync(file, 'utf8');
+  let match;
+  const regex = /^(<<<<<<< .*|=======|>>>>>>> .*)/gm;
+  while ((match = regex.exec(content)) !== null) {
+    const line = content.slice(0, match.index).split('\n').length;
+    findings.push({ file, line, marker: match[1] });
+  }
+});
+
+if (findings.length === 0) {
+  console.log('No merge conflict markers found.');
+  process.exit(0);
+}
+
+console.error('Merge conflict markers detected:');
+findings.forEach(({ file, line, marker }) => {
+  console.error(`${file}:${line}: ${marker}`);
+});
+process.exit(1);


### PR DESCRIPTION
## Summary
- add a reusable script to scan tracked files for merge conflict markers
- expose the conflict check through a new package script

## Testing
- node scripts/check-conflicts.js
- pnpm lint *(fails: registry access blocked while downloading pnpm via corepack)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c02b035c8331a8b40171b7890b60)