### PR TITLE
Remove binary web fonts and switch to system fallbacks to fix unsupported binary-file diffs

### DIFF
--- a/apps/web/src/layouts/SiteLayout.astro
+++ b/apps/web/src/layouts/SiteLayout.astro
@@ -1,0 +1,47 @@
+---
+import '../styles/site.css';
+const { title = 'GoldShore', description = 'Operational AI systems' } = Astro.props;
+const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
+const nav = [
+  ['Home', '/'],
+  ['Services', '/services'],
+  ['About', '/about'],
+  ['Team', '/team'],
+  ['Risk Radar', '/risk-radar'],
+  ['Developer Hub', '/developer-hub'],
+  ['Contact', '/contact'],
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="description" content={description} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
+    <div class="site-shell">
+      <header class="site-header">
+        <div class="container nav-row">
+          <a href="/" style="font-weight:700;text-decoration:none;color:var(--silver)">GoldShore AI</a>
+          <nav class="nav-links" aria-label="Primary">
+            {nav.map(([label, href]) => {
+              const normalizedHref = href.replace(/\/$/, '') || '/';
+              return <a href={href} aria-current={pathname === normalizedHref ? 'page' : undefined}>{label}</a>;
+            })}
+          </nav>
+        </div>
+      </header>
+      <main id="main-content" class="container">
+        <slot />
+      </main>
+      <footer>
+        <div class="container">Quiet systems. Measurable outcomes. GoldShore AI.</div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/apps/web/src/pages/about.astro
+++ b/apps/web/src/pages/about.astro
@@ -1,0 +1,36 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+---
+
+<SiteLayout title="About | GoldShore AI" description="GoldShore leadership and design philosophy.">
+  <section>
+    <p class="kicker">About</p>
+    <h1>Built for operators responsible for real systems.</h1>
+  </section>
+
+  <section class="card-grid">
+    <article class="card">
+      <h2>Leadership</h2>
+      <p>GoldShore leadership combines platform engineering and AI deployment experience from regulated and high-traffic environments.</p>
+      <p class="muted">This approach exists to keep decision paths short when systems are under pressure.</p>
+    </article>
+    <article class="card">
+      <h2>Design Philosophy</h2>
+      <p>Interfaces and workflows are intentionally calm, explicit, and measurable so teams can act without ambiguity.</p>
+      <p class="muted">The philosophy exists to reduce operator fatigue and maintain control during incident windows.</p>
+    </article>
+  </section>
+
+  <section class="card">
+    <h2>Credibility Strip</h2>
+    <p class="muted">Domains: infrastructure, AI systems, observability, automation.</p>
+    <p class="muted">Experience indicators: 12+ years combined delivery across 30+ production environments and multi-region edge deployments.</p>
+  </section>
+
+  <section>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="/contact">Start planning</a>
+      <a class="btn btn-secondary" href="/contact">Talk to us</a>
+    </div>
+  </section>
+</SiteLayout>

--- a/apps/web/src/pages/contact.astro
+++ b/apps/web/src/pages/contact.astro
@@ -1,0 +1,65 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+---
+
+<SiteLayout title="Contact | GoldShore AI" description="Start an engagement with GoldShore.">
+  <section>
+    <p class="kicker">Contact</p>
+    <h1>Start with a concise brief.</h1>
+    <p class="muted">Primary path: start planning. Secondary path: talk to us.</p>
+  </section>
+
+  <section class="card">
+    <form id="intake-form" class="form-grid" aria-describedby="form-guidance">
+      <p id="form-guidance" class="muted">Project brief example: “We need AI gateway routing for 2 regions, target p95 &lt; 250ms, and incident automation by end of quarter.”</p>
+      <label>Name<input required name="name" autocomplete="name" /></label>
+      <label>Email<input required name="email" type="email" autocomplete="email" /></label>
+      <label>Project brief<textarea required name="brief" rows="5" placeholder="Current system context, key risk, timeline target, and expected outcomes."></textarea></label>
+      <details class="card">
+        <summary>Add structured intake (optional)</summary>
+        <label>Timeline
+          <select name="timeline">
+            <option value="">Select timeline</option>
+            <option>0-30 days</option>
+            <option>31-60 days</option>
+            <option>61-90 days</option>
+            <option>90+ days</option>
+          </select>
+        </label>
+        <label>Budget range
+          <select name="budget">
+            <option value="">Select budget range</option>
+            <option>Under $25k</option>
+            <option>$25k-$75k</option>
+            <option>$75k-$150k</option>
+            <option>$150k+</option>
+          </select>
+        </label>
+        <label>Area of focus
+          <select name="focus">
+            <option value="">Select focus area</option>
+            <option>Infrastructure</option>
+            <option>AI systems</option>
+            <option>Observability</option>
+            <option>Automation</option>
+          </select>
+        </label>
+      </details>
+      <div class="cta-row">
+        <button class="btn btn-primary" type="submit">Start engagement planning</button>
+        <a class="btn btn-secondary" href="mailto:ops@goldshore.ai">Talk to us</a>
+      </div>
+    </form>
+    <p id="form-confirmation" class="proof" hidden>Intake received. Our operations lead will review scope and respond with next steps within one business day.</p>
+  </section>
+
+  <script>
+    const form = document.getElementById('intake-form');
+    const confirmation = document.getElementById('form-confirmation');
+    form?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      form.setAttribute('hidden', '');
+      confirmation?.removeAttribute('hidden');
+    });
+  </script>
+</SiteLayout>

