### PR TITLE
Add Tailwind dependencies to admin and web apps

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@astrojs/cloudflare": "^12.6.11",
+    "@astrojs/tailwind": "^6.0.2",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,8 +16,10 @@
   "devDependencies": {
     "@astrojs/cloudflare": "^12.6.11",
     "@astrojs/mdx": "^3.1.0",
+    "@astrojs/tailwind": "^6.0.2",
     "remark-gfm": "^4.0.0",
     "rehype-pretty-code": "^0.12.0",
+    "tailwindcss": "^3.4.17",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
### Motivation
- The Astro configs for the `web` and `admin` apps enable the Tailwind integration but the per-package `devDependencies` did not declare `@astrojs/tailwind` and `tailwindcss`, causing isolated filtered installs/builds to fail with "Cannot find module '@astrojs/tailwind'".

### Description
- Add `@astrojs/tailwind` and `tailwindcss` to the `devDependencies` in `apps/web/package.json`.
- Add `@astrojs/tailwind` and `tailwindcss` to the `devDependencies` in `apps/admin/package.json`.
- Modified files: `apps/web/package.json` and `apps/admin/package.json`.

### Testing
- No automated tests were run for this change because it is a dependency-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69801df726c083319f9abb33eab872ec)