### PR TITLE
Add Super Bowl boxes landing page

### DIFF
--- a/apps/web/src/layouts/WebLayout.astro
+++ b/apps/web/src/layouts/WebLayout.astro
@@ -7,6 +7,7 @@ const navLinks = [
   { href: '/about', label: 'About' },
   { href: '/services', label: 'Services' },
   { href: '/team', label: 'Team' },
+  { href: '/super-bowl-boxes', label: 'Super Bowl Boxes' },
   { href: '/contact', label: 'Contact' },
   { href: '/apps/risk-radar', label: 'Risk Radar' }
 ];

--- a/apps/web/src/pages/super-bowl-boxes.astro
+++ b/apps/web/src/pages/super-bowl-boxes.astro
@@ -1,0 +1,330 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+export const prerender = true;
+
+const teams = {
+  home: 'Home Team',
+  away: 'Away Team',
+  kickoff: 'Feb 9, 2025 • 6:30 PM ET',
+  venue: 'Caesars Superdome, New Orleans'
+};
+
+const quarterPrizes = [
+  { label: 'Q1', amount: '$250', detail: 'Score at end of 1st quarter' },
+  { label: 'Q2', amount: '$500', detail: 'Halftime payout' },
+  { label: 'Q3', amount: '$250', detail: 'Score at end of 3rd quarter' },
+  { label: 'Final', amount: '$1,000', detail: 'Final score payout' }
+];
+
+const steps = [
+  {
+    title: 'Claim a box',
+    body: 'Pick any open square from the 10x10 board. Each square represents a unique combination of the final digits for each team.'
+  },
+  {
+    title: 'Numbers are randomized',
+    body: 'Once the grid fills, numbers 0–9 are shuffled across the top and side. Your box inherits the numbers where the row and column meet.'
+  },
+  {
+    title: 'Track scores',
+    body: 'Payouts are based on the last digit of each team’s score at the end of each quarter.'
+  }
+];
+
+const rows = Array.from({ length: 10 }, (_, index) => index);
+const cols = Array.from({ length: 10 }, (_, index) => index);
+---
+<BaseLayout title="Super Bowl Boxes | GoldShore" description="Interactive Super Bowl boxes board for game-day pools.">
+  <section class="gs-hero sb-hero">
+    <div>
+      <p class="gs-badge">Super Bowl Boxes</p>
+      <h1>Run a game-day pool with cinematic clarity</h1>
+      <p class="gs-lead">
+        Organize your Super Bowl squares with a polished, easy-to-share board. Assign boxes, randomize numbers,
+        and track quarter payouts in one place.
+      </p>
+      <div class="sb-meta">
+        <div>
+          <span class="sb-meta__label">Kickoff</span>
+          <strong>{teams.kickoff}</strong>
+        </div>
+        <div>
+          <span class="sb-meta__label">Venue</span>
+          <strong>{teams.venue}</strong>
+        </div>
+      </div>
+      <div class="sb-actions">
+        <a class="gs-button" href="#board">View board</a>
+        <a class="gs-button gs-button--ghost" href="#rules">How it works</a>
+      </div>
+    </div>
+    <div class="gs-card sb-score-card">
+      <div class="sb-score-card__header">
+        <span class="material-symbols-rounded" aria-hidden="true">stadium</span>
+        Live matchup preview
+      </div>
+      <div class="sb-score-card__teams">
+        <div>
+          <p class="sb-team-label">Away</p>
+          <h3>{teams.away}</h3>
+        </div>
+        <div class="sb-score-divider">vs</div>
+        <div>
+          <p class="sb-team-label">Home</p>
+          <h3>{teams.home}</h3>
+        </div>
+      </div>
+      <p class="sb-helper">Update team names once the Super Bowl matchup is set.</p>
+    </div>
+  </section>
+
+  <section class="gs-section" id="rules">
+    <div class="gs-grid columns-3">
+      {steps.map((step) => (
+        <article class="gs-card sb-step">
+          <h3>{step.title}</h3>
+          <p>{step.body}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="gs-section" id="board">
+    <div class="gs-section-header">
+      <div>
+        <h2>Super Bowl boxes board</h2>
+        <p class="gs-helper">Boxes fill in real time. Randomized numbers will appear across the top and left once entries close.</p>
+      </div>
+      <div class="sb-tags">
+        <span class="gs-badge gs-badge--info">100 total boxes</span>
+        <span class="gs-badge gs-badge--warning">Numbers randomized at 95% full</span>
+      </div>
+    </div>
+
+    <div class="sb-board">
+      <div class="sb-board__header">
+        <span>{teams.away} last digit</span>
+      </div>
+      <div class="sb-board__grid">
+        <div class="sb-board__corner"></div>
+        {cols.map((col) => (
+          <div class="sb-board__label" aria-hidden="true">{col}</div>
+        ))}
+        {rows.map((row) => (
+          <>
+            <div class="sb-board__label" aria-hidden="true">{row}</div>
+            {cols.map((col) => (
+              <div class="sb-board__cell">
+                <div class="sb-board__cell-id">{row}-{col}</div>
+                <div class="sb-board__cell-name">Open</div>
+              </div>
+            ))}
+          </>
+        ))}
+      </div>
+      <div class="sb-board__footer">
+        <span>{teams.home} last digit</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="gs-section sb-prizes">
+    <div>
+      <h2>Payout structure</h2>
+      <p class="gs-helper">Customize the amounts below or keep the classic quarter-by-quarter format.</p>
+    </div>
+    <div class="gs-grid columns-4">
+      {quarterPrizes.map((prize) => (
+        <article class="gs-card sb-prize-card">
+          <div class="sb-prize-card__badge">{prize.label}</div>
+          <h3>{prize.amount}</h3>
+          <p>{prize.detail}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="gs-section sb-callout">
+    <div class="gs-card sb-callout__card">
+      <div>
+        <h2>Need help running the pool?</h2>
+        <p>Share this page with your group, collect entries, and keep everyone aligned on payouts and scoring.</p>
+      </div>
+      <div class="sb-actions">
+        <a class="gs-button" href="/contact">Get support</a>
+        <a class="gs-button gs-button--ghost" href="/apps/risk-radar">Explore other apps</a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .sb-hero {
+    gap: var(--gs-space-6);
+    align-items: center;
+  }
+
+  .sb-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--gs-space-3);
+    margin: var(--gs-space-4) 0;
+  }
+
+  .sb-meta__label {
+    display: block;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--gs-color-text-subtle);
+  }
+
+  .sb-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gs-space-3);
+  }
+
+  .sb-score-card {
+    display: grid;
+    gap: var(--gs-space-4);
+  }
+
+  .sb-score-card__header {
+    display: flex;
+    align-items: center;
+    gap: var(--gs-space-2);
+    font-weight: 600;
+  }
+
+  .sb-score-card__teams {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--gs-space-3);
+    text-align: center;
+  }
+
+  .sb-team-label {
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.75rem;
+    color: var(--gs-color-text-subtle);
+  }
+
+  .sb-score-divider {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--gs-color-text-subtle);
+  }
+
+  .sb-helper {
+    color: var(--gs-color-text-subtle);
+    margin: 0;
+  }
+
+  .sb-step {
+    border-left: 3px solid var(--gs-color-border);
+  }
+
+  .sb-board {
+    display: grid;
+    gap: var(--gs-space-3);
+  }
+
+  .sb-board__header,
+  .sb-board__footer {
+    text-align: center;
+    font-weight: 600;
+    color: var(--gs-color-text-subtle);
+  }
+
+  .sb-board__grid {
+    display: grid;
+    grid-template-columns: 60px repeat(10, minmax(0, 1fr));
+    gap: 6px;
+    min-width: 720px;
+    overflow-x: auto;
+    padding-bottom: var(--gs-space-2);
+  }
+
+  .sb-board__corner {
+    background: transparent;
+  }
+
+  .sb-board__label {
+    display: grid;
+    place-items: center;
+    padding: var(--gs-space-2);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--gs-color-text-subtle);
+    font-size: 0.85rem;
+  }
+
+  .sb-board__cell {
+    min-height: 64px;
+    border-radius: 14px;
+    padding: var(--gs-space-2);
+    background: rgba(15, 19, 30, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: grid;
+    gap: var(--gs-space-1);
+  }
+
+  .sb-board__cell-id {
+    font-size: 0.7rem;
+    color: var(--gs-color-text-subtle);
+  }
+
+  .sb-board__cell-name {
+    font-weight: 600;
+  }
+
+  .sb-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--gs-space-2);
+  }
+
+  .sb-prizes {
+    gap: var(--gs-space-4);
+  }
+
+  .sb-prize-card {
+    text-align: center;
+  }
+
+  .sb-prize-card__badge {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--gs-color-text-subtle);
+  }
+
+  .sb-callout {
+    padding-bottom: var(--gs-space-6);
+  }
+
+  .sb-callout__card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--gs-space-4);
+    flex-wrap: wrap;
+  }
+
+  @media (max-width: 900px) {
+    .sb-board__grid {
+      grid-template-columns: 48px repeat(10, minmax(0, 1fr));
+      font-size: 0.85rem;
+    }
+
+    .sb-board__cell {
+      min-height: 56px;
+    }
+  }
+
+</style>


