### PR TITLE
Add integrations hub documentation and admin integrations config

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -44,6 +44,9 @@ Cloudflare metadata:
 - Pages bindings config: `infra/cloudflare/goldshore-admin.wrangler.toml`
 - Connected services for preview builds: `PUBLIC_API=https://api-preview.goldshore.ai`, `PUBLIC_GATEWAY=https://gw-preview.goldshore.ai`
 
+Documentation:
+- [Integrations hub](../../docs/integrations.md)
+
 ## Routes/Endpoints
 Admin sections:
 - `/admin/overview`
@@ -117,6 +120,9 @@ pnpm --filter @goldshore/admin dev
 
 ## Overview
 The GoldShore admin cockpit is an Astro SSR dashboard protected by Cloudflare Access. It uses the shared GoldShore UI kit and theme tokens.
+
+Documentation:
+- [Integrations hub](../../docs/integrations.md)
 
 ## Routes/Endpoints
 Admin sections:

--- a/apps/admin/src/lib/integrations.ts
+++ b/apps/admin/src/lib/integrations.ts
@@ -1,0 +1,90 @@
+export type IntegrationDefinition = {
+  id: string;
+  name: string;
+  baseUrl: string;
+  authMethod: string;
+  scopes: string[];
+  rateLimits: string;
+  dataClassification: string;
+};
+
+export const integrations: IntegrationDefinition[] = [
+  {
+    id: 'cloudflare-api',
+    name: 'Cloudflare API',
+    baseUrl: 'https://api.cloudflare.com/client/v4',
+    authMethod: 'API token (bearer)',
+    scopes: [
+      'Zone:Read',
+      'Zone:Edit',
+      'Workers:Read',
+      'Workers:Edit',
+      'Access:Read',
+      'Access:Edit',
+      'DNS:Read',
+      'DNS:Edit',
+    ],
+    rateLimits: 'Global API limit (typically 1,200 requests / 5 min / user; endpoint-specific caps apply).',
+    dataClassification: 'Confidential (infrastructure metadata, DNS records, access policies).',
+  },
+  {
+    id: 'google-api',
+    name: 'Google APIs',
+    baseUrl: 'https://www.googleapis.com',
+    authMethod: 'OAuth 2.0 (user or service account) or API key for public endpoints',
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+      'https://www.googleapis.com/auth/userinfo.email',
+    ],
+    rateLimits: 'Project- and API-specific quotas (varies by API; enforced in Google Cloud Console).',
+    dataClassification: 'Confidential (workspace, project, and identity metadata).',
+  },
+  {
+    id: 'gemini-api',
+    name: 'Google Gemini API',
+    baseUrl: 'https://generativelanguage.googleapis.com',
+    authMethod: 'API key (Google AI Studio) or OAuth 2.0 (Vertex AI)',
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform (Vertex AI)',
+    ],
+    rateLimits: 'Model- and project-specific quotas (see Google AI Studio or Vertex AI quotas).',
+    dataClassification: 'Confidential (prompt and completion content).',
+  },
+  {
+    id: 'thinkorswim-api',
+    name: 'ThinkorSwim API',
+    baseUrl: 'https://api.tdameritrade.com/v1',
+    authMethod: 'OAuth 2.0 (authorization code + refresh token)',
+    scopes: [
+      'Account:Read',
+      'Account:Trade',
+      'MarketData:Read',
+    ],
+    rateLimits: 'Typically ~120 requests/minute per user; subject to broker throttling.',
+    dataClassification: 'Restricted (brokerage credentials, account and trading data).',
+  },
+  {
+    id: 'openai-api',
+    name: 'OpenAI / ChatGPT API',
+    baseUrl: 'https://api.openai.com/v1',
+    authMethod: 'API key (bearer)',
+    scopes: [
+      'Project API key (model access scoped by project)',
+    ],
+    rateLimits: 'Per-model and per-project rate limits (configured in OpenAI dashboard).',
+    dataClassification: 'Confidential (prompt, completion, and usage telemetry).',
+  },
+  {
+    id: 'jules-api',
+    name: 'Jules API',
+    baseUrl: 'https://api.goldshore.ai/jules',
+    authMethod: 'OAuth 2.0 (internal service-to-service tokens)',
+    scopes: [
+      'jules:read',
+      'jules:write',
+      'automation:run',
+    ],
+    rateLimits: 'Internal gateway limits (align with automation workload SLOs).',
+    dataClassification: 'Confidential (automation runs, internal workflows, and task metadata).',
+  },
+];

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,65 @@
+# Integrations Hub
+
+This hub documents external integrations used by GoldShore services and the admin cockpit. The canonical configuration list for the admin UI lives in `apps/admin/src/lib/integrations.ts`.
+
+## Integration Catalog
+
+### Cloudflare API
+
+| Field | Details |
+| --- | --- |
+| Base URL | `https://api.cloudflare.com/client/v4` |
+| Auth method | API token (bearer) |
+| Scopes | `Zone:Read`, `Zone:Edit`, `Workers:Read`, `Workers:Edit`, `Access:Read`, `Access:Edit`, `DNS:Read`, `DNS:Edit` |
+| Rate limits | Global API limit (typically 1,200 requests / 5 min / user; endpoint-specific caps apply). |
+| Data classification | Confidential (infrastructure metadata, DNS records, access policies). |
+
+### Google APIs
+
+| Field | Details |
+| --- | --- |
+| Base URL | `https://www.googleapis.com` |
+| Auth method | OAuth 2.0 (user or service account) or API key for public endpoints |
+| Scopes | `https://www.googleapis.com/auth/cloud-platform`, `https://www.googleapis.com/auth/userinfo.email` |
+| Rate limits | Project- and API-specific quotas (varies by API; enforced in Google Cloud Console). |
+| Data classification | Confidential (workspace, project, and identity metadata). |
+
+### Google Gemini API
+
+| Field | Details |
+| --- | --- |
+| Base URL | `https://generativelanguage.googleapis.com` |
+| Auth method | API key (Google AI Studio) or OAuth 2.0 (Vertex AI) |
+| Scopes | `https://www.googleapis.com/auth/cloud-platform` (Vertex AI) |
+| Rate limits | Model- and project-specific quotas (see Google AI Studio or Vertex AI quotas). |
+| Data classification | Confidential (prompt and completion content). |
+
+### ThinkorSwim API
+
+| Field | Details |
+| --- | --- |
+| Base URL | `https://api.tdameritrade.com/v1` |
+| Auth method | OAuth 2.0 (authorization code + refresh token) |
+| Scopes | `Account:Read`, `Account:Trade`, `MarketData:Read` |
+| Rate limits | Typically ~120 requests/minute per user; subject to broker throttling. |
+| Data classification | Restricted (brokerage credentials, account and trading data). |
+
+### OpenAI / ChatGPT API
+
+| Field | Details |
+| --- | --- |
+| Base URL | `https://api.openai.com/v1` |
+| Auth method | API key (bearer) |
+| Scopes | Project API key (model access scoped by project) |
+| Rate limits | Per-model and per-project rate limits (configured in OpenAI dashboard). |
+| Data classification | Confidential (prompt, completion, and usage telemetry). |
+
+### Jules API
+
+| Field | Details |
+| --- | --- |
+| Base URL | `https://api.goldshore.ai/jules` |
+| Auth method | OAuth 2.0 (internal service-to-service tokens) |
+| Scopes | `jules:read`, `jules:write`, `automation:run` |
+| Rate limits | Internal gateway limits (align with automation workload SLOs). |
+| Data classification | Confidential (automation runs, internal workflows, and task metadata). |


### PR DESCRIPTION
### Motivation
- Provide a single canonical reference for external integrations used by GoldShore services and the admin cockpit. 
- Standardize integration metadata (base URL, auth method, scopes, rate limits, data classification) so the admin UI and docs can reference a single source of truth. 
- Surface the integrations doc from the admin README to improve discoverability for operators and engineers. 

### Description
- Add a documentation hub at `docs/integrations.md` that catalogs Cloudflare API, Google APIs, Google Gemini, ThinkorSwim, OpenAI/ChatGPT, and Jules with base URLs, auth methods, scopes, rate limits, and data classification. 
- Add `apps/admin/src/lib/integrations.ts` which exports an `IntegrationDefinition` type and a canonical `integrations` array containing the same entries for programmatic use by the admin app. 
- Link the new integrations hub from `apps/admin/README.md` in both overview sections to make the reference easy to find. 

### Testing
- No automated tests were run because this change only adds documentation and a static configuration list. 
- Files were created and committed: `docs/integrations.md`, `apps/admin/src/lib/integrations.ts`, and `apps/admin/README.md` was updated, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697319a582888331afb5e0a4c91882a9)