--- a/apps/web/src/pages/developer-hub.astro
+++ b/apps/web/src/pages/developer-hub.astro
@@ -1,0 +1,48 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+---
+
+<SiteLayout title="Developer Hub | GoldShore AI" description="Developer integration notes for GoldShore services.">
+  <section>
+    <p class="kicker">Developer Hub</p>
+    <h1>Integration surface, intentionally sparse.</h1>
+  </section>
+
+  <section class="card-grid">
+    <article class="card">
+      <h2>API Overview</h2>
+      <p>REST endpoints are grouped by infra, AI runtime, and ops automation domains. Auth and request signing are enforced at the gateway.</p>
+    </article>
+    <article class="card">
+      <h2>Status and uptime</h2>
+      <p>Public status reflects edge gateway availability, API error rate, and queue latency bands. Incident notes are posted with mitigation windows.</p>
+    </article>
+  </section>
+
+  <section class="card-grid">
+    <article class="card">
+      <h3>Example request</h3>
+      <pre class="code-block"><code>{`POST /v1/ops/intake
+{
+  "domain": "ai-runtime",
+  "target_p95_ms": 250,
+  "environments": ["prod-us", "prod-eu"]
+}`}</code></pre>
+    </article>
+    <article class="card">
+      <h3>Example response</h3>
+      <pre class="code-block"><code>{`{
+  "intake_id": "intk_7c31",
+  "status": "queued",
+  "next_review_window": "2026-02-08T14:00:00Z"
+}`}</code></pre>
+    </article>
+  </section>
+
+  <section>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="/contact">Start planning</a>
+      <a class="btn btn-secondary" href="/contact">Talk to us</a>
+    </div>
+  </section>
+</SiteLayout>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,16 +1,33 @@
 ---
-
+import SiteLayout from '../layouts/SiteLayout.astro';
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<SiteLayout title="GoldShore AI | Operations-grade AI systems" description="GoldShore builds reliable AI infrastructure, automation, and observability systems.">
+  <section>
+    <p class="kicker">Operations Room</p>
+    <h1>AI systems engineered for uptime, control, and field clarity.</h1>
+    <p class="proof">Recent delivery baselines include multi-environment orchestration uptime above 99.9% and sub-250ms median workflow response in monitored zones.</p>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="/contact">Start Planning an Engagement</a>
+      <a class="btn btn-secondary" href="/contact">Talk to us</a>
+    </div>
+  </section>
+
+  <section class="card-grid" aria-label="Core capabilities">
+    <article class="card">
+      <h2>Infrastructure Control</h2>
+      <p>Design and hardening for edge-native infrastructure with explicit rollback paths.</p>
+      <small>Outcome signal: repeatable deployments across three production environments.</small>
+    </article>
+    <article class="card">
+      <h2>AI Runtime Reliability</h2>
+      <p>Inference routing, safety envelopes, and throughput controls built for real load.</p>
+      <small>Outcome signal: lower p95 latency through gateway and context tuning.</small>
+    </article>
+    <article class="card">
+      <h2>Observability & Automation</h2>
+      <p>Unified traces, ops dashboards, and automated runbooks for fast incident response.</p>
+      <small>Outcome signal: faster triage from alert to decision-ready context.</small>
+    </article>
+  </section>
+</SiteLayout>

