### PR TITLE
Harden workflows by removing unpinned actions

### DIFF
--- a/.github/workflows/conflict-sweeper-nightly.yml
+++ b/.github/workflows/conflict-sweeper-nightly.yml
@@ -20,9 +20,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
       - name: Preview CONFLICT-SWEEPER prompt
         run: node ./.Jules/run-conflict-sweeper.jsagent

--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -20,14 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,11 +37,11 @@ jobs:
         working-directory: apps/admin
         run: pnpm build
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@3.101.0
+
       - name: Deploy to Cloudflare Pages (production)
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: gs-admin
-          directory: apps/admin/dist
-          branch: main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy apps/admin/dist --project-name gs-admin --branch main

--- a/.github/workflows/deploy-agent.yml
+++ b/.github/workflows/deploy-agent.yml
@@ -23,14 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-api-worker.yml
+++ b/.github/workflows/deploy-api-worker.yml
@@ -20,14 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-control-worker.yml
+++ b/.github/workflows/deploy-control-worker.yml
@@ -21,14 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -21,14 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -20,14 +20,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,11 +37,11 @@ jobs:
         working-directory: apps/web
         run: pnpm build
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@3.101.0
+
       - name: Deploy to Cloudflare Pages (production)
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: gs-web
-          directory: apps/web/dist
-          branch: main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy apps/web/dist --project-name gs-web --branch main

--- a/.github/workflows/jules-auto-fix.yml
+++ b/.github/workflows/jules-auto-fix.yml
@@ -38,9 +38,10 @@ jobs:
           ref: ${{ steps.pr_data.outputs.branch_name }}
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Configure Git
         run: |
@@ -99,14 +100,11 @@ jobs:
           git push
 
       - name: Comment on PR after Fix
-        uses: marocchino/sticky-pull-request-comment@v2
         if: steps.sync.outputs.status == 'merge_fix'
-        with:
-          header: Jules AutoFix
-          message: |
-            ✔ Branch synced with \`main\` by merging.
-            ✔ Lockfile regenerated to resolve conflicts.
-            ✔ CI checks re-started.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ steps.pr_data.outputs.pr_number }} --body "✔ Branch synced with \`main\` by merging.\n✔ Lockfile regenerated to resolve conflicts.\n✔ CI checks re-started."
 
   code-fix:
     runs-on: ubuntu-latest
@@ -135,14 +133,15 @@ jobs:
           ref: ${{ steps.pr_data.outputs.branch_name }}
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/jules-daily.yml
+++ b/.github/workflows/jules-daily.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: "9"
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile || pnpm install

--- a/.github/workflows/jules-sentinel.yml
+++ b/.github/workflows/jules-sentinel.yml
@@ -38,15 +38,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Run Conflict Sweeper
         run: node .Jules/run-conflict-sweeper.jsagent

--- a/.github/workflows/preview-admin.yml
+++ b/.github/workflows/preview-admin.yml
@@ -21,14 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -40,11 +41,11 @@ jobs:
           PUBLIC_GATEWAY: https://gw-preview.goldshore.ai
         run: pnpm build
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@3.101.0
+
       - name: Deploy to Cloudflare Pages (preview)
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: preview-admin
-          directory: apps/admin/dist
-          branch: ${{ github.head_ref || github.ref_name }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy apps/admin/dist --project-name preview-admin --branch "${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/preview-agent.yml
+++ b/.github/workflows/preview-agent.yml
@@ -24,14 +24,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/preview-api-worker.yml
+++ b/.github/workflows/preview-api-worker.yml
@@ -17,14 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/preview-control-worker.yml
+++ b/.github/workflows/preview-control-worker.yml
@@ -21,14 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/preview-gateway.yml
+++ b/.github/workflows/preview-gateway.yml
@@ -21,14 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -21,14 +21,15 @@ jobs:
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.2 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -40,11 +41,11 @@ jobs:
           PUBLIC_GATEWAY: https://gw-preview.goldshore.ai
         run: pnpm build
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@3.101.0
+
       - name: Deploy to Cloudflare Pages (preview)
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: preview-web
-          directory: apps/web/dist
-          branch: ${{ github.head_ref || github.ref_name }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy apps/web/dist --project-name preview-web --branch "${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/sentinel-nightly.yml
+++ b/.github/workflows/sentinel-nightly.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
             node-version: 20
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-            version: 8
+      - name: Enable pnpm via Corepack
+        run: |
+            corepack enable
+            corepack prepare pnpm@8.15.7 --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Sentinel

--- a/.github/workflows/sentinel-pr.yml
+++ b/.github/workflows/sentinel-pr.yml
@@ -17,17 +17,16 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@8.15.7 --activate
 
       - name: Run Sentinel (PR Mode)
         env:


### PR DESCRIPTION
### Motivation

- Address code-scanning findings about unpinned third-party Actions to reduce supply-chain risk and improve reproducibility.  
- Avoid using unpinned `pnpm/action-setup` and `cloudflare/pages-action` refs in workflows.  
- Use deterministic tool installation (Corepack / pinned pnpm and pinned `wrangler`) and avoid non-immutable action tags.  
- Request review: `@Jules-Bot [review-request]`

### Description

- Replaced `pnpm/action-setup@*` steps with Corepack activation and `corepack prepare pnpm@<version> --activate` in CI workflows.  
- Replaced `cloudflare/pages-action@v1` steps with an explicit `npm install -g wrangler@3.101.0` and `wrangler pages deploy ...` invocations for Pages deployments.  
- Replaced the `marocchino/sticky-pull-request-comment@v2` step with GitHub CLI calls (`gh pr comment ...`) in the Jules AutoFix workflow to remove an unpinned action.  
- Applied these changes across multiple files under `.github/workflows/` to remove unpinned actions and pin tool versions.

### Testing

- No automated tests were run because these are workflow-only changes.  
- Changes were staged and committed successfully with `git commit`.  
- The `pnpm-lock.yaml` diff was inspected and reverted where necessary during the update.  
- Workflows will be validated by CI on subsequent runs (no runtime results included in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960ffe538b883318c474140e3c59fb2)