### PR TITLE
Add contact intake endpoint, lead-qualification form, auto-responder, and thank-you page

### DIFF
--- a/apps/web/src/emails/leadAutoResponder.ts
+++ b/apps/web/src/emails/leadAutoResponder.ts
@@ -1,0 +1,43 @@
+type AutoResponderInput = {
+  name?: string;
+  formType?: string;
+};
+
+const DEFAULT_SIGN_OFF = '— The GoldShore team';
+
+export function buildLeadAutoResponder({ name, formType }: AutoResponderInput) {
+  const friendlyName = name?.trim() || 'there';
+  const title =
+    formType === 'lead-qualification'
+      ? 'Thanks for sharing your project intake'
+      : 'Thanks for getting in touch with GoldShore';
+
+  const intro =
+    formType === 'lead-qualification'
+      ? 'We are reviewing the details you shared and will follow up with next steps.'
+      : 'We have your message and will respond with a tailored plan shortly.';
+
+  const subject = `${title} | GoldShore`;
+  const text = `Hi ${friendlyName},
+
+${intro}
+
+If you have additional details, reply to this email or contact us at hello@goldshore.ai.
+
+${DEFAULT_SIGN_OFF}
+`;
+
+  const html = `
+    <div style="font-family: 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #111;">
+      <p>Hi ${friendlyName},</p>
+      <p>${intro}</p>
+      <p>
+        If you have additional details, reply to this email or contact us at
+        <a href="mailto:hello@goldshore.ai">hello@goldshore.ai</a>.
+      </p>
+      <p>${DEFAULT_SIGN_OFF}</p>
+    </div>
+  `.trim();
+
+  return { subject, html, text };
+}

--- a/apps/web/src/pages/api/contact.ts
+++ b/apps/web/src/pages/api/contact.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from 'astro';
+import { buildLeadAutoResponder } from '../../emails/leadAutoResponder';
+
+const CONTACT_TTL_SECONDS = 60 * 60 * 24 * 90;
+
+const extractString = (value: FormDataEntryValue | null) =>
+  typeof value === 'string' ? value.trim() : '';
+
+const safeRedirect = (redirectTo: string | null, origin: string) => {
+  if (!redirectTo) return new URL('/thank-you', origin);
+  const trimmed = redirectTo.trim();
+  if (!trimmed.startsWith('/')) return new URL('/thank-you', origin);
+  return new URL(trimmed, origin);
+};
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  if (!request.headers.get('content-type')?.includes('form')) {
+    return new Response('Unsupported payload.', { status: 415 });
+  }
+
+  const formData = await request.formData();
+  const formType = extractString(formData.get('formType')) || 'contact';
+  const redirectTo = extractString(formData.get('redirectTo'));
+
+  const submission = {
+    id: crypto.randomUUID(),
+    formType,
+    name: extractString(formData.get('name')),
+    email: extractString(formData.get('email')),
+    company: extractString(formData.get('company')),
+    role: extractString(formData.get('role')),
+    website: extractString(formData.get('website')),
+    teamSize: extractString(formData.get('teamSize')),
+    industry: extractString(formData.get('industry')),
+    timeline: extractString(formData.get('timeline')),
+    budget: extractString(formData.get('budget')),
+    goals: extractString(formData.get('goals')),
+    message: extractString(formData.get('message')),
+    receivedAt: new Date().toISOString(),
+    ipAddress: request.headers.get('CF-Connecting-IP') ?? undefined,
+    userAgent: request.headers.get('User-Agent') ?? undefined,
+  };
+
+  const env = locals.runtime?.env as Env | undefined;
+
+  if (!env?.KV) {
+    return new Response('Storage unavailable.', { status: 503 });
+  }
+
+  const autoResponder = buildLeadAutoResponder({
+    name: submission.name,
+    formType: submission.formType,
+  });
+
+  await env.KV.put(
+    `contact:${submission.id}`,
+    JSON.stringify({ submission, autoResponder }),
+    {
+      expirationTtl: CONTACT_TTL_SECONDS,
+      metadata: {
+        formType: submission.formType,
+      },
+    }
+  );
+
+  const redirectUrl = safeRedirect(redirectTo, new URL(request.url).origin);
+  return Response.redirect(redirectUrl, 303);
+};
+
+export const GET: APIRoute = async () =>
+  new Response('Method not allowed.', { status: 405 });

--- a/apps/web/src/pages/contact.astro
+++ b/apps/web/src/pages/contact.astro
@@ -13,8 +13,14 @@ export const prerender = true;
         Tell us about your systems, service levels, or the experiences you want
         to build. We will respond with a tailored plan.
       </p>
+      <p>
+        Prefer a structured intake? Use our
+        <a href="/intake">project qualification form</a>.
+      </p>
     </div>
-    <form class="gs-card" action="mailto:hello@goldshore.ai" method="post">
+    <form class="gs-card" action="/api/contact" method="post">
+      <input type="hidden" name="formType" value="contact" />
+      <input type="hidden" name="redirectTo" value="/thank-you" />
       <div class="gs-input-group">
         <label for="name">Name</label>
         <input id="name" name="name" type="text" autocomplete="name" required />