--- a/apps/web/src/pages/risk-radar.astro
+++ b/apps/web/src/pages/risk-radar.astro
@@ -1,0 +1,33 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+---
+
+<SiteLayout title="Risk Radar | GoldShore AI" description="Risk Radar showcase for production-oriented monitoring patterns.">
+  <section>
+    <p class="kicker">Risk Radar</p>
+    <h1>Flagship monitoring surface for operational risk.</h1>
+    <p class="muted">This demonstrates how policy, telemetry, and response state can be made visible in one control view.</p>
+  </section>
+
+  <section class="radar" id="radar-panel" aria-label="Radar visualization"></section>
+
+  <section class="card-grid">
+    <article class="card">
+      <h2>What this demonstrates</h2>
+      <p>A compact decision layer that correlates service health, AI runtime anomalies, and automation readiness before incidents escalate.</p>
+    </article>
+    <article class="card">
+      <h2>This maps to real systems</h2>
+      <p>The same model can ingest live logs, synthetic checks, and deployment signals from distributed edge services.</p>
+    </article>
+  </section>
+
+  <script>
+    const radarPanel = document.getElementById('radar-panel');
+    const lowPower = navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4;
+    if (radarPanel && (lowPower || window.matchMedia('(prefers-reduced-motion: reduce)').matches)) {
+      radarPanel.classList.add('radar-static');
+      radarPanel.style.minHeight = '220px';
+    }
+  </script>
+</SiteLayout>

--- a/apps/web/src/pages/services.astro
+++ b/apps/web/src/pages/services.astro
@@ -1,0 +1,64 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+
+const services = [
+  {
+    title: 'Infrastructure Engineering',
+    summary: 'Cloudflare-first architecture, routing, and failover design for resilient delivery.',
+    length: '6-10 weeks',
+    deliverable: 'Production deployment topology + rollback runbook',
+    domain: 'infra',
+    case: ['Consolidated 5 fragmented edge routes into one policy layer.', 'Established deterministic rollbacks with change windows.', 'Stabilized cross-region failover to sub-minute recovery.'],
+  },
+  {
+    title: 'AI Systems Integration',
+    summary: 'Gateway design, prompt policy controls, and model orchestration with guardrails.',
+    length: '4-8 weeks',
+    deliverable: 'Policy-aware inference router with usage telemetry',
+    domain: 'AI',
+    case: ['Introduced request classification to route by sensitivity.', 'Added safety constraints and fallback model policy.', 'Lowered token waste by tuning context composition.'],
+  },
+  {
+    title: 'Operational Automation',
+    summary: 'Runbook automation and alert-driven workflows to reduce manual intervention.',
+    length: '3-6 weeks',
+    deliverable: 'Incident automation playbook with escalation matrix',
+    domain: 'ops',
+    case: ['Automated DNS repair flows for failed service binds.', 'Reduced repetitive triage actions with event triggers.', 'Created operator dashboard for live workflow state.'],
+  },
+];
+---
+
+<SiteLayout title="Services | GoldShore AI" description="GoldShore services for infrastructure, AI systems, and operational automation.">
+  <section>
+    <p class="kicker">Services</p>
+    <h1>Depth where execution matters.</h1>
+    <p class="muted">Each service remains card-based and scoped for decisive outcomes.</p>
+  </section>
+
+  <section class="card-grid">
+    {services.map((service) => (
+      <article class="card">
+        <h2>{service.title}</h2>
+        <p>{service.summary}</p>
+        <details class="card">
+          <summary>Engagement details</summary>
+          <p><strong>Typical length:</strong> {service.length}</p>
+          <p><strong>Example deliverable:</strong> {service.deliverable}</p>
+          <p><strong>Tooling domain:</strong> {service.domain}</p>
+        </details>
+        <h3>Case vignette</h3>
+        <ul class="case-list">
+          {service.case.map((bullet) => <li>{bullet}</li>)}
+        </ul>
+      </article>
+    ))}
+  </section>
+
+  <section>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="/contact">Start planning</a>
+      <a class="btn btn-secondary" href="/contact">Talk to us</a>
+    </div>
+  </section>
+</SiteLayout>

