### PR TITLE
Add AI provider abstraction, PII policy, and /ai/analysis endpoint

### DIFF
--- a/apps/api-worker/src/index.ts
+++ b/apps/api-worker/src/index.ts
@@ -14,6 +14,8 @@ type Env = {
   DB: D1Database;
   ASSETS: R2Bucket;
   AI: any;
+  OPENAI_API_KEY?: string;
+  GEMINI_API_KEY?: string;
 };
 
 const app = new Hono<{ Bindings: Env }>();

--- a/apps/api-worker/src/routes/ai.ts
+++ b/apps/api-worker/src/routes/ai.ts
@@ -1,7 +1,62 @@
 import { Hono } from "hono";
+import { applyAnalysisPolicy, getProvider, type AnalysisRequest } from "@goldshore/ai-providers";
 
 const ai = new Hono();
 
 ai.get("/", (c) => c.json({ message: "AI endpoint" }));
+
+ai.post("/analysis", async (c) => {
+  let body: AnalysisRequest;
+  try {
+    body = await c.req.json();
+  } catch (error) {
+    return c.json({ error: "Invalid JSON payload" }, 400);
+  }
+
+  let policyResult;
+  try {
+    policyResult = applyAnalysisPolicy(body);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid request";
+    return c.json({ error: message }, 400);
+  }
+
+  const provider = getProvider(policyResult.sanitized.provider);
+  if (!provider) {
+    return c.json({ error: "Unsupported provider" }, 400);
+  }
+
+  const apiKey =
+    policyResult.sanitized.provider === "openai"
+      ? c.env.OPENAI_API_KEY
+      : c.env.GEMINI_API_KEY;
+
+  const startedAt = Date.now();
+  const providerResponse = await provider.analyze(policyResult.sanitized.input, {
+    apiKey,
+    fetch,
+  });
+  const durationMs = Date.now() - startedAt;
+
+  const logEntry = {
+    event: "ai.analysis",
+    timestamp: new Date().toISOString(),
+    request: policyResult.sanitized,
+    response: {
+      provider: providerResponse.provider,
+      output: providerResponse.output,
+    },
+    redactions: policyResult.redactions,
+    durationMs,
+  };
+
+  console.log(JSON.stringify(logEntry));
+
+  return c.json({
+    ...providerResponse,
+    redactions: policyResult.redactions,
+    durationMs,
+  });
+});
 
 export default ai;

--- a/packages/ai-providers/gemini.ts
+++ b/packages/ai-providers/gemini.ts
@@ -1,0 +1,46 @@
+import type { AnalysisProvider, AnalysisInput, AnalysisResponse, ProviderConfig } from './types';
+
+const buildPrompt = (input: AnalysisInput) => {
+  const parts = [] as string[];
+  if (input.context && input.context.length > 0) {
+    parts.push(input.context.join('\n'));
+  }
+  parts.push(input.prompt);
+  return parts.join('\n');
+};
+
+export const geminiProvider: AnalysisProvider = {
+  name: 'gemini',
+  async analyze(input: AnalysisInput, config: ProviderConfig): Promise<AnalysisResponse> {
+    const apiKey = config.apiKey;
+    if (!apiKey) {
+      throw new Error('Gemini API key is missing');
+    }
+
+    const model = config.model ?? 'gemini-1.5-pro';
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+    const response = await config.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: buildPrompt(input) }],
+          },
+        ],
+      }),
+    });
+
+    const payload = await response.json();
+    const output = payload?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+
+    return {
+      provider: 'gemini',
+      output,
+      raw: payload,
+    };
+  },
+};

--- a/packages/ai-providers/index.ts
+++ b/packages/ai-providers/index.ts
@@ -1,0 +1,15 @@
+export type { AnalysisInput, AnalysisRequest, AnalysisResponse, AnalysisProvider, ProviderConfig, ProviderName } from './types';
+export { applyAnalysisPolicy } from './policy';
+export { openAIProvider } from './openai';
+export { geminiProvider } from './gemini';
+
+import type { AnalysisProvider, ProviderName } from './types';
+import { openAIProvider } from './openai';
+import { geminiProvider } from './gemini';
+
+const providers: Record<ProviderName, AnalysisProvider> = {
+  openai: openAIProvider,
+  gemini: geminiProvider,
+};
+
+export const getProvider = (name: ProviderName) => providers[name];

--- a/packages/ai-providers/openai.ts
+++ b/packages/ai-providers/openai.ts
@@ -1,0 +1,44 @@
+import type { AnalysisProvider, AnalysisInput, AnalysisResponse, ProviderConfig } from './types';
+
+const buildMessages = (input: AnalysisInput) => {
+  const messages: Array<{ role: 'system' | 'user'; content: string }> = [];
+
+  if (input.context && input.context.length > 0) {
+    messages.push({ role: 'system', content: input.context.join('\n') });
+  }
+
+  messages.push({ role: 'user', content: input.prompt });
+  return messages;
+};
+
+export const openAIProvider: AnalysisProvider = {
+  name: 'openai',
+  async analyze(input: AnalysisInput, config: ProviderConfig): Promise<AnalysisResponse> {
+    const apiKey = config.apiKey;
+    if (!apiKey) {
+      throw new Error('OpenAI API key is missing');
+    }
+
+    const model = config.model ?? 'gpt-4o-mini';
+    const response = await config.fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: buildMessages(input),
+      }),
+    });
+
+    const payload = await response.json();
+    const output = payload?.choices?.[0]?.message?.content ?? '';
+
+    return {
+      provider: 'openai',
+      output,
+      raw: payload,
+    };
+  },
+};

