### PR TITLE
Add routing access policy documentation

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -48,6 +48,8 @@ Documentation:
 - [Integrations hub](../../docs/integrations.md)
 
 ## Routes/Endpoints
+Routing & access policy: [`docs/security-scope.md`](../../docs/security-scope.md).
+
 Admin sections:
 - `/admin/overview`
 - `/admin/api-logs`
@@ -131,6 +133,8 @@ Documentation:
 - [Integrations hub](../../docs/integrations.md)
 
 ## Routes/Endpoints
+Routing & access policy: [`docs/security-scope.md`](../../docs/security-scope.md).
+
 Admin sections:
 - `/admin/overview`
 - `/admin/api-logs`

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -54,6 +54,8 @@ Cloudflare metadata:
 - Connected services for preview builds: `PUBLIC_API=https://api-preview.goldshore.ai`, `PUBLIC_GATEWAY=https://gw-preview.goldshore.ai`
 
 ## Routes/Endpoints
+Routing & access policy: [`docs/security-scope.md`](../../docs/security-scope.md).
+
 Public routes:
 - `/`
 - `/about`
@@ -141,6 +143,8 @@ pnpm --filter @goldshore/web dev
 The public GoldShore website and user portal built with Astro, shared theme, and UI components. It deploys to Cloudflare Pages as the primary marketing and customer-facing experience.
 
 ## Routes/Endpoints
+Routing & access policy: [`docs/security-scope.md`](../../docs/security-scope.md).
+
 Public routes:
 - `/`
 - `/about`

--- a/docs/security-scope.md
+++ b/docs/security-scope.md
@@ -1,0 +1,29 @@
+# Routing & Access Policy
+
+This document defines the routing and access policy for GoldShore properties. It clarifies which routes are public-facing and which require authentication via Cloudflare Access or application middleware.
+
+## Public routes (no authentication required)
+
+Public routes are marketing- or engagement-focused and should remain accessible without authentication. Examples include:
+
+- Marketing pages (home, about, pricing, legal)
+- Contact flows (contact form, support entry points)
+- Engagement content (campaign landing pages, newsletters, announcements)
+- Risk-radar demo experiences (public demo/preview routes)
+
+## Private routes (authentication required)
+
+Private routes are restricted to staff or authenticated users and must be protected by Cloudflare Access and/or application middleware.
+
+- Admin interfaces (all `/admin/*` sections)
+- Internal dashboards (staff-only or authenticated user portals)
+- Operational tooling (logs, workflow controls, user management)
+
+## Enforcement
+
+Private routes must enforce access at the edge or application layer:
+
+- **Cloudflare Access**: Configure Access policies to require identity verification for private route paths and preview environments.
+- **Application middleware**: Ensure SSR middleware or edge handlers validate sessions before serving private content.
+
+When introducing new routes, update this policy and ensure enforcement is in place before deployment.


### PR DESCRIPTION
### Motivation
- Centralize and document which routes are public vs private and provide enforcement guidance for Cloudflare Access and application middleware so README pages can reference a single policy.

### Description
- Add `docs/security-scope.md` that lists public routes (marketing, contact, engagement, risk‑radar demo), private routes (all `/admin/*`, internal dashboards, operational tooling) and enforcement guidance, and link this policy from `apps/web/README.md` and `apps/admin/README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973259d779883319d8f6be107141f55)