### PR TITLE
Home: blueprint‑meets‑luxury visuals with parallax & reveal motion

### DIFF
--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -2,6 +2,7 @@
 import '@goldshore/theme/tokens';
 import { GSButton } from '@goldshore/ui';
 import MarketingLayout from '../layouts/MarketingLayout.astro';
+import '../styles/home.css';
 
 export const prerender = true;
 
@@ -29,8 +30,11 @@ const highlights = [
 ---
 
 <MarketingLayout title="GoldShore | Shaping Waves" description="Unified AI infrastructure for trading and intelligent operations.">
-  <section class="gs-hero">
-    <div>
+  <section class="gs-hero home-hero parallax-section">
+    <div class="parallax-layer layer-grid" data-parallax="0.08" aria-hidden="true"></div>
+    <div class="parallax-layer layer-glow" data-parallax="0.14" aria-hidden="true"></div>
+    <div class="parallax-layer layer-orbit" data-parallax="0.2" aria-hidden="true"></div>
+    <div class="hero-content reveal">
       <p class="gs-badge" style="margin-bottom: var(--gs-space-3);">Modern ops for fluid markets</p>
       <h1>Shaping Waves with Applied Intelligence</h1>
       <p>
@@ -41,7 +45,7 @@ const highlights = [
         <GSButton href="/contact" variant="secondary">Book a call</GSButton>
       </div>
     </div>
-    <div class="gs-card gs-pulse-frame">
+    <div class="gs-card gs-pulse-frame hero-card reveal">
       <h3 class="section-title"><span>⇄</span>Performance at a glance</h3>
       <div class="gs-grid columns-2">
         {highlights.map((item) => (
@@ -58,15 +62,19 @@ const highlights = [
 
   <div class="border-t-[var(--gs-border)]"></div>
 
-  <section class="max-w-7xl mx-auto py-24 px-6 grid grid-cols-1 md:grid-cols-3 gap-12">
+  <section class="home-features parallax-section">
+    <div class="parallax-layer layer-grid" data-parallax="0.05" aria-hidden="true"></div>
+    <div class="parallax-layer layer-glow" data-parallax="0.1" aria-hidden="true"></div>
+    <div class="max-w-7xl mx-auto py-24 px-6 grid grid-cols-1 md:grid-cols-3 gap-12">
     {features.map((feature) => (
-      <div class="space-y-4">
+      <div class="feature-card reveal">
         <h3 class="text-xl font-semibold" style="color: var(--gs-text-primary);">{feature.title}</h3>
         <p class="text-[var(--gs-text-secondary)]">
           {feature.body}
         </p>
       </div>
     ))}
+    </div>
   </section>
 </MarketingLayout>
 
@@ -120,3 +128,35 @@ const highlights = [
     letter-spacing: 0.05em;
   }
 </style>
+
+<script is:inline>
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (!prefersReducedMotion) {
+    const revealTargets = document.querySelectorAll('.reveal');
+    const revealObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            revealObserver.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.18 }
+    );
+    revealTargets.forEach((el) => revealObserver.observe(el));
+
+    const parallaxLayers = Array.from(document.querySelectorAll('[data-parallax]'));
+    const updateParallax = () => {
+      const scrollY = window.scrollY || window.pageYOffset;
+      parallaxLayers.forEach((layer) => {
+        const speed = parseFloat(layer.dataset.parallax || '0');
+        layer.style.transform = `translate3d(0, ${scrollY * speed * -0.12}px, 0)`;
+      });
+    };
+    updateParallax();
+    window.addEventListener('scroll', () => requestAnimationFrame(updateParallax), { passive: true });
+  } else {
+    document.querySelectorAll('.reveal').forEach((el) => el.classList.add('is-visible'));
+  }
+</script>

--- a/apps/web/src/styles/home.css
+++ b/apps/web/src/styles/home.css
@@ -1,0 +1,139 @@
+.home-hero,
+.home-features {
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at top left, rgba(88, 130, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(212, 179, 93, 0.16), transparent 45%),
+    linear-gradient(130deg, rgba(3, 8, 22, 0.95), rgba(8, 13, 28, 0.9) 45%, rgba(4, 6, 16, 0.96));
+  box-shadow: inset 0 0 140px rgba(0, 0, 0, 0.65);
+}
+
+.home-hero::after,
+.home-features::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(100, 130, 200, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(100, 130, 200, 0.1) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mix-blend-mode: screen;
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.home-hero::before,
+.home-features::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 20%, rgba(255, 255, 255, 0.12), transparent 60%);
+  opacity: 0.6;
+  animation: gradient-drift 18s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.parallax-layer {
+  position: absolute;
+  inset: -20% -10%;
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.layer-grid {
+  background-image: linear-gradient(rgba(120, 180, 255, 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(120, 180, 255, 0.18) 1px, transparent 1px);
+  background-size: 120px 120px;
+  filter: drop-shadow(0 0 24px rgba(88, 130, 255, 0.4));
+}
+
+.layer-glow {
+  background: radial-gradient(circle at 40% 30%, rgba(190, 224, 255, 0.36), transparent 45%),
+    radial-gradient(circle at 65% 70%, rgba(212, 179, 93, 0.3), transparent 45%);
+  filter: blur(2px);
+}
+
+.layer-orbit {
+  background: conic-gradient(from 140deg, rgba(255, 255, 255, 0.12), transparent 60%, rgba(255, 255, 255, 0.12));
+  mask-image: radial-gradient(circle at 50% 50%, rgba(0, 0, 0, 0.9), transparent 70%);
+  opacity: 0.5;
+}
+
+.home-hero .hero-content,
+.home-hero .hero-card {
+  position: relative;
+  z-index: 2;
+}
+
+.home-hero h1 {
+  text-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
+}
+
+.home-hero .gs-card,
+.home-features .feature-card {
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.92), rgba(10, 18, 30, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 60px rgba(2, 8, 23, 0.55), inset 0 0 30px rgba(120, 170, 255, 0.08);
+}
+
+.home-features {
+  padding: var(--gs-space-8) 0;
+}
+
+.home-features .feature-card {
+  padding: var(--gs-space-5);
+  border-radius: var(--gs-radius-md);
+  position: relative;
+  z-index: 1;
+}
+
+.home-features .feature-card h3 {
+  background: linear-gradient(90deg, #f8fafc, #cbd5f5);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes gradient-drift {
+  0% {
+    transform: translate3d(-2%, -1%, 0);
+  }
+  50% {
+    transform: translate3d(2%, 1%, 0);
+  }
+  100% {
+    transform: translate3d(-2%, -1%, 0);
+  }
+}
+
+@media (max-width: 900px) {
+  .home-hero,
+  .home-features {
+    box-shadow: inset 0 0 90px rgba(0, 0, 0, 0.6);
+  }
+
+  .parallax-layer {
+    inset: -10% -5%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-hero::before,
+  .home-features::before {
+    animation: none;
+  }
+
+  .reveal {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Update the home hero and features to a more distinctive “blueprint‑meets‑luxury” visual system featuring gridlines, metallic highlights, and deeper shadows to match the product aesthetic. 
- Add layered parallax and subtle motion to create perceived depth without heavy runtime cost. 
- Respect accessibility preferences by honoring `prefers-reduced-motion` and using lightweight, unobtrusive interactions.

### Description
- Added import of a new stylesheet `apps/web/src/styles/home.css` and created that file which contains the blueprint‑luxury look (gridline overlays, metallic/glow accents, deep inset shadows, and a slow `gradient-drift` animation). 
- Reworked the hero and features markup in `apps/web/src/pages/index.astro` to include parallax layers (`.parallax-layer`) and reveal hooks (`.reveal` / `.is-visible`) and updated card/feature markup to use the new styles. 
- Added a small inline script in `index.astro` that wires an `IntersectionObserver` for scroll‑in reveals, a simple scroll‑based parallax transform keyed to `data-parallax`, and falls back to non-animated states when `prefers-reduced-motion` is set. 
- Kept the change minimal and opt-in: visual layers are `aria-hidden` and pointer-events are disabled on decorative layers.

### Testing
- Started the dev server with `pnpm --filter web dev -- --host 0.0.0.0 --port 4321`, and the server initialized and reported ready. 
- Attempted automated browser validation via Playwright to capture a screenshot of `http://localhost:4321/`, but the Playwright run failed with `net::ERR_EMPTY_RESPONSE` when loading the local dev server. 
- No unit/test-suite runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973314ae95883319942006145c16cf9)