### PR TITLE
🛡️ Sentinel: [CRITICAL] Add authentication to control-worker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -28,3 +28,8 @@
 **Vulnerability:** The `apps/admin` application (dashboard) lacked standard HTTP security headers (`X-Frame-Options`, `HSTS`, `X-Content-Type-Options`), making it potentially vulnerable to clickjacking and MIME sniffing.
 **Learning:** When creating new Astro apps in a monorepo, middleware (and thus security headers) is not automatically inherited from other apps.
 **Prevention:** Enforce a standard `middleware.ts` template for all new Astro applications or move security headers to the infrastructure layer (Cloudflare `_headers` or Gateway rules) if consistent application-level enforcement is prone to oversight.
+
+## 2026-02-13 - Unprotected Sensitive Operations Worker
+**Vulnerability:** `apps/control-worker` exposed sensitive operational endpoints (`/dns/apply`, `/workers/reconcile`) without any authentication middleware, relying solely on (potentially missing or misconfigured) network-level protection.
+**Learning:** Internal automation or "worker" apps are often overlooked during security reviews because they aren't "user-facing", but they hold the "keys to the kingdom" (DNS, deployment credentials).
+**Prevention:** Treat every worker as a public API. Mandate default-deny authentication middleware for all new workers at the template level.

--- a/apps/control-worker/package.json
+++ b/apps/control-worker/package.json
@@ -8,6 +8,7 @@
     "run-task": "wrangler dev src/index.ts --test-scheduled"
   },
   "dependencies": {
+    "@goldshore/auth": "workspace:*",
     "hono": "^4.0.0"
   },
   "devDependencies": {

--- a/apps/control-worker/src/index.ts
+++ b/apps/control-worker/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { secureHeaders } from "hono/secure-headers";
+import { verifyAccess } from "@goldshore/auth";
 import * as DNS from "./libs/dns";
 import * as Workers from "./libs/workers";
 import * as Pages from "./libs/pages";
@@ -12,6 +13,21 @@ const app = new Hono<{ Bindings: ControlEnv }>();
 
 // Sentinel: Add security headers to all responses (Defense in Depth)
 app.use('*', secureHeaders());
+
+// Sentinel: CRITICAL - Enforce Authentication on all sensitive endpoints
+app.use('*', async (c, next) => {
+  // Allow root (status check) to remain public
+  if (c.req.path === '/') {
+    await next();
+    return;
+  }
+
+  const authorized = await verifyAccess(c.req.raw, c.env);
+  if (!authorized) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+  await next();
+});
 
 app.get("/", (c) => c.json({ service: "gs-control", ok: true }));
 

--- a/apps/control-worker/src/libs/types.ts
+++ b/apps/control-worker/src/libs/types.ts
@@ -3,4 +3,6 @@ export interface ControlEnv {
   STATE: R2Bucket;
   API: Fetcher;
   GATEWAY: Fetcher;
+  CLOUDFLARE_ACCESS_AUDIENCE?: string;
+  CLOUDFLARE_TEAM_DOMAIN?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         specifier: latest
         version: 12.6.12(@types/node@25.0.10)(astro@5.16.14(@types/node@25.0.10)(jiti@1.21.7)(rollup@4.56.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       turbo:
-        specifier: ^2.6.1
+        specifier: ^2.7.5
         version: 2.7.5
     devDependencies:
       '@astrojs/tailwind':
@@ -99,6 +99,9 @@ importers:
 
   apps/control-worker:
     dependencies:
+      '@goldshore/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
       hono:
         specifier: ^4.0.0
         version: 4.11.5


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `apps/control-worker` exposed sensitive operational endpoints (`/dns/apply`, `/workers/reconcile`) without any authentication middleware.
🎯 Impact: Unauthorized access could allow attackers to modify DNS records or rotate keys.
🔧 Fix: Added `@goldshore/auth` dependency and implemented a global middleware in `src/index.ts` that enforces `verifyAccess` on all non-root paths.