### PR TITLE
Add admin page management and dynamic content endpoints

### DIFF
--- a/apps/admin/src/components/Sidebar.astro
+++ b/apps/admin/src/components/Sidebar.astro
@@ -5,6 +5,7 @@ const links = [
   { href: '/admin/analytics', label: 'Analytics' },
   { href: '/admin/systems', label: 'Systems' },
   { href: '/admin/users', label: 'Users' },
+  { href: '/admin/pages', label: 'Pages' },
   { href: '/admin/pii-scans', label: 'PII Scans' },
   { href: '/admin/logs', label: 'Logs' },
   { href: '/admin/settings', label: 'Settings' }

--- a/apps/admin/src/pages/admin/pages/[id].astro
+++ b/apps/admin/src/pages/admin/pages/[id].astro
@@ -1,0 +1,85 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+
+const { id } = Astro.params;
+const API_BASE = import.meta.env.PUBLIC_API || 'https://api.goldshore.dev';
+---
+<AdminLayout title="Edit Page | GoldShore Admin">
+  <section class="max-w-4xl mx-auto py-12 px-6 space-y-6">
+    <header>
+      <h1 class="text-3xl gs-heading">Edit Page</h1>
+      <p class="text-[var(--gs-text-secondary)]">Update content and publishing status.</p>
+    </header>
+
+    <form id="page-form" class="card space-y-4">
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="slug">Slug</label>
+        <input class="gs-input w-full" id="slug" name="slug" required />
+      </div>
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="title">Title</label>
+        <input class="gs-input w-full" id="title" name="title" required />
+      </div>
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="body">Body (HTML)</label>
+        <textarea class="gs-input w-full min-h-[220px]" id="body" name="body" required></textarea>
+      </div>
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="status">Status</label>
+        <select class="gs-input w-full" id="status" name="status">
+          <option value="draft">Draft</option>
+          <option value="published">Published</option>
+          <option value="disabled">Disabled</option>
+        </select>
+      </div>
+      <div class="flex flex-wrap gap-3">
+        <button class="gs-btn-primary" type="submit">Save Changes</button>
+        <a class="gs-btn-secondary" href="/admin/pages">Back to Pages</a>
+      </div>
+      <p id="form-message" class="text-sm text-[var(--gs-text-secondary)]"></p>
+    </form>
+  </section>
+  <script define:vars={{ API_BASE, id }}>
+    const form = document.getElementById('page-form');
+    const message = document.getElementById('form-message');
+
+    const loadPage = async () => {
+      message.textContent = 'Loading...';
+      try {
+        const response = await fetch(`${API_BASE}/pages/${id}`, { credentials: 'include' });
+        if (!response.ok) {
+          message.textContent = 'Page not found.';
+          return;
+        }
+        const page = await response.json();
+        form.slug.value = page.slug;
+        form.title.value = page.title;
+        form.body.value = page.body;
+        form.status.value = page.status;
+        message.textContent = '';
+      } catch (error) {
+        message.textContent = 'Failed to load page.';
+      }
+    };
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      message.textContent = 'Saving...';
+      const data = Object.fromEntries(new FormData(form));
+      try {
+        const response = await fetch(`${API_BASE}/pages/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(data)
+        });
+        const payload = await response.json();
+        message.textContent = response.ok ? 'Changes saved.' : payload?.error || 'Failed to save.';
+      } catch (error) {
+        message.textContent = 'Failed to save.';
+      }
+    });
+
+    loadPage();
+  </script>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/pages/index.astro
+++ b/apps/admin/src/pages/admin/pages/index.astro
@@ -1,0 +1,128 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+
+const API_BASE = import.meta.env.PUBLIC_API || 'https://api.goldshore.dev';
+---
+<AdminLayout title="Pages | GoldShore Admin">
+  <section class="max-w-6xl mx-auto py-12 px-6 space-y-6">
+    <header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div>
+        <h1 class="text-3xl gs-heading">Pages</h1>
+        <p class="text-[var(--gs-text-secondary)]">Manage dynamic content pages and publishing status.</p>
+      </div>
+      <a class="gs-btn-primary" href="/admin/pages/new">Create New Page</a>
+    </header>
+
+    <div class="card">
+      <div class="card-header">
+        <span class="icon">📄</span>
+        <h2>All Pages</h2>
+      </div>
+      <div id="pages-table" class="overflow-x-auto text-sm text-[var(--gs-text-secondary)]">
+        Loading pages...
+      </div>
+    </div>
+  </section>
+  <script define:vars={{ API_BASE }}>
+    const container = document.getElementById('pages-table');
+
+    const statusBadge = (status) => {
+      const color =
+        status === 'published'
+          ? 'text-green-300 bg-green-900/40 border-green-500/40'
+          : status === 'disabled'
+          ? 'text-red-300 bg-red-900/40 border-red-500/40'
+          : 'text-yellow-300 bg-yellow-900/40 border-yellow-500/40';
+      return `<span class="inline-flex items-center px-2 py-1 rounded border ${color}">${status}</span>`;
+    };
+
+    const renderTable = (pages) => {
+      if (!pages.length) {
+        container.innerHTML = '<p class="p-4">No pages yet. Create your first page.</p>';
+        return;
+      }
+
+      container.innerHTML = `
+        <table class="min-w-full text-left">
+          <thead>
+            <tr class="text-xs uppercase tracking-wide text-[var(--gs-text-tertiary)]">
+              <th class="p-3">Slug</th>
+              <th class="p-3">Title</th>
+              <th class="p-3">Status</th>
+              <th class="p-3">Updated</th>
+              <th class="p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${pages
+              .map(
+                (page) => `
+                  <tr class="border-t border-white/5">
+                    <td class="p-3 font-mono text-[var(--gs-text-primary)]">/${page.slug}</td>
+                    <td class="p-3 text-[var(--gs-text-primary)]">${page.title}</td>
+                    <td class="p-3">${statusBadge(page.status)}</td>
+                    <td class="p-3">${new Date(page.updatedAt).toLocaleString()}</td>
+                    <td class="p-3 flex flex-wrap gap-2">
+                      <a class="gs-btn-xs" href="/admin/pages/${page.id}">Edit</a>
+                      <button class="gs-btn-xs gs-btn-secondary" data-toggle-id="${page.id}" data-status="${
+                        page.status === 'published' ? 'disabled' : 'published'
+                      }">
+                        ${page.status === 'published' ? 'Disable' : 'Publish'}
+                      </button>
+                      <button class="gs-btn-xs gs-btn-danger" data-delete-id="${page.id}">Delete</button>
+                    </td>
+                  </tr>
+                `
+              )
+              .join('')}
+          </tbody>
+        </table>
+      `;
+    };
+
+    const loadPages = async () => {
+      try {
+        const response = await fetch(`${API_BASE}/pages`, { credentials: 'include' });
+        const data = await response.json();
+        renderTable(data.pages || []);
+      } catch (error) {
+        container.innerHTML = '<p class="p-4 text-red-300">Failed to load pages.</p>';
+      }
+    };
+
+    const updateStatus = async (id, status) => {
+      await fetch(`${API_BASE}/pages/${id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ status })
+      });
+      await loadPages();
+    };
+
+    const deletePage = async (id) => {
+      if (!confirm('Delete this page? This cannot be undone.')) return;
+      await fetch(`${API_BASE}/pages/${id}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+      await loadPages();
+    };
+
+    container.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const toggleId = target.dataset.toggleId;
+      const status = target.dataset.status;
+      if (toggleId && status) {
+        updateStatus(toggleId, status);
+      }
+      const deleteId = target.dataset.deleteId;
+      if (deleteId) {
+        deletePage(deleteId);
+      }
+    });
+
+    loadPages();
+  </script>
+</AdminLayout>

--- a/apps/admin/src/pages/admin/pages/new.astro
+++ b/apps/admin/src/pages/admin/pages/new.astro
@@ -1,0 +1,68 @@
+---
+import AdminLayout from '../../../layouts/AdminLayout.astro';
+
+const API_BASE = import.meta.env.PUBLIC_API || 'https://api.goldshore.dev';
+---
+<AdminLayout title="Create Page | GoldShore Admin">
+  <section class="max-w-4xl mx-auto py-12 px-6 space-y-6">
+    <header>
+      <h1 class="text-3xl gs-heading">Create New Page</h1>
+      <p class="text-[var(--gs-text-secondary)]">Draft a new dynamic page for the web site.</p>
+    </header>
+
+    <form id="page-form" class="card space-y-4">
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="slug">Slug</label>
+        <input class="gs-input w-full" id="slug" name="slug" placeholder="pricing/enterprise" required />
+      </div>
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="title">Title</label>
+        <input class="gs-input w-full" id="title" name="title" placeholder="Enterprise Pricing" required />
+      </div>
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="body">Body (HTML)</label>
+        <textarea class="gs-input w-full min-h-[220px]" id="body" name="body" placeholder="<p>Page content...</p>" required></textarea>
+      </div>
+      <div>
+        <label class="block text-sm text-[var(--gs-text-tertiary)] mb-2" for="status">Status</label>
+        <select class="gs-input w-full" id="status" name="status">
+          <option value="draft">Draft</option>
+          <option value="published">Published</option>
+          <option value="disabled">Disabled</option>
+        </select>
+      </div>
+      <div class="flex flex-wrap gap-3">
+        <button class="gs-btn-primary" type="submit">Create Page</button>
+        <a class="gs-btn-secondary" href="/admin/pages">Cancel</a>
+      </div>
+      <p id="form-message" class="text-sm text-[var(--gs-text-secondary)]"></p>
+    </form>
+  </section>
+  <script define:vars={{ API_BASE }}>
+    const form = document.getElementById('page-form');
+    const message = document.getElementById('form-message');
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      message.textContent = 'Saving...';
+      const data = Object.fromEntries(new FormData(form));
+      try {
+        const response = await fetch(`${API_BASE}/pages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(data)
+        });
+        if (!response.ok) {
+          const payload = await response.json();
+          message.textContent = payload?.error || 'Failed to create page.';
+          return;
+        }
+        const payload = await response.json();
+        window.location.href = `/admin/pages/${payload.id}`;
+      } catch (error) {
+        message.textContent = 'Failed to create page.';
+      }
+    });
+  </script>
+</AdminLayout>

