### PR TITLE
Add Cloudflare resource panels and API routes

### DIFF
--- a/apps/admin/src/pages/admin/system.astro
+++ b/apps/admin/src/pages/admin/system.astro
@@ -9,9 +9,28 @@ import { GSButton } from '@goldshore/ui';
             <p class="text-[var(--gs-text-secondary)]">
                 Review Cloudflare infrastructure data and trigger controlled updates from the admin console.
             </p>
+            <p class="text-sm gs-text-subtle">
+                Cloudflare API credentials are stored as worker secrets and never exposed to the browser. All requests
+                flow through the secured control worker.
+            </p>
         </header>
 
         <div class="grid gap-6 lg:grid-cols-2">
+            <div class="gs-card space-y-4 lg:col-span-2">
+                <div>
+                    <h2 class="text-xl font-semibold">Managed Resources</h2>
+                    <p class="text-sm gs-text-subtle">Cloudflare resources managed via the ops control worker.</p>
+                </div>
+                <div class="flex flex-wrap gap-2 text-sm">
+                    <span class="gs-pill">Pages</span>
+                    <span class="gs-pill">Workers</span>
+                    <span class="gs-pill">KV</span>
+                    <span class="gs-pill">R2</span>
+                    <span class="gs-pill">D1</span>
+                    <span class="gs-pill">DNS</span>
+                </div>
+            </div>
+
             <div class="gs-card space-y-4">
                 <div>
                     <h2 class="text-xl font-semibold">DNS Records</h2>
@@ -41,6 +60,42 @@ import { GSButton } from '@goldshore/ui';
                 </div>
                 <GSButton variant="secondary" id="workers-status">Fetch Workers Status</GSButton>
                 <textarea id="workers-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">Pages Projects</h2>
+                    <p class="text-sm gs-text-subtle">Review Cloudflare Pages projects and deployment metadata.</p>
+                </div>
+                <GSButton variant="secondary" id="pages-projects">Fetch Pages Projects</GSButton>
+                <textarea id="pages-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">KV Namespaces</h2>
+                    <p class="text-sm gs-text-subtle">List KV namespaces backing runtime configuration.</p>
+                </div>
+                <GSButton variant="secondary" id="kv-namespaces">Fetch KV Namespaces</GSButton>
+                <textarea id="kv-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">R2 Buckets</h2>
+                    <p class="text-sm gs-text-subtle">Inspect R2 buckets used for state and storage.</p>
+                </div>
+                <GSButton variant="secondary" id="r2-buckets">Fetch R2 Buckets</GSButton>
+                <textarea id="r2-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
+            </div>
+
+            <div class="gs-card space-y-4">
+                <div>
+                    <h2 class="text-xl font-semibold">D1 Databases</h2>
+                    <p class="text-sm gs-text-subtle">List D1 databases available to Cloudflare Workers.</p>
+                </div>
+                <GSButton variant="secondary" id="d1-databases">Fetch D1 Databases</GSButton>
+                <textarea id="d1-output" class="w-full min-h-[180px] gs-input" readonly></textarea>
             </div>
 
             <div class="gs-card space-y-4">
@@ -97,6 +152,30 @@ import { GSButton } from '@goldshore/ui';
             setOutput('workers-output', 'Loading...');
             const result = await adminService.getWorkersStatus();
             setOutput('workers-output', result.payload);
