### PR TITLE
Update layout logos to SVG assets

### DIFF
--- a/apps/admin/src/layouts/AdminLayout.astro
+++ b/apps/admin/src/layouts/AdminLayout.astro
@@ -2,7 +2,7 @@
 import Sidebar from '../components/Sidebar.astro';
 import Topbar from '../components/Topbar.astro';
 import '@goldshore/theme';
-import logo from '../assets/goldshore-logo.png';
+import logo from '../assets/logo.svg';
 
 interface Props {
   title?: string;
@@ -24,7 +24,7 @@ const { title = 'GoldShore Admin' } = Astro.props;
   <body>
     <a href="#admin-content" class="skip-link">Skip to content</a>
     <div class="gs-admin-grid">
-      <Sidebar logo={logo} />
+      <Sidebar logo={logo.src} />
       <div class="gs-admin-main">
         <Topbar title={title} />
         <main id="admin-content" class="gs-admin-content">

--- a/apps/web/src/layouts/WebLayout.astro
+++ b/apps/web/src/layouts/WebLayout.astro
@@ -1,6 +1,6 @@
 ---
 import '@goldshore/theme';
-import logo from '../assets/goldshore-logo.png';
+import logo from '../assets/logo.svg';
 import { GSButton } from '@goldshore/ui';
 
 const navLinks = [


### PR DESCRIPTION
### Motivation
- Replace the PNG logo imports with the SVG asset so the app uses the new logo path for header/footer and admin UI.

### Description
- Switched `apps/web/src/layouts/WebLayout.astro` to import the SVG asset with `import logo from '../assets/logo.svg';` and kept using `logo.src` in `<img>`.
- Switched `apps/admin/src/layouts/AdminLayout.astro` to import the SVG asset with `import logo from '../assets/logo.svg';` and pass the resolved path into the sidebar with `Sidebar logo={logo.src}`.
- Verified `apps/admin/src/components/Sidebar.astro` already consumes the `logo` prop and uses `logo.src || logo` for the `<img>` `src`, so no component changes were required.

### Testing
- Started the web dev server with `pnpm --filter web dev` and observed `astro v... ready` indicating the dev server launched successfully. (succeeded)
- Attempted an automated browser check with Playwright to capture a screenshot, but the script failed with `net::ERR_EMPTY_RESPONSE` when navigating to the local server. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697339f119e48331b0e49fae8275ab2c)