--- a/apps/api-worker/db/pages.sql
+++ b/apps/api-worker/db/pages.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS pages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS pages_status_idx ON pages(status);

--- a/apps/api-worker/src/index.ts
+++ b/apps/api-worker/src/index.ts
@@ -8,6 +8,7 @@ import ai from './routes/ai';
 import user from './routes/user';
 import system from './routes/system';
 import templates from './routes/templates';
+import pages from './routes/pages';
 
 type Env = {
   KV: KVNamespace;
@@ -101,6 +102,7 @@ app.route('/users', users);
 app.route('/user', user);
 app.route('/system', system);
 app.route('/templates', templates);
+app.route('/pages', pages);
 
 // V1 Routes
 const v1 = new Hono<{ Bindings: Env }>();

--- a/apps/api-worker/src/routes/pages.ts
+++ b/apps/api-worker/src/routes/pages.ts
@@ -1,0 +1,169 @@
+import { Hono } from 'hono';
+
+type PageRow = {
+  id: number;
+  slug: string;
+  title: string;
+  body: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+const allowedStatuses = new Set(['draft', 'published', 'disabled']);
+
+const normalizePage = (row: PageRow) => ({
+  id: row.id,
+  slug: row.slug,
+  title: row.title,
+  body: row.body,
+  status: row.status,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at
+});
+
+const pages = new Hono();
+
+pages.get('/', async (c) => {
+  const status = c.req.query('status');
+  const query = status
+    ? c.env.DB.prepare('SELECT * FROM pages WHERE status = ? ORDER BY updated_at DESC').bind(status)
+    : c.env.DB.prepare('SELECT * FROM pages ORDER BY updated_at DESC');
+  const result = await query.all<PageRow>();
+  return c.json({
+    pages: result.results.map(normalizePage)
+  });
+});
+
+pages.get('/slug/:slug', async (c) => {
+  const slug = c.req.param('slug');
+  const page = await c.env.DB.prepare('SELECT * FROM pages WHERE slug = ? LIMIT 1')
+    .bind(slug)
+    .first<PageRow>();
+
+  if (!page) {
+    return c.json({ error: 'Page not found' }, 404);
+  }
+
+  return c.json(normalizePage(page));
+});
+
+pages.get('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) {
+    return c.json({ error: 'Invalid page id' }, 400);
+  }
+
+  const page = await c.env.DB.prepare('SELECT * FROM pages WHERE id = ? LIMIT 1')
+    .bind(id)
+    .first<PageRow>();
+
+  if (!page) {
+    return c.json({ error: 'Page not found' }, 404);
+  }
+
+  return c.json(normalizePage(page));
+});
+
+pages.post('/', async (c) => {
+  const payload = await c.req.json().catch(() => null) as
+    | { slug?: string; title?: string; body?: string; status?: string }
+    | null;
+
+  if (!payload?.slug || !payload?.title || !payload?.body) {
+    return c.json({ error: 'slug, title, and body are required' }, 400);
+  }
+
+  const status = allowedStatuses.has(payload.status ?? '') ? payload.status! : 'draft';
+
+  const insertResult = await c.env.DB.prepare(
+    'INSERT INTO pages (slug, title, body, status) VALUES (?, ?, ?, ?)'
+  )
+    .bind(payload.slug, payload.title, payload.body, status)
+    .run();
+
+  const page = await c.env.DB.prepare('SELECT * FROM pages WHERE id = ? LIMIT 1')
+    .bind(insertResult.meta.last_row_id)
+    .first<PageRow>();
+
+  return c.json(page ? normalizePage(page) : { error: 'Page not found after insert' }, page ? 201 : 500);
+});
+
+pages.put('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) {
+    return c.json({ error: 'Invalid page id' }, 400);
+  }
+
+  const payload = await c.req.json().catch(() => null) as
+    | { slug?: string; title?: string; body?: string; status?: string }
+    | null;
+
+  if (!payload?.slug || !payload?.title || !payload?.body) {
+    return c.json({ error: 'slug, title, and body are required' }, 400);
+  }
+
+  const status = allowedStatuses.has(payload.status ?? '') ? payload.status! : 'draft';
+
+  const result = await c.env.DB.prepare(
+    'UPDATE pages SET slug = ?, title = ?, body = ?, status = ?, updated_at = datetime(\'now\') WHERE id = ?'
+  )
+    .bind(payload.slug, payload.title, payload.body, status, id)
+    .run();
+
+  if (!result.meta.changes) {
+    return c.json({ error: 'Page not found' }, 404);
+  }
+
+  const page = await c.env.DB.prepare('SELECT * FROM pages WHERE id = ? LIMIT 1')
+    .bind(id)
+    .first<PageRow>();
+
+  return c.json(page ? normalizePage(page) : { error: 'Page not found' }, page ? 200 : 404);
+});
+
+pages.patch('/:id/status', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) {
+    return c.json({ error: 'Invalid page id' }, 400);
+  }
+
+  const payload = await c.req.json().catch(() => null) as { status?: string } | null;
+  const status = payload?.status;
+  if (!status || !allowedStatuses.has(status)) {
+    return c.json({ error: 'Invalid status value' }, 400);
+  }
+
+  const result = await c.env.DB.prepare(
+    'UPDATE pages SET status = ?, updated_at = datetime(\'now\') WHERE id = ?'
+  )
+    .bind(status, id)
+    .run();
+
+  if (!result.meta.changes) {
+    return c.json({ error: 'Page not found' }, 404);
+  }
+
+  const page = await c.env.DB.prepare('SELECT * FROM pages WHERE id = ? LIMIT 1')
+    .bind(id)
+    .first<PageRow>();
+
+  return c.json(page ? normalizePage(page) : { error: 'Page not found' }, page ? 200 : 404);
+});
+
+pages.delete('/:id', async (c) => {
+  const id = Number(c.req.param('id'));
+  if (Number.isNaN(id)) {
+    return c.json({ error: 'Invalid page id' }, 400);
+  }
+
+  const result = await c.env.DB.prepare('DELETE FROM pages WHERE id = ?').bind(id).run();
+
+  if (!result.meta.changes) {
+    return c.json({ error: 'Page not found' }, 404);
+  }
+
+  return c.json({ ok: true });
+});
+
+export default pages;

