### PR TITLE
Add Cloudflare admin proxy routes and UI controls

### DIFF
--- a/apps/admin/src/pages/admin/system.astro
+++ b/apps/admin/src/pages/admin/system.astro
@@ -1,11 +1,118 @@
 ---
 import AdminLayout from '../../layouts/AdminLayout.astro';
+import { GSButton } from '@goldshore/ui';
 ---
 <AdminLayout title="System | GoldShore Admin">
-    <section class="max-w-5xl mx-auto py-24 px-6">
-        <h1 class="text-3xl gs-heading mb-4">System Configuration</h1>
-        <p class="text-[var(--gs-text-secondary)]">
-            DNS, Secrets, Pages, and Cloudflare integrations will appear here.
-        </p>
+    <section class="max-w-6xl mx-auto py-16 px-6 space-y-10">
+        <header class="space-y-3">
+            <h1 class="text-3xl gs-heading">System Configuration</h1>
+            <p class="text-[var(--gs-text-secondary)]">
+                Review Cloudflare infrastructure data and trigger controlled updates from the admin console.
+            </p>
+        </header>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">DNS Records</h2>
+                    <p class="text-sm gs-text-subtle">List Cloudflare DNS records for the primary zone.</p>
+                </div>
+                <GSButton variant="secondary" id="dns-list">Fetch DNS Records</GSButton>
+                <textarea id="dns-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">Update DNS Record</h2>
+                    <p class="text-sm gs-text-subtle">Submit a targeted DNS record update.</p>
+                </div>
+                <div class="grid gap-3">
+                    <input id="dns-record-id" class="gs-input" placeholder="DNS Record ID" />
+                    <input id="dns-record-content" class="gs-input" placeholder="New content (e.g. 192.0.2.10)" />
+                    <GSButton variant="primary" id="dns-update">Update Record</GSButton>
+                </div>
+                <textarea id="dns-update-output" class="w-full min-h-[140px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">Workers Status</h2>
+                    <p class="text-sm gs-text-subtle">Inspect Cloudflare Workers services in the account.</p>
+                </div>
+                <GSButton variant="secondary" id="workers-status">Fetch Workers Status</GSButton>
+                <textarea id="workers-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">Access Policies</h2>
+                    <p class="text-sm gs-text-subtle">List Cloudflare Access policies for a specific app.</p>
+                </div>
+                <div class="grid gap-3">
+                    <input id="access-app-id" class="gs-input" placeholder="Access App ID" />
+                    <GSButton variant="secondary" id="access-list">Fetch Policies</GSButton>
+                </div>
+                <textarea id="access-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+        </div>
     </section>
