### PR TITLE
Fix Astro landing page frontmatter

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -5,51 +5,6 @@ import { GSButton } from '@goldshore/ui';
 // Goldshore Landing Page
 // Aesthetic: Military x Tech, Sports Car, Utility
 import MarketingLayout from '../layouts/MarketingLayout.astro';
----
-
-<MarketingLayout title="GoldShore | Shaping Waves">
-    <section class="max-w-4xl mx-auto py-32 px-6 text-center">
-        <h1 class="text-6xl font-bold mb-6 tracking-tight gs-heading text-[var(--gs-text-primary)]">
-            Shaping <span style="color: var(--gs-brand-gold);">Waves</span>
-        </h1>
-        <p class="text-xl text-[var(--gs-text-secondary)] max-w-2xl mx-auto leading-relaxed">
-            Gold Shore Labs builds AI-powered infrastructure for trading, automation, and applied intelligence.
-        </p>
-
-        <div class="mt-12 flex justify-center gap-4">
-            <GSButton href="/about" variant="primary">
-                Learn More
-            </GSButton>
-            <GSButton href="/contact" variant="secondary">
-                Get in Touch
-            </GSButton>
-        </div>
-    </section>
-
-    <div class="border-t-[var(--gs-border)]"></div>
-
-    <section class="max-w-7xl mx-auto py-24 px-6 grid grid-cols-1 md:grid-cols-3 gap-12">
-        <div class="space-y-4">
-            <h3 class="text-xl font-semibold" style="color: var(--gs-text-primary);">Algorithmic Precision</h3>
-            <p class="text-[var(--gs-text-secondary)]">
-                High-frequency execution modeled on fluid dynamics. Zero latency expectations.
-            </p>
-        </div>
-        <div class="space-y-4">
-            <h3 class="text-xl font-semibold" style="color: var(--gs-text-primary);">Military Grade</h3>
-            <p class="text-[var(--gs-text-secondary)]">
-                Infrastructure built to withstand extreme volatility. Security first architecture.
-            </p>
-        </div>
-        <div class="space-y-4">
-            <h3 class="text-xl font-semibold" style="color: var(--gs-text-primary);">Global Reach</h3>
-            <p class="text-[var(--gs-text-secondary)]">
-                Connected to major liquidity pools across all timezones. 24/7 operations.
-            </p>
-        </div>
-    </section>
-import { GSButton } from '@goldshore/ui';
-import MarketingLayout from '../layouts/MarketingLayout.astro';
 
 export const prerender = true;
 
@@ -74,6 +29,7 @@ const highlights = [
   { label: 'Signals processed / day', value: '2.1B', tone: 'warning' },
 ];
 ---
+
 <MarketingLayout title="GoldShore | Shaping Waves" description="Unified AI infrastructure for trading and intelligent operations.">
   <section class="gs-hero">
     <div>


### PR DESCRIPTION
### Motivation
- Resolve an Astro/Vite build failure caused by duplicated frontmatter and mixed template/script blocks in `apps/web/src/pages/index.astro`, which produced a parsing error during `astro build`.

### Description
- Remove the duplicated Astro frontmatter and duplicate imports/markup, leaving a single frontmatter block containing imports, `prerender`, `capabilities`, and `highlights`.
- Keep the consolidated template using `MarketingLayout` and render the `capabilities` and `highlights` arrays from the frontmatter.
- Simplify the page so the file has one coherent frontmatter/template structure to satisfy the Astro parser.

### Testing
- The original automated build (`pnpm --filter @goldshore/web build`) failed with an esbuild/Astro parsing error (`Expected "}" but found ":"`) before this fix.
- No automated builds or tests were executed after the change in this rollout (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9adf8c948331a5f12b0e991ccbd4)