### PR TITLE
Update worker route documentation

### DIFF
--- a/apps/api-worker/README.md
+++ b/apps/api-worker/README.md
@@ -19,12 +19,17 @@ Configuration highlights (from `wrangler.toml`):
 - AI binding: `AI`
 
 ## Routes/Endpoints
+- `GET /` (status page)
 - `GET /health`
-- `GET /version`
-- `POST /auth/login`
-- `GET /auth/session`
-- `GET /content/:slug`
-- `POST /queue/task`
+- `GET /ai`
+- `GET /users`
+- `GET /user/:id`
+- `GET /system/info`
+- `GET /templates`
+- `GET /v1/users`
+- `GET /v1/agents`
+- `GET /v1/models`
+- `GET /v1/logs`
 
 ## Local Dev
 ```bash

--- a/apps/control-worker/README.md
+++ b/apps/control-worker/README.md
@@ -25,11 +25,6 @@ Configuration highlights (from `wrangler.toml`):
 - R2 binding: `STATE`
 - Service bindings: `API` (`gs-api`), `GATEWAY` (`gs-gateway`)
 
-## Routes/Endpoints
-- `POST /system/sync`
-- `POST /dns/update`
-- `POST /preview/create`
-
 ## Local Dev
 ```bash
 pnpm install

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -11,10 +11,12 @@ Cloudflare metadata (from `wrangler.toml`):
 - Environment variables: `ENV=production`, `API_ORIGIN=https://api.goldshore.ai`, `CLOUDFLARE_ACCESS_AUDIENCE`, `CLOUDFLARE_TEAM_DOMAIN`
 
 ## Routes/Endpoints
-- `https://gw.goldshore.ai/*` (proxy + routing entrypoint)
+- `GET /` (status page)
 - `GET /health`
+- `GET /templates`
 - `GET /user/login`
 - `POST /v1/chat`
+- `*` (proxy passthrough to `gs-api` when no matching route)
 The `gs-gateway` worker is the routing and queue ingress layer for GoldShore, served from `https://gw.goldshore.ai/*` on Cloudflare Workers. It handles proxying to the API, rate limiting, and preflight authorization checks.
 
 Configuration highlights (from `wrangler.toml`):
@@ -25,9 +27,6 @@ Configuration highlights (from `wrangler.toml`):
 - KV bindings: `gs-kv`, `GATEWAY_KV`
 - Queue producer: `JOB_QUEUE`
 - AI binding: `AI`
-
-## Routes/Endpoints
-- `https://gw.goldshore.ai/*` (proxy + routing entrypoint)
 
 ## Local Dev
 ```bash


### PR DESCRIPTION
### Motivation
- Reduce confusion between README route lists and the actual Hono router implementations by aligning documentation with code. 
- Make the worker `src/index.ts` (router files) the authoritative source for routes so reviewers and integrators know where to check behavior. 

### Description
- Updated `apps/api-worker/README.md` to list the actual root, core, and `/v1` endpoints implemented in `apps/api-worker/src/index.ts` and its `routes/*` modules. 
- Removed stale endpoint references from `apps/control-worker/README.md` so the README now documents only the active routes implemented in `apps/control-worker/src/index.ts`. 
- Refined `apps/gateway/README.md` to include the implemented `GET /`, `GET /templates`, `GET /user/login`, `POST /v1/chat` handlers and to document the proxy passthrough fallback to `gs-api`. 
- Committed the documentation updates to the repository. 

### Testing
- No automated tests were run because this is a documentation-only change. 
- Changes are limited to README files and do not modify runtime code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973135cd2008331b4762b438b8fdcfb)