### PR TITLE
feat(web): add keyboard shortcut hint to docs search

### DIFF
--- a/apps/web/src/components/DocsSearch.astro
+++ b/apps/web/src/components/DocsSearch.astro
@@ -4,17 +4,52 @@
 
 <div class="search-wrapper">
   <label for="docs-search-input" class="sr-only">Search</label>
-  <input type="search" id="docs-search-input" placeholder="Search docs..." aria-controls="results" aria-expanded="false" />
+  <div class="search-input-wrapper">
+    <input type="search" id="docs-search-input" placeholder="Search docs..." aria-controls="results" aria-expanded="false" />
+    <kbd class="search-shortcut">⌘K</kbd>
+  </div>
   <ul id="results" role="list" aria-live="polite"></ul>
 </div>
 
 <style>
   .search-wrapper { position: relative; width: 100%; }
-  input { width: 100%; padding: 0.5rem; border: 1px solid var(--gs-color-border); border-radius: 4px; background: var(--gs-color-bg-surface); color: var(--gs-color-text); }
+  /* Consolidated styles */
+  .search-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  input { width: 100%; padding: 0.5rem; padding-right: 3.5rem; border: 1px solid var(--gs-color-border); border-radius: 4px; background: var(--gs-color-bg-surface); color: var(--gs-color-text); }
   input:focus { outline: 2px solid var(--gs-color-primary); border-color: transparent; }
+
   #results { position: absolute; top: 100%; left: 0; right: 0; background: var(--gs-color-bg-surface); border: 1px solid var(--gs-color-border); list-style: none; padding: 0; margin-top: 4px; display: none; z-index: 50; box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1); border-radius: 4px; max-height: 300px; overflow-y: auto; }
   #results:not(:empty) { display: block; }
   .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+  .search-shortcut {
+    position: absolute;
+    right: 0.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 1.5rem;
+    padding: 0 0.4rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--gs-color-subtle, #94a3b8);
+    background: var(--gs-color-bg, #f8fafc);
+    border: 1px solid var(--gs-color-border, #e2e8f0);
+    border-radius: 4px;
+    pointer-events: none;
+    user-select: none;
+    font-family: inherit;
+  }
+
+  :global(.dark) .search-shortcut {
+    background: #1e293b;
+    border-color: #334155;
+  }
 
   /* Dynamic content styling */
   :global(#results li) { padding: 0.25rem 0; }
@@ -29,6 +64,15 @@
   const list = document.getElementById('results');
   let timer: ReturnType<typeof setTimeout>;
   let controller: AbortController | null = null;
+
+  // Platform detection for shortcut
+  if (typeof navigator !== 'undefined') {
+    const isMac = navigator.userAgent.toUpperCase().indexOf('MAC') >= 0;
+    if (!isMac) {
+      const shortcut = document.querySelector('.search-shortcut');
+      if (shortcut) shortcut.textContent = 'Ctrl K';
+    }
+  }
 
   if (input && list) {
     input.addEventListener('input', (e) => {
@@ -89,11 +133,10 @@
         list.innerHTML = ''; input.setAttribute('aria-expanded', 'false');
       }
     });
-  }
 
-  if (resultsList) {
-    resultsList.addEventListener('keydown', (e: KeyboardEvent) => {
-        const items = Array.from(resultsList.querySelectorAll('a'));
+    // Fix: use 'list' instead of 'resultsList'
+    list.addEventListener('keydown', (e: KeyboardEvent) => {
+        const items = Array.from(list.querySelectorAll('a'));
         const activeElement = document.activeElement as HTMLElement;
         const index = items.indexOf(activeElement as HTMLAnchorElement);
 
@@ -111,96 +154,22 @@
             }
         } else if (e.key === 'Escape') {
             e.preventDefault();
-            showResults(false);
+            // Fix: implement showResults(false) logic inline
+            list.innerHTML = '';
+            input.setAttribute('aria-expanded', 'false');
             input?.focus();
         }
     });
   }
 
   // Palette: Add keyboard shortcut for search
-  console.log('DocsSearch: script loaded');
   document.addEventListener('keydown', (e) => {
-    // console.log('Key pressed:', e.key, 'Meta:', e.metaKey, 'Ctrl:', e.ctrlKey);
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-      console.log('DocsSearch: Shortcut triggered');
       e.preventDefault();
       const searchInput = document.getElementById('docs-search-input');
       if (searchInput) {
         searchInput.focus();
-        console.log('DocsSearch: Input focused');
-      } else {
-        console.error('DocsSearch: Input not found');
       }
     }
   });
 </script>
-
-<style>
-  .search-box {
-    margin-bottom: 1.5rem;
-  }
-
-  .search-input-wrapper {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
-
-  input[type="search"] {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    padding-right: 3.5rem; /* Space for the shortcut */
-    border: 1px solid var(--gs-color-border, #e2e8f0);
-    border-radius: var(--gs-radius-sm, 0.375rem);
-    background: var(--gs-color-surface, #fff);
-    font-size: 0.95rem;
-    transition: all 0.2s ease;
-  }
-
-  input[type="search"]:focus {
-    outline: none;
-    border-color: var(--gs-primary, #0f172a);
-    box-shadow: 0 0 0 2px var(--gs-primary-alpha, rgba(15, 23, 42, 0.1));
-  }
-
-  .search-shortcut {
-    position: absolute;
-    right: 0.75rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 1.5rem;
-    padding: 0 0.4rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--gs-color-subtle, #94a3b8);
-    background: var(--gs-color-bg, #f8fafc);
-    border: 1px solid var(--gs-color-border, #e2e8f0);
-    border-radius: 4px;
-    pointer-events: none;
-    user-select: none;
-  }
-
-  :global(.dark) .search-shortcut {
-    background: #1e293b;
-    border-color: #334155;
-  }
-
-  #results {
-    margin-top: 0.5rem;
-  }
-
-  :global(.search-result-link) {
-    display: block;
-    padding: 0.5rem 0.75rem;
-    text-decoration: none;
-    color: var(--gs-color-text, #334155);
-    border-radius: 4px;
-    font-size: 0.9rem;
-  }
-
-  :global(.search-result-link:hover) {
-    background: var(--gs-color-bg-hover, #f1f5f9);
-    color: var(--gs-primary, #0f172a);
-  }
-</style>


### PR DESCRIPTION
- Adds `<kbd>` visual hint for `Cmd+K` / `Ctrl+K` to `DocsSearch.astro`.
- Updates JS to detect platform and display correct modifier.
- Fixes `resultsList` variable reference error.
- Cleans up duplicate CSS styles.