--- a/apps/web/src/pages/intake.astro
+++ b/apps/web/src/pages/intake.astro
@@ -1,0 +1,116 @@
+---
+import { GSButton } from '@goldshore/ui';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+export const prerender = true;
+---
+
+<BaseLayout
+  title="Project Intake | GoldShore"
+  description="Share your goals and requirements so we can qualify your lead and respond quickly."
+>
+  <section class="gs-hero">
+    <div>
+      <h1>Project intake</h1>
+      <p>
+        Help us understand your organization, timelines, and priorities. We will
+        follow up with a tailored plan and next steps.
+      </p>
+    </div>
+    <form class="gs-card" action="/api/contact" method="post">
+      <input type="hidden" name="formType" value="lead-qualification" />
+      <input type="hidden" name="redirectTo" value="/thank-you" />
+      <div class="gs-input-group">
+        <label for="name">Name</label>
+        <input id="name" name="name" type="text" autocomplete="name" required />
+      </div>
+      <div class="gs-input-group">
+        <label for="email">Work email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          autocomplete="email"
+          spellcheck="false"
+          required
+        />
+      </div>
+      <div class="gs-input-group">
+        <label for="company">Company</label>
+        <input
+          id="company"
+          name="company"
+          type="text"
+          autocomplete="organization"
+          required
+        />
+      </div>
+      <div class="gs-input-group">
+        <label for="role">Role / team</label>
+        <input id="role" name="role" type="text" autocomplete="organization-title" />
+      </div>
+      <div class="gs-input-group">
+        <label for="website">Company website</label>
+        <input
+          id="website"
+          name="website"
+          type="url"
+          placeholder="https://"
+          autocomplete="url"
+        />
+      </div>
+      <div class="gs-input-group">
+        <label for="teamSize">Team size</label>
+        <select id="teamSize" name="teamSize" required>
+          <option value="">Select a range</option>
+          <option value="1-10">1-10</option>
+          <option value="11-50">11-50</option>
+          <option value="51-200">51-200</option>
+          <option value="201-1000">201-1000</option>
+          <option value="1000+">1000+</option>
+        </select>
+      </div>
+      <div class="gs-input-group">
+        <label for="industry">Industry</label>
+        <input id="industry" name="industry" type="text" />
+      </div>
+      <div class="gs-input-group">
+        <label for="timeline">Ideal timeline</label>
+        <select id="timeline" name="timeline" required>
+          <option value="">Select a timeline</option>
+          <option value="immediate">Immediate (0-30 days)</option>
+          <option value="quarter">This quarter (1-3 months)</option>
+          <option value="half-year">3-6 months</option>
+          <option value="future">6+ months</option>
+        </select>
+      </div>
+      <div class="gs-input-group">
+        <label for="budget">Budget range</label>
+        <select id="budget" name="budget" required>
+          <option value="">Select a range</option>
+          <option value="under-50k">Under $50k</option>
+          <option value="50k-150k">$50k-$150k</option>
+          <option value="150k-500k">$150k-$500k</option>
+          <option value="500k+">$500k+</option>
+        </select>
+      </div>
+      <div class="gs-input-group">
+        <label for="goals">Primary goals</label>
+        <textarea
+          id="goals"
+          name="goals"
+          rows="4"
+          aria-describedby="goals-helper"
+          required></textarea>
+        <p id="goals-helper" class="gs-helper">
+          Include KPIs, compliance needs, or systems you need to integrate.
+        </p>
+      </div>
+      <div class="gs-input-group">
+        <label for="message">Anything else we should know?</label>
+        <textarea id="message" name="message" rows="3"></textarea>
+      </div>
+      <GSButton type="submit">Submit intake</GSButton>
+    </form>
+  </section>
+</BaseLayout>

--- a/apps/web/src/pages/thank-you.astro
+++ b/apps/web/src/pages/thank-you.astro
@@ -1,0 +1,22 @@
+---
+import { GSButton } from '@goldshore/ui';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+export const prerender = true;
+---
+
+<BaseLayout
+  title="Thank You | GoldShore"
+  description="Your details are on the way to the GoldShore team."
+>
+  <section class="gs-hero">
+    <div>
+      <h1>Thank you</h1>
+      <p>
+        We have received your submission and will respond within one business
+        day. You can also email us directly at hello@goldshore.ai.
+      </p>
+      <GSButton href="/">Back to home</GSButton>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
### Motivation

- Replace the fragile `mailto:` form with a server-side submission endpoint to securely persist leads and prepare an auto-responder.
- Provide a structured intake page for lead qualification and a confirmation page to improve conversion and triage.

### Description

- Updated the public contact form to POST to the new endpoint and added hidden fields `formType` and `redirectTo` for routing and flow control (`apps/web/src/pages/contact.astro`).
- Added a lead-qualification intake page at `apps/web/src/pages/intake.astro` and a confirmation page at `apps/web/src/pages/thank-you.astro` to complete the submission flow.
- Implemented an Astro API route `apps/web/src/pages/api/contact.ts` that validates `form` submissions, builds a structured `submission` payload, stores it in Cloudflare KV with a TTL and metadata, and performs a safe redirect to the thank-you page.
- Added an auto-responder template builder `apps/web/src/emails/leadAutoResponder.ts` which produces subject, text and HTML bodies based on the `formType` and submitter name.

### Testing

- Started the site with `pnpm --filter ./apps/web dev` and verified HTTP 200 responses for `/intake` and `/thank-you` using `curl`, which returned OK.
- Ran an automated Playwright script that navigated to `/intake` and `/thank-you` and saved screenshots (`artifacts/intake.png`, `artifacts/thank-you.png`), which completed successfully.
- No unit tests were added; the changes were smoke-tested via the local dev server and browser automation and then committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697325a310a48331975e155abc22554e)