### PR TITLE
Use CLOUDFLARE_* secrets in preview API worker workflow

### DIFF
--- a/.github/workflows/preview-api-worker.yml
+++ b/.github/workflows/preview-api-worker.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Deploy API worker (preview)
         working-directory: apps/api-worker
         env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler deploy --env preview


### PR DESCRIPTION
### Motivation
- Align the preview API worker workflow with other preview workflows by using `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` naming.

### Description
- Replace `CF_API_TOKEN` and `CF_ACCOUNT_ID` with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in `.github/workflows/preview-api-worker.yml`.

### Testing
- No automated tests were run because this is a GitHub Actions workflow configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69730e03b9dc833190bacfbd57ffdbb3)