### PR TITLE
Add reusable parallax helper and wire homepage parallax layers

### DIFF
--- a/apps/web/src/components/parallax.ts
+++ b/apps/web/src/components/parallax.ts
@@ -1,0 +1,58 @@
+export type ParallaxOptions = {
+  selector?: string;
+  speedAttribute?: string;
+  factor?: number;
+};
+
+export const initParallax = (options: ParallaxOptions = {}) => {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (prefersReducedMotion) {
+    return () => undefined;
+  }
+
+  const {
+    selector = '[data-parallax]',
+    speedAttribute = 'data-parallax',
+    factor = -0.12
+  } = options;
+
+  const layers = Array.from(document.querySelectorAll<HTMLElement>(selector)).map((element) => ({
+    element,
+    speed: parseFloat(element.getAttribute(speedAttribute) || '0')
+  }));
+
+  if (layers.length === 0) {
+    return () => undefined;
+  }
+
+  let ticking = false;
+  const updateParallax = () => {
+    const scrollY = window.scrollY || window.pageYOffset;
+    layers.forEach(({ element, speed }) => {
+      const offset = scrollY * speed * factor;
+      element.style.setProperty('--gs-parallax-offset', `${offset}px`);
+    });
+    ticking = false;
+  };
+
+  updateParallax();
+
+  const handleScroll = () => {
+    if (!ticking) {
+      window.requestAnimationFrame(updateParallax);
+      ticking = true;
+    }
+  };
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+  window.addEventListener('resize', updateParallax);
+
+  return () => {
+    window.removeEventListener('scroll', handleScroll);
+    window.removeEventListener('resize', updateParallax);
+  };
+};

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -101,9 +101,9 @@ const highlights = [
 
     <!-- Performance Section (Secondary Hero) -->
     <section class="gs-hero home-hero parallax-section" style="padding-top: 0;">
-        <div class="parallax-layer layer-grid" data-parallax="0.08" aria-hidden="true"></div>
-        <div class="parallax-layer layer-glow" data-parallax="0.14" aria-hidden="true"></div>
-        <div class="parallax-layer layer-orbit" data-parallax="0.2" aria-hidden="true"></div>
+        <div class="parallax-layer gs-parallax layer-grid" data-parallax="0.08" aria-hidden="true"></div>
+        <div class="parallax-layer gs-parallax layer-glow" data-parallax="0.14" aria-hidden="true"></div>
+        <div class="parallax-layer gs-parallax layer-orbit" data-parallax="0.2" aria-hidden="true"></div>
 
         <div class="hero-content reveal">
             <p class="gs-badge" style="margin-bottom: var(--gs-space-3);">Modern ops for fluid markets</p>
@@ -461,36 +461,13 @@ const highlights = [
   }
 </style>
 
-<script is:inline>
+<script type="module">
+  import { initParallax } from '../components/parallax';
+
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (!prefersReducedMotion) {
-    const parallaxLayers = Array.from(document.querySelectorAll('[data-parallax]')).map((layer) => ({
-      element: layer,
-      speed: parseFloat(layer.dataset.parallax || '0'),
-    }));
-
-    let ticking = false;
-    const updateParallax = () => {
-      const scrollY = window.scrollY || window.pageYOffset;
-      parallaxLayers.forEach(({ element, speed }) => {
-        element.style.transform = `translate3d(0, ${scrollY * speed * -0.12}px, 0)`;
-      });
-      ticking = false;
-    };
-
-    updateParallax();
-
-    window.addEventListener(
-      'scroll',
-      () => {
-        if (!ticking) {
-          window.requestAnimationFrame(updateParallax);
-          ticking = true;
-        }
-      },
-      { passive: true }
-    );
+    initParallax();
   } else {
     document.querySelectorAll('.reveal').forEach((el) => el.classList.add('is-visible'));
   }


### PR DESCRIPTION
### Motivation
- Provide a small, reusable JS helper that drives existing CSS parallax offsets so parallax layers can be reused across the site while respecting `prefers-reduced-motion`.
- Surface an implementation that composes with the existing `gs-effects.css` and `sectionLift` utilities instead of duplicating inline scripts on pages.

### Description
- Added `apps/web/src/components/parallax.ts` which exports `initParallax` to drive CSS offset variable `--gs-parallax-offset` for elements matching a configurable selector and speed attribute.
- Wired the homepage hero to use the new helper by adding the `gs-parallax` class to parallax layers and replacing the inline parallax script in `apps/web/src/pages/index.astro` with a module import calling `initParallax()`.
- The helper respects `prefers-reduced-motion`, uses `requestAnimationFrame` for scroll updates, and returns a cleanup function that removes event listeners.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69801d178eec8331bd584247602560f2)