### PR TITLE
Gate preview workflows on 'preview' label or main readiness

### DIFF
--- a/.github/workflows/preview-admin.yml
+++ b/.github/workflows/preview-admin.yml
@@ -5,18 +5,25 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
     paths:
       - "apps/admin/**"
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
-  push:
-    branches:
-      - "feature/**"
 
 jobs:
   preview-admin:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')
 
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e

--- a/.github/workflows/preview-agent.yml
+++ b/.github/workflows/preview-agent.yml
@@ -5,6 +5,13 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
     paths:
       - "apps/gs-agent/**"
       - "apps/goldshore-agent/**"
@@ -13,13 +20,13 @@ on:
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
-  push:
-    branches:
-      - "feature/**"
 
 jobs:
   preview-agent:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')
 
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e

--- a/.github/workflows/preview-api-worker.yml
+++ b/.github/workflows/preview-api-worker.yml
@@ -4,16 +4,23 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
     paths:
       - "apps/api-worker/**"
       - "packages/schema/**"
-  push:
-    branches:
-      - "feature/**"
 
 jobs:
   deploy-preview-api:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e
 

--- a/.github/workflows/preview-control-worker.yml
+++ b/.github/workflows/preview-control-worker.yml
@@ -5,18 +5,25 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
     paths:
       - "apps/control-worker/**"
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
-  push:
-    branches:
-      - "feature/**"
 
 jobs:
   deploy-preview-control:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')
 
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e

--- a/.github/workflows/preview-gateway.yml
+++ b/.github/workflows/preview-gateway.yml
@@ -5,18 +5,25 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
     paths:
       - "apps/gateway/**"
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
-  push:
-    branches:
-      - "feature/**"
 
 jobs:
   deploy-preview-gateway:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')
 
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -5,18 +5,25 @@ permissions:
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
     paths:
       - "apps/web/**"
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
-  push:
-    branches:
-      - "feature/**"
 
 jobs:
   preview-web:
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') ||
+      (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')
 
     steps:
       - uses: actions/checkout@3df4d485d8ce6d2b61b8d12e8f44cdfffbea301e


### PR DESCRIPTION
### Motivation
- Prevent preview jobs from running for every push by only executing them when a PR is explicitly requested as a preview or has been marked ready for review against `main`.
- Ensure preview deployments respond to label changes and `ready_for_review` events so toggling previews does not require new commits.

### Description
- Updated the following workflows: `.github/workflows/preview-admin.yml`, `.github/workflows/preview-agent.yml`, `.github/workflows/preview-api-worker.yml`, `.github/workflows/preview-control-worker.yml`, `.github/workflows/preview-gateway.yml`, and `.github/workflows/preview-web.yml`.
- Added `pull_request.types` to include `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`, and `ready_for_review` so workflows react to label/ready events.
- Removed the `push` triggers that matched `feature/**` branches to keep previews PR-driven.
- Added a job-level `if` guard using `contains(github.event.pull_request.labels.*.name, 'preview') || (github.event.action == 'ready_for_review' && github.event.pull_request.base.ref == 'main')` to gate execution.

### Testing
- No automated tests were run because this is a GitHub Actions workflow-only change; validation consisted of committing the updated workflow files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d5f6b2648331a4a67d5b0b7ab2aa)