+        });
+
+        document.getElementById('pages-projects')?.addEventListener('click', async () => {
+            setOutput('pages-output', 'Loading...');
+            const result = await adminService.listPagesProjects();
+            setOutput('pages-output', result.payload);
+        });
+
+        document.getElementById('kv-namespaces')?.addEventListener('click', async () => {
+            setOutput('kv-output', 'Loading...');
+            const result = await adminService.listKvNamespaces();
+            setOutput('kv-output', result.payload);
+        });
+
+        document.getElementById('r2-buckets')?.addEventListener('click', async () => {
+            setOutput('r2-output', 'Loading...');
+            const result = await adminService.listR2Buckets();
+            setOutput('r2-output', result.payload);
+        });
+
+        document.getElementById('d1-databases')?.addEventListener('click', async () => {
+            setOutput('d1-output', 'Loading...');
+            const result = await adminService.listD1Databases();
+            setOutput('d1-output', result.payload);
         });
 
         document.getElementById('access-list')?.addEventListener('click', async () => {

--- a/apps/control-worker/README.md
+++ b/apps/control-worker/README.md
@@ -21,6 +21,10 @@ These are worker API endpoints implemented in `src/index.ts` and `src/routes/clo
 - `GET /cloudflare/dns/records`
 - `PUT /cloudflare/dns/records/:recordId`
 - `GET /cloudflare/workers/status`
+- `GET /cloudflare/pages/projects`
+- `GET /cloudflare/kv/namespaces`
+- `GET /cloudflare/r2/buckets`
+- `GET /cloudflare/d1/databases`
 - `GET /cloudflare/access/policies`
 The `gs-control` worker handles infrastructure automation tasks (DNS updates, preview environment creation, secret rotation, and sync operations) and is served from `https://ops.goldshore.ai/*` on Cloudflare Workers.
 
@@ -47,6 +51,7 @@ pnpm --filter ./apps/control-worker run-task
 - Production deploy: `.github/workflows/deploy-control-worker.yml`
 - Preview deploy: `.github/workflows/preview-control-worker.yml`
 - Uses `wrangler deploy` with `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets
+- Store `CLOUDFLARE_API_TOKEN` in Cloudflare secrets (via `wrangler secret put`) rather than committing env values
 
 <!-- // [AUTO-UPDATE] Updated by Jules AI on 2026-01-23 01:43 -->
 ```bash

--- a/apps/control-worker/src/routes/cloudflare.ts
+++ b/apps/control-worker/src/routes/cloudflare.ts
@@ -231,6 +231,114 @@ cloudflareRoutes.get("/workers/status", async (c) => {
   }
 });
 
+cloudflareRoutes.get("/pages/projects", async (c) => {
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/accounts/${c.env.CLOUDFLARE_ACCOUNT_ID}/pages/projects`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:pages:list",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status }
+    });
+
+    return c.json(result.data, result.status as ContentfulStatusCode);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:pages:list",
+      actor,
+      status: "error",
+      metadata: { message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
+cloudflareRoutes.get("/kv/namespaces", async (c) => {
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/accounts/${c.env.CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:kv:list",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status }
+    });
+
+    return c.json(result.data, result.status as ContentfulStatusCode);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:kv:list",
+      actor,
+      status: "error",
+      metadata: { message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
+cloudflareRoutes.get("/r2/buckets", async (c) => {
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/accounts/${c.env.CLOUDFLARE_ACCOUNT_ID}/r2/buckets`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:r2:list",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status }
+    });
+
+    return c.json(result.data, result.status as ContentfulStatusCode);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:r2:list",
+      actor,
+      status: "error",
+      metadata: { message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
+cloudflareRoutes.get("/d1/databases", async (c) => {
+  const actor = getActor(c.get("accessClaims"), c.req.raw);
+  try {
+    const result = await fetchCloudflare(
+      c.env,
+      `/accounts/${c.env.CLOUDFLARE_ACCOUNT_ID}/d1/database`
+    );
+
+    await logAuditEvent(c.env, {
+      action: "cloudflare:d1:list",
+      actor,
+      status: result.ok ? "success" : "error",
+      metadata: { status: result.status }
+    });
+
+    return c.json(result.data, result.status as ContentfulStatusCode);
+  } catch (error) {
+    await logAuditEvent(c.env, {
+      action: "cloudflare:d1:list",
+      actor,
+      status: "error",
+      metadata: { message: formatErrorMessage(error) }
+    });
+    return c.json({ error: "Cloudflare API request failed." }, 502);
+  }
+});
+
 cloudflareRoutes.get("/access/policies", async (c) => {
   const actor = getActor(c.get("accessClaims"), c.req.raw);
   const appId = c.req.query("appId");

--- a/packages/integrations/admin.ts
+++ b/packages/integrations/admin.ts
@@ -101,6 +101,18 @@ export const createAdminService = (config: AdminServiceConfig) => {
   const getWorkersStatus = async () =>
     performAdminAction('workers.status.read', 'workers', () => httpClient.get('/workers/status', { cache: 'no-store' }));
 
+  const listPagesProjects = async () =>
+    performAdminAction('pages.projects.list', 'pages', () => httpClient.get('/pages/projects', { cache: 'no-store' }));
+
+  const listKvNamespaces = async () =>
+    performAdminAction('kv.namespaces.list', 'kv', () => httpClient.get('/kv/namespaces', { cache: 'no-store' }));
+
+  const listR2Buckets = async () =>
+    performAdminAction('r2.buckets.list', 'r2', () => httpClient.get('/r2/buckets', { cache: 'no-store' }));
+
+  const listD1Databases = async () =>
+    performAdminAction('d1.databases.list', 'd1', () => httpClient.get('/d1/databases', { cache: 'no-store' }));
+
   const listAccessPolicies = async (appId: string) =>
     performAdminAction(
       'access.policies.list',
@@ -114,6 +126,10 @@ export const createAdminService = (config: AdminServiceConfig) => {
     listDnsRecords,
     updateDnsRecord,
     getWorkersStatus,
+    listPagesProjects,
+    listKvNamespaces,
+    listR2Buckets,
+    listD1Databases,
     listAccessPolicies
   };
 };


### PR DESCRIPTION
### Motivation
- Provide admin visibility and control over Cloudflare resources (Pages, Workers, KV, R2, D1, DNS) via the existing ops control worker and admin cockpit.  
- Surface these resources as dashboard panels so operators can inspect configuration and status without exposing Cloudflare credentials to the browser.  
- Centralize Cloudflare API calls in the control worker so credentials remain stored as worker secrets and all UI requests are proxied through a secured service.

### Description
- Added new control-worker API routes to list Cloudflare resources: `GET /cloudflare/pages/projects`, `GET /cloudflare/kv/namespaces`, `GET /cloudflare/r2/buckets`, and `GET /cloudflare/d1/databases` with audit logging and error handling in `apps/control-worker/src/routes/cloudflare.ts`.  
- Extended the admin integration service in `packages/integrations/admin.ts` with helper methods `listPagesProjects`, `listKvNamespaces`, `listR2Buckets`, and `listD1Databases` to call the new endpoints.  
- Expanded the admin system page (`apps/admin/src/pages/admin/system.astro`) with a managed-resources panel and new UI panels/buttons/textareas wired to the integration methods for Pages, KV, R2, and D1.  
- Updated `apps/control-worker/README.md` to document the new endpoints and to recommend storing `CLOUDFLARE_API_TOKEN` via `wrangler secret put` so credentials are not committed or exposed.

### Testing
- Started the admin dev server with `pnpm --filter ./apps/admin dev` and the server came up (Astro dev ready).  
- Attempted an automated Playwright screenshot of `/admin/system`, but the run failed with `net::ERR_EMPTY_RESPONSE` so no end-to-end UI screenshot was captured.  
- No unit test suite was run as part of this change within the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989cd6c10448331ac1f857a75aacc70)