### PR TITLE
Add Client Intake service to Services page

### DIFF
--- a/apps/web/src/pages/services.astro
+++ b/apps/web/src/pages/services.astro
@@ -19,6 +19,12 @@ const services = [
     name: 'Edge Intelligence',
     detail: 'Low-latency inference and routing tuned for reliability across regions.',
     cta: '/contact'
+  },
+  {
+    name: 'Client Intake',
+    detail:
+      'Lead capture forms, CRM integrations (HubSpot/Salesforce), billing flows (Stripe/PayPal), and an opportunity ranking pipeline surfaced in admin KPIs.',
+    cta: '/contact'
   }
 ];
 ---


### PR DESCRIPTION
### Motivation
- Surface a new “Client Intake” offering in the Services catalog so visitors and admins can see capabilities for lead capture, CRM (HubSpot/Salesforce) and billing (Stripe/PayPal) integrations plus an opportunity-ranking pipeline and KPIs.

### Description
- Added a `Client Intake` service entry to `apps/web/src/pages/services.astro` describing lead capture, CRM and billing integrations and opportunity ranking surfaced in admin KPIs.

### Testing
- Ran a local dev smoke test with `pnpm dev` and verified the site root returned `HTTP/1.1 200 OK` via `curl`; attempting a Playwright screenshot of `http://localhost:4321/services` failed with `net::ERR_EMPTY_RESPONSE`, so the visual check did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697319c5986083318dc2bd4f37bcdb43)