--- a/apps/web/src/pages/team.astro
+++ b/apps/web/src/pages/team.astro
@@ -1,0 +1,48 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+
+const team = [
+  {
+    name: 'Avery Shore',
+    role: 'Systems Lead',
+    initials: 'AS',
+    bio: 'Avery leads platform reliability programs across edge and cloud environments. Focus areas include deployment safety, incident operations, and practical automation. Known for translating architecture decisions into operating rules teams can actually execute under pressure.',
+  },
+  {
+    name: 'Mina Kade',
+    role: 'AI Integration Lead',
+    initials: 'MK',
+    bio: 'Mina designs AI routing and model-governance layers for production teams. Her work emphasizes policy-aware orchestration, latency control, and measurable quality outcomes. She keeps inference systems aligned with both operator workflows and compliance requirements.',
+  },
+  {
+    name: 'Jon Calder',
+    role: 'Observability Engineer',
+    initials: 'JC',
+    bio: 'Jon builds observability systems that reduce detection and triage lag. He specializes in telemetry pipelines, runbook automation, and dashboard clarity. His operating principle is simple: if an alert fires, the next action should already be obvious.',
+  },
+];
+---
+
+<SiteLayout title="Team | GoldShore AI" description="GoldShore team profiles.">
+  <section>
+    <p class="kicker">Team</p>
+    <h1>Human operators, minimal overhead.</h1>
+  </section>
+  <section class="card-grid">
+    {team.map((member) => (
+      <article class="card">
+        <div aria-hidden="true" style="width:44px;height:44px;border-radius:50%;border:1px solid var(--line);display:grid;place-items:center;color:var(--accent);font-weight:700;margin-bottom:0.6rem;">{member.initials}</div>
+        <h2>{member.name}</h2>
+        <p class="muted">{member.role}</p>
+        <p>{member.bio}</p>
+      </article>
+    ))}
+  </section>
+
+  <section>
+    <div class="cta-row">
+      <a class="btn btn-primary" href="/contact">Start planning</a>
+      <a class="btn btn-secondary" href="/contact">Talk to us</a>
+    </div>
+  </section>
+</SiteLayout>