--- a/packages/ai-providers/package.json
+++ b/packages/ai-providers/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@goldshore/ai-providers",
+  "version": "0.0.1",
+  "main": "index.ts"
+}

--- a/packages/ai-providers/policy.ts
+++ b/packages/ai-providers/policy.ts
@@ -1,0 +1,110 @@
+import type { AnalysisRequest, AnalysisInput } from './types';
+
+type RedactionResult = {
+  text: string;
+  redactions: number;
+};
+
+const PII_PATTERNS: RegExp[] = [
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+  /\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b/g,
+  /\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b/g,
+  /\b(?:\d[ -]*?){13,19}\b/g,
+];
+
+const redactText = (value: string): RedactionResult => {
+  let redactions = 0;
+  let text = value;
+
+  for (const pattern of PII_PATTERNS) {
+    const matches = text.match(pattern);
+    if (matches) {
+      redactions += matches.length;
+      text = text.replace(pattern, '[REDACTED]');
+    }
+  }
+
+  return { text, redactions };
+};
+
+const assertInputTypes = (input: AnalysisInput) => {
+  if (typeof input.prompt !== 'string') {
+    throw new Error('input.prompt must be a string');
+  }
+
+  if (input.context && !Array.isArray(input.context)) {
+    throw new Error('input.context must be an array of strings');
+  }
+
+  if (input.context) {
+    for (const item of input.context) {
+      if (typeof item !== 'string') {
+        throw new Error('input.context must contain only strings');
+      }
+    }
+  }
+
+  if (input.metadata) {
+    if (Array.isArray(input.metadata) || typeof input.metadata !== 'object') {
+      throw new Error('input.metadata must be an object');
+    }
+
+    for (const [key, value] of Object.entries(input.metadata)) {
+      if (typeof key !== 'string') {
+        throw new Error('input.metadata keys must be strings');
+      }
+
+      const allowed =
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        value === null;
+
+      if (!allowed) {
+        throw new Error('input.metadata values must be string, number, boolean, or null');
+      }
+    }
+  }
+};
+
+export type PolicyResult = {
+  sanitized: AnalysisRequest;
+  redactions: number;
+};
+
+export const applyAnalysisPolicy = (request: AnalysisRequest): PolicyResult => {
+  if (!request || typeof request !== 'object') {
+    throw new Error('request must be an object');
+  }
+
+  if (!request.provider) {
+    throw new Error('provider is required');
+  }
+
+  if (!request.input) {
+    throw new Error('input is required');
+  }
+
+  assertInputTypes(request.input);
+
+  const promptResult = redactText(request.input.prompt);
+  let redactions = promptResult.redactions;
+
+  const context = request.input.context?.map((entry) => {
+    const result = redactText(entry);
+    redactions += result.redactions;
+    return result.text;
+  });
+
+  return {
+    sanitized: {
+      provider: request.provider,
+      input: {
+        prompt: promptResult.text,
+        context,
+        metadata: request.input.metadata,
+      },
+    },
+    redactions,
+  };
+};

--- a/packages/ai-providers/types.ts
+++ b/packages/ai-providers/types.ts
@@ -1,0 +1,29 @@
+export type ProviderName = 'openai' | 'gemini';
+
+export type AnalysisInput = {
+  prompt: string;
+  context?: string[];
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type AnalysisRequest = {
+  provider: ProviderName;
+  input: AnalysisInput;
+};
+
+export type AnalysisResponse = {
+  provider: ProviderName;
+  output: string;
+  raw?: unknown;
+};
+
+export type ProviderConfig = {
+  fetch: typeof fetch;
+  apiKey?: string;
+  model?: string;
+};
+
+export interface AnalysisProvider {
+  name: ProviderName;
+  analyze(input: AnalysisInput, config: ProviderConfig): Promise<AnalysisResponse>;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
       "@goldshore/utils/*": ["packages/utils/*"],
       "@goldshore/auth/*": ["packages/auth/*"],
       "@goldshore/theme/*": ["packages/theme/*"],
+      "@goldshore/ai-providers/*": ["packages/ai-providers/*"],
       "@packages/*": ["packages/*"],
       "@apps/*": ["apps/*"]
     }


### PR DESCRIPTION
### Motivation
- Introduce a pluggable provider layer so AI integrations (OpenAI, Gemini) can be used interchangeably by the API.
- Ensure inputs are type-checked and PII is redacted before sending data to external models to reduce leakage risk.
- Provide a single admin-facing analysis endpoint that centralizes policy enforcement, provider dispatch, and request/response logging for auditing.

### Description
- Add a new package `@goldshore/ai-providers` with types (`types.ts`), a policy layer (`policy.ts`) that enforces input types and redacts PII, and provider implementations for OpenAI (`openai.ts`) and Google Gemini (`gemini.ts`).
- Export `applyAnalysisPolicy`, provider implementations, and `getProvider` from `packages/ai-providers/index.ts` for easy consumption.
- Wire a new POST `/ai/analysis` endpoint in `apps/api-worker/src/routes/ai.ts` that parses the request, applies the policy, selects the provider, dispatches the call using the provider abstraction, logs a JSON audit entry (request, response metadata, redactions, duration), and returns the provider output plus metadata.
- Add `OPENAI_API_KEY` and `GEMINI_API_KEY` bindings to the API worker environment typing and add a workspace path mapping for `@goldshore/ai-providers/*` in `tsconfig.base.json`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697319b0dcec8331ab2093d6ee594e09)