### PR DESCRIPTION
### Motivation
- Provide a sharable, marketing-style Super Bowl boxes page that includes an interactive-looking 10x10 board, rules, and payout structure for running game-day pools.
- Make the page discoverable from the site header by adding a primary navigation link.
- Ensure the board layout behaves on narrower viewports by enabling horizontal scroll when needed.

### Description
- Added a new Astro page at `apps/web/src/pages/super-bowl-boxes.astro` implementing hero content, rules, a 10x10 board layout, payout cards, and scoped styles for the component.
- Adjusted the board CSS to include `min-width: 720px`, `overflow-x: auto`, and `padding-bottom` for horizontal scrolling of the grid on small screens.
- Exposed the page from the primary navigation by adding `{ href: '/super-bowl-boxes', label: 'Super Bowl Boxes' }` to `apps/web/src/layouts/WebLayout.astro`.
- Fixed page frontmatter placement (added closing `---`) to resolve an `Unexpected "export"` build error encountered during dev.

### Testing
- Launched the dev server with `pnpm --filter @goldshore/web dev` and observed the Astro dev server start (initial build error occurred and was then fixed). (succeeded after fix)
- Verified the page responded via `curl -I http://localhost:4321/super-bowl-boxes` and received an `HTTP/1.1 200 OK` after correcting the frontmatter. (succeeded)
- Attempted automated screenshot capture with Playwright, but navigation failed with `net::ERR_EMPTY_RESPONSE` during several attempts and no screenshot was produced. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69891f32370c8331a556c49d4c7bf734)