### PR TITLE
feat: standardize footer and enable docs search

### DIFF
--- a/apps/web/src/components/DocsSearch.astro
+++ b/apps/web/src/components/DocsSearch.astro
@@ -9,11 +9,12 @@ let results = [];
 <div class="search-box">
   <input
     type="search"
+    aria-label="Search documentation"
     placeholder="Search docs…"
     id="docs-search-input"
   />
 
-  <div id="results">
+  <div id="results" aria-live="polite">
   </div>
 </div>
 
@@ -95,3 +96,61 @@ let results = [];
     input.addEventListener('input', debouncedSearch);
   }
 </script>
+
+<style>
+  .search-box {
+    margin-bottom: var(--gs-space-4);
+    position: relative;
+  }
+
+  input[type="search"] {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    background: var(--gs-bg-surface);
+    border: 1px solid var(--gs-border);
+    border-radius: var(--gs-radius-sm);
+    color: var(--gs-fg);
+    font-size: 0.875rem;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+
+  input[type="search"]:focus {
+    outline: none;
+    border-color: var(--gs-accent);
+    box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.1); /* Cyan glow */
+  }
+
+  input[type="search"]::placeholder {
+    color: var(--gs-fg-muted);
+  }
+
+  #results {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  /* Global selector because results are injected dynamically */
+  :global(#results a) {
+    display: block;
+    padding: 0.5rem;
+    background: var(--gs-bg-panel);
+    border: 1px solid var(--gs-border-subtle);
+    border-radius: var(--gs-radius-sm);
+    color: var(--gs-fg);
+    text-decoration: none;
+    font-size: 0.875rem;
+  }
+
+  :global(#results a:hover), :global(#results a:focus) {
+    background: var(--gs-bg-surface-hover);
+    border-color: var(--gs-accent);
+    color: var(--gs-accent);
+  }
+
+  :global(.search-error) {
+    font-size: 0.875rem;
+    padding: 0.5rem;
+  }
+</style>

--- a/apps/web/src/components/DocsSidebar.astro
+++ b/apps/web/src/components/DocsSidebar.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import DocsSearch from './DocsSearch.astro';
 
 const { currentSlug } = Astro.props;
 const pages = await getCollection('docs');
