### PR TITLE
Fix duplicate declarations in parallax component build

### DIFF
--- a/apps/web/src/components/parallax.ts
+++ b/apps/web/src/components/parallax.ts
@@ -54,24 +54,6 @@ export const initParallax = (options: ParallaxOptions = {}) => {
     });
     observer.observe(element);
   });
-  // Bolt: Optimize by tracking visibility to avoid layout thrashing for off-screen elements
-  const layers = Array.from(elements).map((element) => ({
-    element,
-    speed: parseFloat(element.getAttribute(speedAttribute) || '0'),
-    isVisible: true // Start visible to ensure initial position is set, IntersectionObserver will correct this
-  }));
-
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      const layer = layers.find((l) => l.element === entry.target);
-      if (layer) {
-        layer.isVisible = entry.isIntersecting;
-      }
-    });
-  }, { rootMargin: '200px' });
-
-  layers.forEach((l) => observer.observe(l.element));
-
   let ticking = false;
   const updateParallax = () => {
     const scrollY = window.scrollY || window.pageYOffset;


### PR DESCRIPTION
### Motivation
- The build was failing with `The symbol "layers" has already been declared` due to duplicated `layers` and `observer` declarations in the parallax component, so the change unifies the implementation to remove the conflict.
- The intent is to preserve the existing Map-based visibility tracking and single `IntersectionObserver` approach while avoiding duplicate state structures that caused the esbuild error.

### Description
- Removed the redundant array-based `layers` structure and the second `IntersectionObserver` from `apps/web/src/components/parallax.ts` and kept the Map-based implementation. 
- Kept the existing behaviors: visibility tracking via `IntersectionObserver`, on-scroll offset updates, and proper cleanup handlers. 
- Simplified the file to use a single source of truth for layer state to prevent duplicate symbol declarations and potential layout thrashing. 

### Testing
- Ran a production build with `pnpm --filter @goldshore/web build` and it completed successfully. 
- Started the dev server with `pnpm --filter @goldshore/web dev --host 0.0.0.0 --port 4321` and it served pages successfully. 
- Captured a Playwright screenshot of the homepage to exercise the component at runtime and confirm no runtime errors were observed. 

@Jules-Bot [review-request]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854bce4a848331804058f7b06e0620)