### PR TITLE
Add agent integration policy document and link from admin README

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -46,6 +46,7 @@ Cloudflare metadata:
 
 Documentation:
 - [Integrations hub](../../docs/integrations.md)
+- [Agent integration policy](../../docs/agent-integration.md)
 
 ## Routes/Endpoints
 Admin sections:
@@ -129,6 +130,7 @@ The GoldShore admin cockpit is an Astro SSR dashboard protected by Cloudflare Ac
 
 Documentation:
 - [Integrations hub](../../docs/integrations.md)
+- [Agent integration policy](../../docs/agent-integration.md)
 
 ## Routes/Endpoints
 Admin sections:

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,32 @@
+# Agent Integration Policy
+
+## When to use Jules/Agent
+
+Use Jules/Agent for **automation and operational workflows** that benefit from repeatable execution and audit trails, such as:
+
+- Routine content formatting and publishing steps.
+- Data syncing, report generation, and batch updates.
+- Internal documentation updates and maintenance tasks.
+
+Do **not** use Jules/Agent for **SEO strategy or insight work** that requires human judgment, including:
+
+- Keyword strategy and prioritization.
+- Competitive positioning or market research.
+- Editorial direction and topic selection.
+
+## Required approvals (HITL checkpoints)
+
+- **Pre-run approval:** A human owner must approve any new automation workflow before first use.
+- **High-impact changes:** Any action that touches production data, public content, or user access requires a named approver.
+- **Publishing changes:** Automated publishing or distribution steps must be reviewed by a content owner before release.
+
+## Logging expectations
+
+All automated actions must leave an audit trail that includes:
+
+- **Who** triggered the automation (user or system identity).
+- **What** was changed (resources, files, records, or endpoints).
+- **When** the action occurred (timestamp in UTC).
+- **Outcome** (success/failure) with links to relevant logs or artifacts.
+
+Logs should be retained according to standard operational retention policies and be accessible to admins through the operational console.


### PR DESCRIPTION
### Motivation
- Provide a concise policy to clarify when `Jules/Agent` automation is appropriate, required human-in-the-loop approvals, and logging/audit expectations to avoid scope confusion in the admin console.

### Description
- Add `docs/agent-integration.md` with guidance on when to use the agent, required approvals (pre-run, high-impact, publishing), and required audit logging fields.
- Link the new policy from the admin documentation in `apps/admin/README.md` so operators can discover the policy from the admin cockpit docs.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697325a905f08331947c901bf64a2e12)