+
+    <script is:inline>
+        const opsBase = 'https://ops.goldshore.ai/cloudflare';
+
+        const setOutput = (elementId, data) => {
+            const el = document.getElementById(elementId);
+            if (el) {
+                el.value = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+            }
+        };
+
+        const handleResponse = async (response) => {
+            const payload = await response.json().catch(() => ({ error: 'Invalid JSON response' }));
+            return { ok: response.ok, payload };
+        };
+
+        document.getElementById('dns-list')?.addEventListener('click', async () => {
+            setOutput('dns-output', 'Loading...');
+            const response = await fetch(`${opsBase}/dns/records`);
+            const { payload } = await handleResponse(response);
+            setOutput('dns-output', payload);
+        });
+
+        document.getElementById('dns-update')?.addEventListener('click', async () => {
+            const recordId = document.getElementById('dns-record-id')?.value;
+            const content = document.getElementById('dns-record-content')?.value;
+            if (!recordId || !content) {
+                setOutput('dns-update-output', 'Record ID and content are required.');
+                return;
+            }
+            setOutput('dns-update-output', 'Updating...');
+            const response = await fetch(`${opsBase}/dns/records/${recordId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content })
+            });
+            const { payload } = await handleResponse(response);
+            setOutput('dns-update-output', payload);
+        });
+
+        document.getElementById('workers-status')?.addEventListener('click', async () => {
+            setOutput('workers-output', 'Loading...');
+            const response = await fetch(`${opsBase}/workers/status`);
+            const { payload } = await handleResponse(response);
+            setOutput('workers-output', payload);
+        });
+
+        document.getElementById('access-list')?.addEventListener('click', async () => {
+            const appId = document.getElementById('access-app-id')?.value;
+            if (!appId) {
+                setOutput('access-output', 'Access App ID is required.');
+                return;
+            }
+            setOutput('access-output', 'Loading...');
+            const response = await fetch(`${opsBase}/access/policies?appId=${encodeURIComponent(appId)}`);
+            const { payload } = await handleResponse(response);
+            setOutput('access-output', payload);
+        });
+    </script>
 </AdminLayout>

--- a/apps/control-worker/src/index.ts
+++ b/apps/control-worker/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { secureHeaders } from "hono/secure-headers";
-import { verifyAccess } from "@goldshore/auth";
+import { verifyAccessWithClaims, type AccessTokenPayload } from "@goldshore/auth";
 import * as DNS from "./libs/dns";
 import * as Workers from "./libs/workers";
 import * as Pages from "./libs/pages";
@@ -8,8 +8,14 @@ import * as Access from "./libs/access";
 import type { ControlEnv } from "./libs/types";
 import { syncDNS } from "./tasks/syncDNS";
 import { rotateKeys } from "./tasks/rotateKeys";
+import { cloudflareRoutes } from "./routes/cloudflare";
 
-const app = new Hono<{ Bindings: ControlEnv }>();
+const app = new Hono<{
+  Bindings: ControlEnv;
+  Variables: {
+    accessClaims: AccessTokenPayload;
+  };
+}>();
 
 // Sentinel: Add security headers to all responses (Defense in Depth)
 app.use('*', secureHeaders());
@@ -22,10 +28,11 @@ app.use('*', async (c, next) => {
     return;
   }
 
-  const authorized = await verifyAccess(c.req.raw, c.env);
-  if (!authorized) {
+  const claims = await verifyAccessWithClaims(c.req.raw, c.env);
+  if (!claims) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
+  c.set('accessClaims', claims);
   await next();
 });
 
@@ -50,6 +57,8 @@ app.post("/access/audit", async (c) => {
   const report = await Access.audit(c.env);
   return c.json(report);
 });
+
+app.route("/cloudflare", cloudflareRoutes);
 
 export default {
   fetch: app.fetch,

--- a/apps/control-worker/src/libs/types.ts
+++ b/apps/control-worker/src/libs/types.ts
@@ -3,6 +3,10 @@ export interface ControlEnv {
   STATE: R2Bucket;
   API: Fetcher;
   GATEWAY: Fetcher;
+  CLOUDFLARE_API_TOKEN?: string;
+  CLOUDFLARE_ACCOUNT_ID?: string;
+  CLOUDFLARE_ZONE_ID?: string;
   CLOUDFLARE_ACCESS_AUDIENCE?: string;
   CLOUDFLARE_TEAM_DOMAIN?: string;
+  CONTROL_ADMIN_ROLES?: string;
 }

--- a/apps/control-worker/src/routes/cloudflare.ts
+++ b/apps/control-worker/src/routes/cloudflare.ts
@@ -1,0 +1,269 @@
+import { Hono } from "hono";
+import type { AccessTokenPayload } from "@goldshore/auth";
+import type { ControlEnv } from "../libs/types";
+
+const DEFAULT_ADMIN_ROLES = ["admin", "ops", "owner", "infra"];
+
+const getRequiredRoles = (env: ControlEnv) => {
+  const configured = env.CONTROL_ADMIN_ROLES?.split(",").map((role) => role.trim()).filter(Boolean);
+  return configured && configured.length > 0 ? configured : DEFAULT_ADMIN_ROLES;
+};
+
+const extractRoles = (claims: AccessTokenPayload) => {
+  const roles = new Set<string>();
+  const candidates = [claims.roles, claims.role, claims.groups];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      candidate.forEach((value) => roles.add(value));
+    } else if (typeof candidate === "string") {
+      roles.add(candidate);
+    }
+  }
+  return Array.from(roles).map((role) => role.toLowerCase());
+};
+
+const isAuthorizedRole = (claims: AccessTokenPayload, requiredRoles: string[]) => {
+  const roles = extractRoles(claims);
+  if (roles.length === 0) {
+    return false;
+  }
+  const required = requiredRoles.map((role) => role.toLowerCase());
+  return roles.some((role) => required.includes(role));
+};
+
+const logAuditEvent = async (
+  env: ControlEnv,
+  details: {
+    action: string;
+    actor?: string;
+    status: "success" | "denied" | "error";
+    metadata?: Record<string, unknown>;
+  }
+) => {
+  const timestamp = new Date().toISOString();
+  const key = `audit:${timestamp}:${crypto.randomUUID()}`;
+  const payload = {
+    ...details,
+    timestamp
+  };
+  await env.CONTROL_LOGS.put(key, JSON.stringify(payload));
+};
+
+const getActor = (claims: AccessTokenPayload, request: Request) => {
+  return (
+    claims.email ||
+    request.headers.get("CF-Access-Authenticated-User-Email") ||
+    request.headers.get("CF-Access-Authenticated-User-Id") ||
+    "unknown"
+  );
+};
+
+const fetchCloudflare = async (
+  env: ControlEnv,
+  path: string,
+  init?: RequestInit
+) => {
+  if (!env.CLOUDFLARE_API_TOKEN || !env.CLOUDFLARE_ACCOUNT_ID) {
+    throw new Error("Missing Cloudflare API credentials.");
+  }
+
+  const response = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
+      "Content-Type": "application/json",
+      ...init?.headers
+    }
+  });
+
+  const data = await response.json();
+  return { ok: response.ok, status: response.status, data };
+};
+
+const formatErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : "Unknown error";
+
+export const cloudflareRoutes = new Hono<{
+  Bindings: ControlEnv;
+  Variables: {
+    accessClaims: AccessTokenPayload;
+  };
+}>();
+
+cloudflareRoutes.use("*", async (c, next) => {
+  const claims = c.get("accessClaims");
+  const requiredRoles = getRequiredRoles(c.env);
+  if (!isAuthorizedRole(claims, requiredRoles)) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:access-denied",
+      actor: getActor(claims, c.req.raw),
+      status: "denied",
+      metadata: {
+        requiredRoles,
+        roles: extractRoles(claims)
+      }
+    });
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  await next();
+});
+
+cloudflareRoutes.get("/dns/records", async (c) => {
+  const zoneId = c.env.CLOUDFLARE_ZONE_ID;
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  if (!zoneId) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:list",
+      actor,
+      status: "error",
+      metadata: { reason: "missing-zone-id" }
+    });
+    return c.json({ error: "Missing Cloudflare zone id." }, 400);
+  }
+
+  const query = new URL(c.req.url).searchParams.toString();
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/zones/${zoneId}/dns_records${query ? `?${query}` : ""}`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:list",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status }
+    });
+
+    return c.json(result.data, result.status);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:list",
+      actor,
+      status: "error",
+      metadata: { message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
+cloudflareRoutes.put("/dns/records/:recordId", async (c) => {
+  const zoneId = c.env.CLOUDFLARE_ZONE_ID;
+  const { recordId } = c.req.param();
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+
+  if (!zoneId) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:update",
+      actor,
+      status: "error",
+      metadata: { reason: "missing-zone-id" }
+    });
+    return c.json({ error: "Missing Cloudflare zone id." }, 400);
+  }
+
+  if (!recordId) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:update",
+      actor,
+      status: "error",
+      metadata: { reason: "missing-record-id" }
+    });
+    return c.json({ error: "Missing DNS record id." }, 400);
+  }
+
+  try {
+    const payload = await c.req.json();
+    const result = await fetchCloudflare(
+      c.env,
+      `/zones/${zoneId}/dns_records/${recordId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(payload)
+      }
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:update",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status, recordId }
+    });
+
+    return c.json(result.data, result.status);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:dns:update",
+      actor,
+      status: "error",
+      metadata: { recordId, message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
+cloudflareRoutes.get("/workers/status", async (c) => {
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/accounts/${c.env.CLOUDFLARE_ACCOUNT_ID}/workers/services`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:workers:status",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status }
+    });
+
+    return c.json(result.data, result.status);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:workers:status",
+      actor,
+      status: "error",
+      metadata: { message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
+cloudflareRoutes.get("/access/policies", async (c) => {
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  const appId = c.req.query("appId");
+  if (!appId) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:access:policies",
+      actor,
+      status: "error",
+      metadata: { reason: "missing-app-id" }
+    });
+    return c.json({ error: "Missing access app id." }, 400);
+  }
+
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/accounts/${c.env.CLOUDFLARE_ACCOUNT_ID}/access/apps/${appId}/policies`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:access:policies",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status, appId }
+    });
+
+    return c.json(result.data, result.status);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:access:policies",
+      actor,
+      status: "error",
+      metadata: { appId, message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});

--- a/packages/auth/verify.ts
+++ b/packages/auth/verify.ts
@@ -1,4 +1,4 @@
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 
 export interface Env {
     // Sentinel: Added support for Audience verification to prevent auth bypass
@@ -20,9 +20,16 @@ function getJwks(domain: string) {
     return jwksCache.get(domain)!;
 }
 
-export async function verifyAccess(req: Request, env: Env) {
+export type AccessTokenPayload = JWTPayload & {
+  email?: string;
+  groups?: string[] | string;
+  roles?: string[] | string;
+  role?: string;
+};
+
+export async function verifyAccessWithClaims(req: Request, env: Env) {
   const token = req.headers.get("CF-Access-Jwt-Assertion");
-  if (!token) return false;
+  if (!token) return null;
 
   const teamDomain = (env && env.CLOUDFLARE_TEAM_DOMAIN) || DEFAULT_TEAM_DOMAIN;
   const JWKS = getJwks(teamDomain);
@@ -38,10 +45,15 @@ export async function verifyAccess(req: Request, env: Env) {
         options.audience = env.CLOUDFLARE_ACCESS_AUDIENCE;
     }
 
-    await jwtVerify(token, JWKS, options);
-    return true;
+    const { payload } = await jwtVerify(token, JWKS, options);
+    return payload as AccessTokenPayload;
   } catch (e) {
     console.error("Token verification failed", e);
-    return false;
+    return null;
   }
+}
+
+export async function verifyAccess(req: Request, env: Env) {
+  const payload = await verifyAccessWithClaims(req, env);
+  return Boolean(payload);
 }


### PR DESCRIPTION
### Motivation
- Provide admin operators with proxied Cloudflare management endpoints (DNS list/update, Workers status, Access policies) guarded by role-based checks. 
- Ensure all Cloudflare admin actions are audit-logged to `CONTROL_LOGS` for traceability. 
- Surface these controls in the admin UI so infra teams can inspect and trigger Cloudflare operations from the console.

### Description
- Add a new Hono route group at `apps/control-worker/src/routes/cloudflare.ts` that proxies Cloudflare API calls via `fetchCloudflare`, with centralized error handling. 
- Implement role extraction and authorization using token claims and `CONTROL_ADMIN_ROLES`, and write audit events to `CONTROL_LOGS` for every action. 
- Integrate the route group into the control worker by switching to `verifyAccessWithClaims` (returns token claims) and setting `accessClaims` in `apps/control-worker/src/index.ts`. 
- Expose admin UI controls in `apps/admin/src/pages/admin/system.astro` with client-side fetches to `https://ops.goldshore.ai/cloudflare` for DNS listing/updating, Workers status, and Access policy listing. 
- Extend environment typings in `apps/control-worker/src/libs/types.ts` for `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID`, and `CONTROL_ADMIN_ROLES`. 
- Update auth helper `packages/auth/verify.ts` to add `verifyAccessWithClaims` and an `AccessTokenPayload` type so the worker can evaluate roles from token claims.

### Testing
- Launched the admin dev server with `pnpm --filter ./apps/admin dev` and loaded `/admin/system` to validate the UI; this succeeded. 
- Captured a Playwright screenshot of the rendered `/admin/system` page (`artifacts/admin-system-cloudflare.png`) to confirm the new controls render; the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697319ad85d88331a6d3bcd09a16a1ff)