### PR TITLE
Restore starfield header background

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,7 @@ import HeaderLink from './HeaderLink.astro';
 import { SITE_TITLE } from '../consts';
 ---
 
-<header>
+<header class="starfield">
 	<nav>
 		<h2><a href="/">{SITE_TITLE}</a></h2>
 		<div class="internal-links">
@@ -46,8 +46,59 @@ import { SITE_TITLE } from '../consts';
 	header {
 		margin: 0;
 		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
+		background: radial-gradient(circle at top, rgba(46, 74, 255, 0.2), rgba(5, 7, 20, 0.95));
+		box-shadow: 0 2px 8px rgba(var(--black), 35%);
+		position: relative;
+		overflow: hidden;
+		color: #f8f9ff;
+	}
+
+	.starfield::before,
+	.starfield::after {
+		content: "";
+		position: absolute;
+		inset: -200% 0 0 0;
+		background-repeat: repeat;
+		opacity: 0.7;
+		pointer-events: none;
+	}
+
+	.starfield::before {
+		background-image:
+			radial-gradient(1px 1px at 15% 20%, rgba(255, 255, 255, 0.9) 0, transparent 100%),
+			radial-gradient(1px 1px at 70% 80%, rgba(255, 255, 255, 0.7) 0, transparent 100%),
+			radial-gradient(1px 1px at 40% 60%, rgba(255, 255, 255, 0.6) 0, transparent 100%),
+			radial-gradient(1px 1px at 85% 35%, rgba(255, 255, 255, 0.8) 0, transparent 100%);
+		background-size: 320px 320px;
+		animation: star-drift 18s linear infinite;
+	}
+
+	.starfield::after {
+		background-image:
+			radial-gradient(2px 2px at 10% 30%, rgba(255, 255, 255, 0.6) 0, transparent 100%),
+			radial-gradient(2px 2px at 55% 15%, rgba(255, 255, 255, 0.5) 0, transparent 100%),
+			radial-gradient(2px 2px at 75% 55%, rgba(255, 255, 255, 0.7) 0, transparent 100%),
+			radial-gradient(2px 2px at 30% 75%, rgba(255, 255, 255, 0.4) 0, transparent 100%);
+		background-size: 520px 520px;
+		animation: star-drift 32s linear infinite reverse;
+		opacity: 0.4;
+	}
+
+	@keyframes star-drift {
+		0% {
+			transform: translate3d(0, 0, 0);
+		}
+		100% {
+			transform: translate3d(0, 35%, 0);
+		}
+	}
+
+	nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		position: relative;
+		z-index: 1;
 	}
 	h2 {
 		margin: 0;
@@ -57,21 +108,17 @@ import { SITE_TITLE } from '../consts';
 	h2 a,
 	h2 a.active {
 		text-decoration: none;
-	}
-	nav {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
+		color: inherit;
 	}
 	nav a {
 		padding: 1em 0.5em;
-		color: var(--black);
+		color: #f8f9ff;
 		border-bottom: 4px solid transparent;
 		text-decoration: none;
 	}
 	nav a.active {
 		text-decoration: none;
-		border-bottom-color: var(--accent);
+		border-bottom-color: rgba(255, 255, 255, 0.65);
 	}
 	.social-links,
 	.social-links a {


### PR DESCRIPTION
### Motivation
- Reintroduce the dark, animated starfield/parallax header that was removed so the site regains its original visual identity and atmosphere.
- Ensure header links remain readable against the darker background by adjusting colors and stacking.

### Description
- Restored and updated `src/components/Header.astro` to add `class="starfield"` to the header and replace the plain white background with a radial dark gradient.
- Implemented two layered pseudo-elements (`::before` and `::after`) that use small `radial-gradient` patterns to simulate star pixels and added the `@keyframes star-drift` animation for subtle vertical motion.
- Adjusted header styling for readability and stacking by adding `position: relative`, `overflow: hidden`, `z-index` on nav, lighter link colors (`#f8f9ff`) and a semi-transparent active underline.
- Kept existing markup and social icons intact while ensuring the starfield layers are non-interactive (`pointer-events: none`).

### Testing
- Launched the web app dev server with `pnpm --filter @goldshore/web dev -- --host 0.0.0.0 --port 4321`, and the Astro dev server reported ready successfully. 
- Verified the site responded with `HTTP/1.1 200 OK` using `curl -I http://localhost:4321/`. 
- Attempted an automated visual capture with Playwright to produce `artifacts/header-starfield.png`, but the browser run failed with `net::ERR_EMPTY_RESPONSE` when loading the page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69867cad7040833190f5ed2075e52415)