### PR TITLE
Add `rel="noopener noreferrer"` to social links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const today = new Date();
 <footer>
 	&copy; {today.getFullYear()} Your name here. All rights reserved.
 	<div class="social-links">
-		<a href="https://m.webtoo.ls/@astro" target="_blank">
+		<a href="https://m.webtoo.ls/@astro" target="_blank" rel="noopener noreferrer">
 			<span class="sr-only">Follow Astro on Mastodon</span>
 			<svg
 				viewBox="0 0 16 16"
@@ -19,7 +19,7 @@ const today = new Date();
 				></path></svg
 			>
 		</a>
-		<a href="https://twitter.com/astrodotbuild" target="_blank">
+		<a href="https://twitter.com/astrodotbuild" target="_blank" rel="noopener noreferrer">
 			<span class="sr-only">Follow Astro on Twitter</span>
 			<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32" astro-icon="social/twitter"
 				><path
@@ -28,7 +28,7 @@ const today = new Date();
 				></path></svg
 			>
 		</a>
-		<a href="https://github.com/withastro/astro" target="_blank">
+		<a href="https://github.com/withastro/astro" target="_blank" rel="noopener noreferrer">
 			<span class="sr-only">Go to Astro's GitHub repo</span>
 			<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32" astro-icon="social/github"
 				><path

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,7 +12,7 @@ import { SITE_TITLE } from '../consts';
 			<HeaderLink href="/about">About</HeaderLink>
 		</div>
 		<div class="social-links">
-			<a href="https://m.webtoo.ls/@astro" target="_blank">
+			<a href="https://m.webtoo.ls/@astro" target="_blank" rel="noopener noreferrer">
 				<span class="sr-only">Follow Astro on Mastodon</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
 					><path
@@ -21,7 +21,7 @@ import { SITE_TITLE } from '../consts';
 					></path></svg
 				>
 			</a>
-			<a href="https://twitter.com/astrodotbuild" target="_blank">
+			<a href="https://twitter.com/astrodotbuild" target="_blank" rel="noopener noreferrer">
 				<span class="sr-only">Follow Astro on Twitter</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
 					><path
@@ -30,7 +30,7 @@ import { SITE_TITLE } from '../consts';
 					></path></svg
 				>
 			</a>
-			<a href="https://github.com/withastro/astro" target="_blank">
+			<a href="https://github.com/withastro/astro" target="_blank" rel="noopener noreferrer">
 				<span class="sr-only">Go to Astro's GitHub repo</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
 					><path


### PR DESCRIPTION
### Motivation
- Prevent potential security and performance issues when opening external links with `target="_blank"` by adding `rel="noopener noreferrer"` to external anchors in the header and footer.

### Description
- Updated `src/components/Header.astro` and `src/components/Footer.astro` to add `rel="noopener noreferrer"` to the Mastodon, Twitter and GitHub `<a>` tags in the `.social-links` blocks that use `target="_blank"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697311b98f288331963a546394e052fa)