@@ -13,6 +14,7 @@ function getHref(slug: string) {
 ---
 
 <aside class="gs-card docs-sidebar" aria-label="Documentation navigation">
+  <DocsSearch />
   <h3 class="section-title"><span>◎</span>Documentation</h3>
   <ul class="docs-nav">
     {pages.map((p) => (

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -1,31 +1,112 @@
-<footer class="footer">
-  <div>© {new Date().getFullYear()} GoldShore</div>
-  <div class="links">
-    <a href="/legal/privacy">Privacy</a>
-    <a href="/legal/terms">Terms</a>
-    <a href="/developer">Developers</a>
+---
+import logo from '@goldshore/theme/assets/logo.svg';
+---
+
+<footer class="gs-footer">
+  <div class="gs-section">
+    <div class="gs-grid columns-2">
+      <div class="brand-col">
+        <div class="gs-logo">
+          <img src={logo.src} alt="GoldShore logo" width="32" height="32" loading="lazy" decoding="async" />
+          <span>GoldShore AI</span>
+        </div>
+        <p class="tagline">Applied intelligence, resilient infrastructure, and responsive operations.</p>
+        <p class="copyright">© {new Date().getFullYear()} GoldShore AI. All rights reserved.</p>
+      </div>
+
+      <div class="links-col">
+        <div class="nav-group">
+          <strong>Company</strong>
+          <a href="/about">About</a>
+          <a href="/team">Team</a>
+          <a href="/services">Services</a>
+        </div>
+        <div class="nav-group">
+          <strong>Support</strong>
+          <a href="/contact">Contact</a>
+          <a href="/legal/privacy">Privacy</a>
+          <a href="/legal/terms">Terms</a>
+        </div>
+      </div>
+    </div>
   </div>
 </footer>
 
 <style>
-  .footer {
-    padding: 2rem;
-    border-top: 1px solid rgba(148,163,184,0.2);
-    background: #000;
+  .gs-footer {
+    border-top: 1px solid var(--gs-border);
+    background: var(--gs-bg-panel);
+    padding: var(--gs-space-6) 0;
+  }
+
+  .gs-section {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 var(--gs-space-4);
+  }
+
+  .gs-grid {
+    display: grid;
+    gap: var(--gs-space-6);
+  }
+
+  .columns-2 {
+    grid-template-columns: 1fr;
+  }
+
+  @media (min-width: 768px) {
+    .columns-2 {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .gs-logo {
     display: flex;
-    justify-content: space-between;
-    font-size: 0.9rem;
-    color: #94a3b8;
+    align-items: center;
+    gap: var(--gs-space-2);
+    font-weight: bold;
+    color: var(--gs-fg);
+    margin-bottom: var(--gs-space-3);
   }
-  .links a {
-    margin-left: 1.2rem;
-    color: #94a3b8;
+
+  .tagline {
+    color: var(--gs-fg-muted);
+    font-size: 0.875rem;
+    margin-bottom: var(--gs-space-4);
+    max-width: 300px;
+  }
+
+  .copyright {
+    color: var(--gs-fg-subtle);
+    font-size: 0.75rem;
+  }
+
+  .links-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--gs-space-4);
+  }
+
+  .nav-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--gs-space-2);
+  }
+
+  .nav-group strong {
+    color: var(--gs-fg);
+    font-size: 0.875rem;
+    margin-bottom: var(--gs-space-1);
+  }
+
+  .nav-group a {
+    color: var(--gs-fg-muted);
     text-decoration: none;
+    font-size: 0.875rem;
+    transition: color 0.2s ease;
   }
-  .links a:hover {
-    color: #f8fafc;
+
+  .nav-group a:hover {
+    color: var(--gs-fg);
   }
 </style>
-<footer>
-  <p>&copy; {new Date().getFullYear()} GoldShore. All rights reserved.</p>
-</footer>

--- a/apps/web/src/layouts/WebLayout.astro
+++ b/apps/web/src/layouts/WebLayout.astro
@@ -2,6 +2,7 @@
 import '@goldshore/theme';
 import logo from '@goldshore/theme/assets/logo.svg';
 import { GSButton } from '@goldshore/ui';
+import Footer from '../components/Footer.astro';
 
 const navLinks = [
   { href: '/', label: 'Home' },
@@ -46,33 +47,7 @@ const { title = 'GoldShore', description = 'GoldShore AI', currentPath = Astro.u
         <slot />
       </main>
 
-      <footer class="gs-footer">
-        <div class="gs-section" style="padding: var(--gs-space-6) 0;">
-          <div class="gs-grid columns-2">
-            <div>
-              <div class="gs-logo" style="gap: var(--gs-space-2);">
-                <img src={logo} alt="GoldShore logo" width="32" height="32" loading="lazy" decoding="async" />
-                <span>GoldShore AI</span>
-              </div>
-              <p>Applied intelligence, resilient infrastructure, and responsive operations.</p>
-            </div>
-            <div class="gs-grid columns-2" style="gap: var(--gs-space-2);">
-              <div class="gs-nav gs-nav--vertical">
-                <strong>Company</strong>
-                <a href="/about">About</a>
-                <a href="/team">Team</a>
-                <a href="/services">Services</a>
-              </div>
-              <div class="gs-nav" style="flex-direction: column; align-items: flex-start; gap: var(--gs-space-2);">
-                <strong>Support</strong>
-                <a href="/contact">Contact</a>
-                <a href="/legal/privacy">Privacy</a>
-                <a href="/legal/terms">Terms</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   </body>
 </html>


### PR DESCRIPTION
- Enabled `DocsSearch` component in `DocsSidebar` with accessibility fixes.
- Refactored `Footer` component to use theme tokens and semantic HTML.
- Replaced hardcoded footer in `WebLayout` with the reusable `Footer` component.
- Added visual verification via Playwright script.