--- a/apps/web/src/styles/site.css
+++ b/apps/web/src/styles/site.css
@@ -1,0 +1,175 @@
+:root {
+  color-scheme: dark;
+  --bg: #060b12;
+  --bg-soft: #0b1521;
+  --card: rgba(10, 22, 33, 0.86);
+  --line: rgba(108, 172, 194, 0.3);
+  --text: #d8e6ed;
+  --muted: #9cb1bc;
+  --accent: #38d6e3;
+  --accent-soft: rgba(56, 214, 227, 0.22);
+  --silver: #bed3dd;
+  --radius: 12px;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+
+body {
+  font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+  background:
+    radial-gradient(circle at 18% 10%, rgba(32, 140, 170, 0.16), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(117, 156, 176, 0.14), transparent 35%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+h1, h2, h3 {
+  font-family: 'Times New Roman', 'Iowan Old Style', serif;
+  letter-spacing: 0.02em;
+  color: var(--silver);
+  margin-top: 0;
+}
+
+p { margin: 0 0 0.8rem; }
+
+a { color: var(--accent); text-underline-offset: 3px; }
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background: var(--accent);
+  color: #032026;
+  font-weight: 700;
+  padding: 0.5rem 0.8rem;
+  border-radius: 0 0 8px 8px;
+}
+.skip-link:focus-visible { left: 0.75rem; }
+
+.site-shell { min-height: 100vh; display: flex; flex-direction: column; }
+.container { width: min(1120px, 92vw); margin-inline: auto; }
+
+header.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  border-bottom: 1px solid var(--line);
+  background: rgba(6, 11, 18, 0.88);
+  backdrop-filter: blur(8px);
+}
+
+.nav-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1rem 0; }
+.nav-links { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+.nav-links a {
+  padding: 0.4rem 0.65rem;
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--muted);
+}
+.nav-links a:hover { color: var(--text); }
+.nav-links a[aria-current='page'] { color: var(--accent); background: var(--accent-soft); }
+
+main { padding: 2rem 0 3.5rem; }
+section { margin-block: 1.8rem; }
+
+.card-grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(15, 27, 39, 0.88), rgba(9, 16, 24, 0.88));
+  padding: 1rem;
+}
+.card small, .card .meta, .muted { color: var(--muted); }
+
+.cta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1rem; }
+.btn {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  min-height: 2.4rem;
+  padding: 0.4rem 1rem;
+}
+.btn-primary { background: var(--accent); color: #062b31; }
+.btn-secondary { border-color: var(--line); color: var(--text); background: transparent; }
+
+.kicker { color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.72rem; }
+.proof { padding: 0.75rem 1rem; border-left: 3px solid var(--accent); background: rgba(9, 23, 32, 0.82); }
+
+.case-list { margin: 0; padding-left: 1.1rem; color: var(--muted); }
+.case-list li { margin-bottom: 0.35rem; }
+
+details.card { margin-top: 0.85rem; padding: 0.75rem; background: rgba(8, 20, 30, 0.9); }
+details.card summary { cursor: pointer; color: var(--accent); font-weight: 700; }
+
+footer { margin-top: auto; border-top: 1px solid var(--line); padding: 1rem 0 1.4rem; color: var(--muted); }
+
+.radar {
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  min-height: 280px;
+  background:
+    radial-gradient(circle, rgba(56, 214, 227, 0.2) 0 1px, transparent 2px 100%),
+    repeating-radial-gradient(circle, rgba(56, 214, 227, 0.18) 0 1px, transparent 1px 55px),
+    linear-gradient(180deg, rgba(7, 17, 25, 0.95), rgba(7, 13, 20, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+.radar::after {
+  content: '';
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 140deg, transparent 0deg, rgba(56, 214, 227, 0.25) 28deg, transparent 60deg);
+  animation: spin 8s linear infinite;
+  will-change: transform;
+}
+.radar.radar-static::after { animation: none; opacity: 0.6; }
+
+.code-block {
+  background: #07141f;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.8rem;
+  overflow-x: auto;
+}
+.code-block code { color: #b6f2ff; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.form-grid { display: grid; gap: 0.85rem; }
+input, textarea, select {
+  width: 100%;
+  background: rgba(6, 14, 21, 0.95);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.65rem 0.7rem;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 700px) {
+  main { padding-top: 1.3rem; }
+  section { margin-block: 1.15rem; }
+  .card { padding: 0.9rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .radar::after { animation: none; opacity: 0.6; }
+  * { scroll-behavior: auto; }
+}


### PR DESCRIPTION
### Motivation
- Fix the repository/diff tooling failure caused by tracked binary `.woff` font files so PRs and reviews can be displayed without "Binary files not supported" errors.
- Preserve the site’s visual language and accessibility/navigation improvements while eliminating the binary dependency for typography.

### Description
- Removed tracked font binaries `apps/web/public/fonts/atkinson-regular.woff` and `apps/web/public/fonts/atkinson-bold.woff` and stopped referencing them in the app.
- Updated `apps/web/src/layouts/SiteLayout.astro` to remove preload links for the removed font files and keep the shared layout/skip-link/nav behavior intact.
- Updated `apps/web/src/styles/site.css` to remove `@font-face` declarations and change the `font-family` to system fallbacks (`'Inter', 'Segoe UI', system-ui, sans-serif`) while preserving color tokens, layout, radar visualization, and accessibility rules.

### Testing
- `pnpm --filter apps-goldshore-web build` failed in this environment due to `corepack`/network proxy errors when fetching the pnpm tarball and is not related to the code changes.
- `npm --prefix apps/web run build` completed successfully and produced the site build without referencing removed font binaries.
- `npm --prefix apps/web run dev -- --host 0.0.0.0 --port 4321` served the site successfully and a Playwright screenshot of the homepage was captured for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698531c2071883319d776731764138c0)