--- a/apps/web/src/pages/[...path].astro
+++ b/apps/web/src/pages/[...path].astro
@@ -1,7 +1,60 @@
 ---
+import BaseLayout from '../layouts/BaseLayout.astro';
 import DefaultPageTemplate from '../components/DefaultPageTemplate.astro';
 
 export const prerender = false;
+
+const slug = Astro.params.path ?? '';
+const API_BASE = import.meta.env.PUBLIC_API || 'https://api.goldshore.dev';
+
+let page: {
+  id: number;
+  slug: string;
+  title: string;
+  body: string;
+  status: string;
+} | null = null;
+
+if (slug) {
+  try {
+    const response = await fetch(`${API_BASE}/pages/slug/${encodeURIComponent(slug)}`, {
+      headers: { Accept: 'application/json' }
+    });
+    if (response.ok) {
+      page = await response.json();
+    } else {
+      Astro.response.status = 404;
+    }
+  } catch (error) {
+    Astro.response.status = 404;
+  }
+} else {
+  Astro.response.status = 404;
+}
 ---
 
-<DefaultPageTemplate />
+{page ? (
+  page.status === 'disabled' ? (
+    <BaseLayout title={`Page Disabled | GoldShore`}>
+      <section class="max-w-4xl mx-auto py-24 px-6 text-center">
+        <h1 class="text-4xl gs-heading mb-6" style="color: var(--gs-brand-gold);">Page Disabled</h1>
+        <p class="text-lg text-[var(--gs-text-secondary)] mb-8">
+          This page is currently disabled. Please check back later or contact support.
+        </p>
+        <a href="/" class="text-[var(--gs-brand-gold)] hover:underline">Return to GoldShore Home</a>
+      </section>
+    </BaseLayout>
+  ) : (
+    <BaseLayout title={`${page.title} | GoldShore`}>
+      <section class="max-w-5xl mx-auto py-16 px-6">
+        <header class="mb-10">
+          <p class="text-sm uppercase tracking-[0.3em] text-[var(--gs-text-tertiary)]">GoldShore</p>
+          <h1 class="text-4xl gs-heading mt-3">{page.title}</h1>
+        </header>
+        <article class="prose prose-invert max-w-none" set:html={page.body} />
+      </section>
+    </BaseLayout>
+  )
+) : (
+  <DefaultPageTemplate />
+)}


