### PR TITLE
Add Cloudflare analytics admin dashboard

### DIFF
--- a/apps/admin/src/components/Sidebar.astro
+++ b/apps/admin/src/components/Sidebar.astro
@@ -1,6 +1,7 @@
 ---
 const links = [
   { href: '/admin/overview', label: 'Overview' },
+  { href: '/admin/analytics', label: 'Analytics' },
   { href: '/admin/dashboard', label: 'Dashboard' },
   { href: '/admin/systems', label: 'Systems' },
   { href: '/admin/users', label: 'Users' },

--- a/apps/admin/src/lib/cloudflare.ts
+++ b/apps/admin/src/lib/cloudflare.ts
@@ -1,0 +1,151 @@
+export type MetricPoint = {
+  label: string;
+  value: number;
+  display: string;
+};
+
+export type ChartMetrics = {
+  title: string;
+  description: string;
+  summary: string;
+  trend: string;
+  series: MetricPoint[];
+};
+
+export type CloudflareMetrics = {
+  highlights: {
+    totalRequests: string;
+    cacheHitRate: string;
+    threatsBlocked: string;
+    dnsChanges: string;
+  };
+  charts: {
+    traffic: ChartMetrics;
+    cache: ChartMetrics;
+    security: ChartMetrics;
+    dns: ChartMetrics;
+  };
+  refreshedAt: string;
+  source: 'live' | 'mock';
+  note: string;
+};
+
+const fallbackMetrics: CloudflareMetrics = {
+  highlights: {
+    totalRequests: '18.4M',
+    cacheHitRate: '86.7%',
+    threatsBlocked: '1,284',
+    dnsChanges: '14',
+  },
+  charts: {
+    traffic: {
+      title: 'Traffic Volume',
+      description: 'Requests served across GoldShore zones.',
+      summary: '+6.4% week over week',
+      trend: 'up',
+      series: [
+        { label: 'Mon', value: 62, display: '6.2M' },
+        { label: 'Tue', value: 74, display: '7.4M' },
+        { label: 'Wed', value: 68, display: '6.8M' },
+        { label: 'Thu', value: 79, display: '7.9M' },
+        { label: 'Fri', value: 71, display: '7.1M' },
+        { label: 'Sat', value: 58, display: '5.8M' },
+        { label: 'Sun', value: 64, display: '6.4M' },
+      ],
+    },
+    cache: {
+      title: 'Cache Hit Rate',
+      description: 'Edge cache effectiveness by day.',
+      summary: 'Stable within 84% - 89% band',
+      trend: 'steady',
+      series: [
+        { label: 'Mon', value: 84, display: '84%' },
+        { label: 'Tue', value: 86, display: '86%' },
+        { label: 'Wed', value: 89, display: '89%' },
+        { label: 'Thu', value: 87, display: '87%' },
+        { label: 'Fri', value: 88, display: '88%' },
+        { label: 'Sat', value: 85, display: '85%' },
+        { label: 'Sun', value: 86, display: '86%' },
+      ],
+    },
+    security: {
+      title: 'Security Events',
+      description: 'Mitigated threats and WAF actions.',
+      summary: 'Peak 312 events on Thursday',
+      trend: 'up',
+      series: [
+        { label: 'Mon', value: 142, display: '142' },
+        { label: 'Tue', value: 196, display: '196' },
+        { label: 'Wed', value: 214, display: '214' },
+        { label: 'Thu', value: 312, display: '312' },
+        { label: 'Fri', value: 238, display: '238' },
+        { label: 'Sat', value: 101, display: '101' },
+        { label: 'Sun', value: 81, display: '81' },
+      ],
+    },
+    dns: {
+      title: 'DNS Changes',
+      description: 'Record updates tracked across zones.',
+      summary: 'Most changes from automation rollouts',
+      trend: 'down',
+      series: [
+        { label: 'Mon', value: 5, display: '5' },
+        { label: 'Tue', value: 3, display: '3' },
+        { label: 'Wed', value: 2, display: '2' },
+        { label: 'Thu', value: 1, display: '1' },
+        { label: 'Fri', value: 1, display: '1' },
+        { label: 'Sat', value: 0, display: '0' },
+        { label: 'Sun', value: 2, display: '2' },
+      ],
+    },
+  },
+  refreshedAt: new Date().toISOString(),
+  source: 'mock',
+  note: 'Live metrics unavailable; showing read-only defaults.',
+};
+
+const mergeMetrics = (payload: Partial<CloudflareMetrics>): CloudflareMetrics => ({
+  ...fallbackMetrics,
+  ...payload,
+  highlights: {
+    ...fallbackMetrics.highlights,
+    ...payload.highlights,
+  },
+  charts: {
+    ...fallbackMetrics.charts,
+    ...payload.charts,
+  },
+});
+
+export const getCloudflareMetrics = async (
+  options: { endpoint?: string; fetcher?: typeof fetch } = {},
+): Promise<CloudflareMetrics> => {
+  const { endpoint = 'https://ops.goldshore.ai/cloudflare/metrics', fetcher = fetch } = options;
+
+  try {
+    const response = await fetcher(endpoint, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      return mergeMetrics({
+        note: `Backend responded with ${response.status}; using cached defaults.`,
+      });
+    }
+
+    const payload = (await response.json()) as Partial<CloudflareMetrics>;
+    return mergeMetrics({
+      ...payload,
+      refreshedAt: payload.refreshedAt ?? new Date().toISOString(),
+      source: payload.source ?? 'live',
+      note: payload.note ?? 'Live metrics pulled from secure backend.',
+    });
+  } catch (error) {
+    return mergeMetrics({
+      note: 'Secure backend unavailable; presenting mock data.',
+      source: 'mock',
+    });
+  }
+};

--- a/apps/admin/src/pages/admin/analytics.astro
+++ b/apps/admin/src/pages/admin/analytics.astro
@@ -1,0 +1,141 @@
+---
+import AdminLayout from '../../layouts/AdminLayout.astro';
+import StatCard from '../../components/StatCard.astro';
+import { getCloudflareMetrics } from '../../lib/cloudflare';
+
+const metrics = await getCloudflareMetrics();
+
+const chartEntries = Object.values(metrics.charts).map((chart) => {
+  const maxValue = Math.max(...chart.series.map((point) => point.value), 1);
+  return {
+    ...chart,
+    series: chart.series.map((point) => ({
+      ...point,
+      percent: Math.round((point.value / maxValue) * 100),
+    })),
+  };
+});
+
+const formatUpdated = (isoString: string) => {
+  const date = new Date(isoString);
+  return Number.isNaN(date.getTime()) ? 'Unavailable' : date.toLocaleString();
+};
+---
+<AdminLayout title="Cloudflare Analytics | GoldShore Admin">
+  <section class="max-w-7xl mx-auto px-6 py-10 space-y-10">
+    <header class="space-y-3">
+      <p class="text-sm uppercase tracking-[0.3em] gs-text-subtle">Cloudflare</p>
+      <h1 class="text-3xl gs-heading">Edge Analytics Overview</h1>
+      <p class="text-lg gs-text-subtle">
+        Visibility into traffic, cache health, security events, and DNS changes across GoldShore zones.
+      </p>
+      <div class="gs-card flex flex-wrap items-center gap-3 text-sm">
+        <span class="font-semibold">Data source:</span>
+        <span class="gs-text-info">{metrics.source === 'live' ? 'Secure backend feed' : 'Read-only mock feed'}</span>
+        <span class="gs-text-subtle">Last updated {formatUpdated(metrics.refreshedAt)}</span>
+        <span class="gs-text-subtle">{metrics.note}</span>
+      </div>
+    </header>
+
+    <section class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <StatCard label="Total Requests" value={metrics.highlights.totalRequests} help="Rolling 7-day total" />
+      <StatCard label="Cache Hit Rate" value={metrics.highlights.cacheHitRate} help="Edge cache average" />
+      <StatCard label="Threats Blocked" value={metrics.highlights.threatsBlocked} help="WAF + rate limiting" />
+      <StatCard label="DNS Changes" value={metrics.highlights.dnsChanges} help="Last 7 days" />
+    </section>
+
+    <section class="grid gap-6 lg:grid-cols-2">
+      {chartEntries.map((chart) => (
+        <article class="gs-card space-y-5">
+          <header class="space-y-2">
+            <div class="flex items-center justify-between">
+              <h2 class="text-xl font-semibold">{chart.title}</h2>
+              <span class={`chart-trend chart-trend--${chart.trend}`}>{chart.summary}</span>
+            </div>
+            <p class="text-sm gs-text-subtle">{chart.description}</p>
+          </header>
+          <div class="chart-stack">
+            {chart.series.map((point) => (
+              <div class="chart-row">
+                <span class="chart-label">{point.label}</span>
+                <div class="chart-track" aria-hidden="true">
+                  <span class="chart-fill" style={`width: ${point.percent}%`}></span>
+                </div>
+                <span class="chart-value">{point.display}</span>
+              </div>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  </section>
+
+  <style>
+    .chart-stack {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .chart-row {
+      display: grid;
+      grid-template-columns: 3rem 1fr 3rem;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+    }
+
+    .chart-label {
+      color: var(--gs-text-secondary);
+      font-weight: 600;
+    }
+
+    .chart-track {
+      width: 100%;
+      height: 0.55rem;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.2);
+      overflow: hidden;
+    }
+
+    .chart-fill {
+      display: block;
+      height: 100%;
+      border-radius: 999px;
+      background: linear-gradient(90deg, rgba(56, 189, 248, 0.7), rgba(59, 130, 246, 0.9));
+      box-shadow: 0 0 12px rgba(56, 189, 248, 0.35);
+    }
+
+    .chart-value {
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+      color: var(--gs-text-primary);
+    }
+
+    .chart-trend {
+      font-size: 0.75rem;
+      padding: 0.25rem 0.6rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .chart-trend--up {
+      color: var(--gs-success);
+      border-color: rgba(34, 197, 94, 0.35);
+      background: rgba(34, 197, 94, 0.12);
+    }
+
+    .chart-trend--down {
+      color: var(--gs-danger);
+      border-color: rgba(239, 68, 68, 0.35);
+      background: rgba(239, 68, 68, 0.12);
+    }
+
+    .chart-trend--steady {
+      color: var(--gs-text-secondary);
+      border-color: rgba(148, 163, 184, 0.35);
+      background: rgba(148, 163, 184, 0.12);
+    }
+  </style>
+</AdminLayout>


### PR DESCRIPTION
### Motivation
- Provide an admin-facing Cloudflare analytics section to surface traffic, cache hit rate, security events, and DNS changes using the existing admin UI style.
- Offer a safe, read-only data path that can pull from a secure backend when available and fall back to mocked metrics for offline/demo use.

### Description
- Added a new analytics page at `apps/admin/src/pages/admin/analytics.astro` that renders stat highlights and chart cards consistent with admin layout and components.
- Implemented a Cloudflare metrics service `apps/admin/src/lib/cloudflare.ts` which exports `getCloudflareMetrics` and returns merged live payloads or a `fallbackMetrics` mock when the secure backend is unavailable; the default backend endpoint is `https://ops.goldshore.ai/cloudflare/metrics`.
- Updated the admin navigation by adding an `Analytics` entry in `apps/admin/src/components/Sidebar.astro` so the page is discoverable from the sidebar.

### Testing
- Started the local dev server with `pnpm --filter @goldshore/admin dev` and confirmed Astro reported ready for local development (server start succeeded).
- Attempted an automated end-to-end screenshot via Playwright targeting `/admin/analytics`, but the Chromium process crashed in this environment and the Playwright run failed.
- No unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697325987d44833184918efd69225a8f)