### PR TITLE
Add placeholder admin pages for README routes

### DIFF
--- a/apps/admin/src/pages/admin/api-logs.astro
+++ b/apps/admin/src/pages/admin/api-logs.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="API Logs | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">API Logs</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Log streams, filters, and export tools will be surfaced here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/system/dns.astro
+++ b/apps/admin/src/pages/admin/system/dns.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="System DNS | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">DNS Configuration</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            DNS records, zones, and propagation status will be displayed here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/system/pages.astro
+++ b/apps/admin/src/pages/admin/system/pages.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="System Pages | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">Pages Deployments</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Build status, deployment history, and environment settings will appear here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/system/secrets.astro
+++ b/apps/admin/src/pages/admin/system/secrets.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="System Secrets | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">Secrets Management</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Secret rotation schedules, access policies, and audit logs will appear here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/system/storage.astro
+++ b/apps/admin/src/pages/admin/system/storage.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="System Storage | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">Storage Services</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Buckets, usage metrics, and retention policies will be summarized here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/users/list.astro
+++ b/apps/admin/src/pages/admin/users/list.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="User List | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">User List</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            User records, roles, and account status will be available here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/users/permissions.astro
+++ b/apps/admin/src/pages/admin/users/permissions.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="User Permissions | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">User Permissions</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Permission sets, access requests, and audit trails will appear here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/users/sessions.astro
+++ b/apps/admin/src/pages/admin/users/sessions.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="User Sessions | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">User Sessions</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Session activity, device history, and revocation actions will live here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/workers/bindings.astro
+++ b/apps/admin/src/pages/admin/workers/bindings.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="Worker Bindings | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">Worker Bindings</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Resource bindings, environment variables, and secrets mapping will be listed here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/workers/routes.astro
+++ b/apps/admin/src/pages/admin/workers/routes.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="Worker Routes | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">Worker Routes</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Route tables, domains, and traffic rules will be managed here.
+        </p>
+    </section>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/workers/status.astro
+++ b/apps/admin/src/pages/admin/workers/status.astro
@@ -1,0 +1,11 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+---
+<AdminLayout title="Worker Status | GoldShore Admin">
+    <section class="max-w-5xl mx-auto py-24 px-6">
+        <h1 class="text-3xl gs-heading mb-4">Worker Status</h1>
+        <p class="text-[var(--gs-text-secondary)]">
+            Health checks and uptime metrics for each worker will appear here.
+        </p>
+    </section>
+</AdminLayout>


### PR DESCRIPTION
### Motivation
- Ensure README-listed admin routes resolve by adding missing page files so the admin UI can render HTML pages for each subroute.
- Provide a consistent scaffold using the existing `AdminLayout` to make later wiring of real data straightforward.

### Description
- Added `apps/admin/src/pages/admin/api-logs.astro` as a placeholder page using `AdminLayout` and simple explanatory content.
- Created worker subroute pages `apps/admin/src/pages/admin/workers/status.astro`, `workers/bindings.astro`, and `workers/routes.astro` with placeholder content and proper relative imports.
- Created user subroute pages `apps/admin/src/pages/admin/users/list.astro`, `users/sessions.astro`, and `users/permissions.astro` with placeholder content and proper relative imports.
- Created system subroute pages `apps/admin/src/pages/admin/system/dns.astro`, `system/pages.astro`, `system/storage.astro`, and `system/secrets.astro` with placeholder content and proper relative imports.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697312767bb48331a5eb4bd3ec2b15ac)