### PR TITLE
ci: guard pnpm lockfile for preview installs

### DIFF
--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -30,6 +30,13 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Verify pnpm lockfile
+        run: |
+          if [ ! -f pnpm-lock.yaml ]; then
+            echo "pnpm-lock.yaml is required for pnpm --frozen-lockfile installs."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
### Motivation
- Prevent CI failures in the preview web workflow caused by `pnpm install --frozen-lockfile` exiting non-zero when `pnpm-lock.yaml` is missing.

### Description
- Add a pre-install check to `.github/workflows/preview-web.yml` that verifies `pnpm-lock.yaml` exists and exits with a clear message if it does not.

### Testing
- No automated tests were run because this is a workflow-only change; the workflow file was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69801dc7f4b08331b211e8f3daf3e972)