### PR DESCRIPTION
### Motivation
- Provide a simple CMS for marketing/operational pages by adding a pages data model, admin UI for CRUD/status management, and API endpoints to back it. 
- Enable the public web app to render stored pages dynamically and to respect `disabled` status (show 404/disabled message).

### Description
- Added a D1 schema for pages at `apps/api-worker/db/pages.sql` with fields `slug`, `title`, `body`, `status`, `created_at`, and `updated_at` and an index on `status`.
- Implemented CRUD and status toggle API routes in `apps/api-worker/src/routes/pages.ts` and mounted them at `app.route('/pages', pages)` in `apps/api-worker/src/index.ts`, including `GET /`, `GET /slug/:slug`, `GET /:id`, `POST /`, `PUT /:id`, `PATCH /:id/status`, and `DELETE /:id` and normalized JSON responses.
- Added admin dashboard pages for listing, creating, editing, publishing/disabling, and deleting pages under `apps/admin/src/pages/admin/pages/` and added a `Pages` link to the admin sidebar in `apps/admin/src/components/Sidebar.astro`.
- Updated the web catch-all route `apps/web/src/pages/[...path].astro` to fetch `GET /pages/slug/:slug`, render stored HTML when found, set a 404 when missing, and display a friendly disabled page when `status === 'disabled'`.

### Testing
- Started the admin dev server with `pnpm --filter ./apps/admin dev` and verified Astro reported as ready (local dev server started successfully).
- Attempted a headless UI screenshot via Playwright to validate the admin pages, but the Chromium process crashed in this environment and the screenshot run failed with a `BrowserType.launch` error.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c7419b4c833188762f6f38dc94d1)