### PR TITLE
Make several third-party security workflows manual (`workflow_dispatch`)

### DIFF
--- a/.github/workflows/apisec-scan.yml
+++ b/.github/workflows/apisec-scan.yml
@@ -29,16 +29,6 @@ name: APIsec
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  # Customize trigger events based on your DevSecOps processes.
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  schedule:
-    - cron: '17 19 * * 4'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -14,13 +14,7 @@
 name: Codacy Security Scan
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '15 5 * * 4'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/contrast-scan.yml
+++ b/.github/workflows/contrast-scan.yml
@@ -13,13 +13,7 @@
 # The required secrets are CONTRAST_API_KEY, CONTRAST_ORGANIZATION_ID and CONTRAST_AUTH_HEADER.
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '37 20 * * 5'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/debricked.yml
+++ b/.github/workflows/debricked.yml
@@ -26,7 +26,7 @@
 name: Debricked Scan
 
 on:
-  push:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -23,12 +23,7 @@ permissions:
   security-events: write
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  schedule:
-    - cron: '44 11 * * 5'
+  workflow_dispatch:
 
 jobs:
   MSDO:

--- a/.github/workflows/mayhem-for-api.yml
+++ b/.github/workflows/mayhem-for-api.yml
@@ -24,11 +24,7 @@
 name: "Mayhem for API"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   mayhem-for-api:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,13 +11,7 @@
 name: Semgrep
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '34 18 * * 0'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- Reduce duplicated and noisy automated scans from third-party security tooling while retaining core automated scans like CodeQL/OSV. 
- Limit scheduled and push/pull triggers for non-essential scanners so they run only when explicitly requested.

### Description
- Replaced repository triggers with `workflow_dispatch` in the following workflows: ` .github/workflows/codacy.yml`, ` .github/workflows/debricked.yml`, ` .github/workflows/semgrep.yml`, ` .github/workflows/contrast-scan.yml`, ` .github/workflows/mayhem-for-api.yml`, ` .github/workflows/defender-for-devops.yml`, and ` .github/workflows/apisec-scan.yml` so they only run manually. 
- Removed `push`, `pull_request`, and `schedule` triggers where present and preserved each workflow's steps and permissions unchanged. 
- Left primary automated scanners (e.g. `codeql.yml` and `osv-scanner.yml`) intact to continue automated coverage.

### Testing
- No automated tests were run because these are workflow-only changes and do not affect runtime code or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d5e4ae1c833198355f6448225e56)