### PR TITLE
Add parallax, layered shadows, and section‑lift utilities

### DIFF
--- a/apps/web/src/components/sectionLift.ts
+++ b/apps/web/src/components/sectionLift.ts
@@ -1,0 +1,37 @@
+export type SectionLiftOptions = {
+  selector?: string;
+  rootMargin?: string;
+  threshold?: number | number[];
+  liftedClass?: string;
+};
+
+export const initSectionLift = (options: SectionLiftOptions = {}) => {
+  if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') {
+    return () => undefined;
+  }
+
+  const {
+    selector = '.gs-section-lift',
+    rootMargin = '0px 0px -15% 0px',
+    threshold = 0.25,
+    liftedClass = 'is-lifted'
+  } = options;
+
+  const elements = Array.from(document.querySelectorAll<HTMLElement>(selector));
+  if (elements.length === 0) {
+    return () => undefined;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        entry.target.classList.toggle(liftedClass, entry.isIntersecting);
+      });
+    },
+    { rootMargin, threshold }
+  );
+
+  elements.forEach((element) => observer.observe(element));
+
+  return () => observer.disconnect();
+};

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "@goldshore/theme";
+@import "./gs-effects.css";
 
 :root {
   font-family: var(--gs-font-body);

--- a/apps/web/src/styles/gs-effects.css
+++ b/apps/web/src/styles/gs-effects.css
@@ -1,0 +1,44 @@
+:root {
+  --gs-parallax-offset: 0px;
+  --gs-shadow-layered-soft: 0 12px 24px -16px rgba(14, 20, 30, 0.22),
+    0 24px 48px -32px rgba(14, 20, 30, 0.3);
+  --gs-shadow-layered-medium: 0 16px 32px -18px rgba(14, 20, 30, 0.26),
+    0 32px 64px -28px rgba(14, 20, 30, 0.36);
+  --gs-shadow-layered-strong: 0 18px 36px -18px rgba(14, 20, 30, 0.32),
+    0 40px 80px -28px rgba(14, 20, 30, 0.42);
+  --gs-section-lift-distance: -12px;
+  --gs-section-lift-shadow: var(--gs-shadow-layered-soft);
+}
+
+.gs-parallax {
+  transform: translate3d(0, var(--gs-parallax-offset), 0);
+  will-change: transform;
+}
+
+.gs-parallax--xs { --gs-parallax-offset: -8px; }
+.gs-parallax--sm { --gs-parallax-offset: -16px; }
+.gs-parallax--md { --gs-parallax-offset: -28px; }
+.gs-parallax--lg { --gs-parallax-offset: -44px; }
+
+.gs-shadow-layered { box-shadow: var(--gs-shadow-layered-soft); }
+.gs-shadow-layered--soft { box-shadow: var(--gs-shadow-layered-soft); }
+.gs-shadow-layered--medium { box-shadow: var(--gs-shadow-layered-medium); }
+.gs-shadow-layered--strong { box-shadow: var(--gs-shadow-layered-strong); }
+
+.gs-section-lift {
+  transform: translateY(0px);
+  transition: transform 500ms ease, box-shadow 500ms ease;
+}
+
+.gs-section-lift.is-lifted {
+  transform: translateY(var(--gs-section-lift-distance));
+  box-shadow: var(--gs-section-lift-shadow);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gs-parallax,
+  .gs-section-lift {
+    transition: none;
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide small, reusable visual utilities for parallax offsets, layered shadows, and a scroll‑triggered "section lift" effect so layouts across the site can reuse consistent motion and shadow styles.

### Description
- Add `apps/web/src/styles/gs-effects.css` containing CSS variables and utility classes for parallax transforms, layered box‑shadows, and the `.gs-section-lift` / `.is-lifted` pattern.
- Add `apps/web/src/components/sectionLift.ts` which exports `initSectionLift`, an IntersectionObserver helper that toggles the lift class when sections enter the viewport.
- Wire the new stylesheet into the site by importing `./gs-effects.css` from `apps/web/src/styles/global.css`.
- Requesting review: `@Jules-Bot [review-request]`.

### Testing
- No automated tests were run for this change; the change consists of new stylesheet and a small runtime helper that require runtime verification in the browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697331526fdc8331830f936c40f2dbaa)