### PR TITLE
chore: mark audit logging as fire-and-forget

### DIFF
--- a/packages/integrations/admin.ts
+++ b/packages/integrations/admin.ts
@@ -67,7 +67,7 @@ export const createAdminService = (config: AdminServiceConfig) => {
       logger.error('[admin] request failed', { action, target, error });
       return { ok: false, payload: { error: 'Request failed' } };
     } finally {
-      auditLogger
+      void auditLogger
         .logAdminAction({
           action,
           actor: config.actor,


### PR DESCRIPTION
### Motivation
- Make the audit logging call explicit non-blocking to clarify intent and avoid keeping admin actions on the critical path by marking the promise as fire-and-forget.

### Description
- Add `void` before `auditLogger.logAdminAction(...)` in `packages/integrations/admin.ts` so the logging call is intentionally detached while preserving the existing `.catch()` error handling.

### Testing
- No automated tests were run as part of this change and no test files were modified; existing tests remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698833c7cde0833185d0c67de8a1e0fe)