### PR TITLE
Remove `actions` language from CodeQL matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
         - language: javascript-typescript
           build-mode: none
         - language: python


### PR DESCRIPTION
### Motivation
- Exclude the `actions` language from the CodeQL matrix in ` .github/workflows/codeql.yml` to avoid scanning GitHub Actions workflow files which are not intended for this repository's analysis.

### Description
- Removed the `actions` entry from `matrix.include` in `.github/workflows/codeql.yml`, leaving `javascript-typescript` and `python` as the scanned languages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d5f4b93c8331943a4a0426dd4e93)