### PR TITLE
Implement foundational GoldShore website rollout across core pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 # 🟦 GoldShore Monorepo
 
 > Looking for the updated documentation? See [README-v2.md](./README-v2.md).
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Unified platform for the **GoldShore** ecosystem, built with:
 
@@ -12,35 +13,42 @@ Unified platform for the **GoldShore** ecosystem, built with:
 - **KV, R2, D1, Queues, AI Gateway**
 - **pnpm + Turborepo** (Monorepo orchestration)
 
-This repository contains *all* applications, shared packages, and infrastructure code used in production.
+This repository contains _all_ applications, shared packages, and infrastructure code used in production.
 The GoldShore Monorepo powers the entire GoldShore ecosystem, including:
-	•	Public Website (Astro + Cloudflare Pages)
-	•	Admin Cockpit Dashboard (Astro SSR + GoldShore UI Kit)
-	•	API Layer (Hono + Cloudflare Workers)
-	•	Gateway Layer (routing, throttling, AI gateway)
-	•	Agent Layer (Autonomous AI service)
-	•	Control Worker (DNS automation, binding sync, deployments)
-	•	Shared Design System (UI components, tokens, themes)
-	•	Infrastructure (Cloudflare + GitHub Actions)
+• Public Website (Astro + Cloudflare Pages)
+• Admin Cockpit Dashboard (Astro SSR + GoldShore UI Kit)
+• API Layer (Hono + Cloudflare Workers)
+• Gateway Layer (routing, throttling, AI gateway)
+• Agent Layer (Autonomous AI service)
+• Control Worker (DNS automation, binding sync, deployments)
+• Shared Design System (UI components, tokens, themes)
+• Infrastructure (Cloudflare + GitHub Actions)
 
 The monorepo uses:
-	•	pnpm for workspace management
-	•	Turborepo for task orchestration
-	•	TypeScript everywhere
-	•	Astro for frontend
-	•	Cloudflare Workers for backend
-	•	A unified theme + UI kit across apps
+• pnpm for workspace management
+• Turborepo for task orchestration
+• TypeScript everywhere
+• Astro for frontend
+• Cloudflare Workers for backend
+• A unified theme + UI kit across apps
 
 ---
+
+## Website rollout docs
+
+- Developer briefing: `docs/developer-briefing.md`
+- Copy style guide: `docs/copy-style-guide.md`
+- Site config and feature flags: `src/data/site-config.json`
 
 # 🚀 Vibe Coding & Ecosystem
 
 We adhere to the **Vibe Coding** philosophy: Human-in-the-Loop (HITL) engineering where AI agents (Jules, Sentinel, GoldShore Agent) handle routine operations, security scanning, and hygiene, allowing humans to focus on high-value architecture.
 
 ### Integrated Tech Stack
-*   **AI Models:** Google Gemini, OpenAI GPT-4, Anthropic Claude (via Cloudflare AI Gateway).
-*   **Financial Data:** Alpaca, Thinkorswim (Planned Integrations).
-*   **Automation:** Jules-Bot (GitHub Hygiene), Sentinel (Security), GoldShore Agent (Background Tasks).
+
+- **AI Models:** Google Gemini, OpenAI GPT-4, Anthropic Claude (via Cloudflare AI Gateway).
+- **Financial Data:** Alpaca, Thinkorswim (Planned Integrations).
+- **Automation:** Jules-Bot (GitHub Hygiene), Sentinel (Security), GoldShore Agent (Background Tasks).
 
 See [ECOSYSTEM.md](./ECOSYSTEM.md) for full details on our extensions and AI integrations.
 
@@ -194,6 +202,7 @@ Responsibilities:
 Autonomous AI Agent Service.
 
 Responsibilities:
+
 - Background reasoning tasks
 - Integration with external AI models
 - Complex workflow orchestration
@@ -219,6 +228,7 @@ Route: https://ops.goldshore.ai/*
 # 🎨 Shared Packages
 
 ## **packages/theme**
+
 Design tokens:
 
 - tokens.css
@@ -227,6 +237,7 @@ Design tokens:
 - Used by both web + admin
 
 ## **packages/ui**
+
 Component library:
 
 - Typography
@@ -241,13 +252,13 @@ Component library:
 
 Template pages are kept alongside each app so navigation, menus, containers, and search remain pluggable.
 
-| App | Template Location | Notes |
-| --- | --- | --- |
-| Web | `apps/web/src/pages/templates/index.astro` | Marketing + search composition |
-| Admin | `apps/admin/src/pages/templates/index.astro` | Dashboard shell + table samples |
-| API Worker | `apps/api-worker/src/routes/templates.ts` | Module checklist for API growth |
-| Gateway | `apps/gateway/src/index.ts` (`/templates`) | Routing + AI dispatch template |
-| Agent | `apps/gs-agent/src/index.ts` (`/templates`) | HITL orchestration template |
+| App        | Template Location                            | Notes                           |
+| ---------- | -------------------------------------------- | ------------------------------- |
+| Web        | `apps/web/src/pages/templates/index.astro`   | Marketing + search composition  |
+| Admin      | `apps/admin/src/pages/templates/index.astro` | Dashboard shell + table samples |
+| API Worker | `apps/api-worker/src/routes/templates.ts`    | Module checklist for API growth |
+| Gateway    | `apps/gateway/src/index.ts` (`/templates`)   | Routing + AI dispatch template  |
+| Agent      | `apps/gs-agent/src/index.ts` (`/templates`)  | HITL orchestration template     |
 
 ---
 
@@ -277,6 +288,7 @@ To keep issues, workflows, PRs, branches, and components aligned:
 - Document component ownership in the admin dashboard templates and UI kit README.
 
 ## **packages/utils**
+
 TypeScript utilities:
 
 - fetch wrapper
@@ -285,6 +297,7 @@ TypeScript utilities:
 - error handling
 
 ## **packages/auth**
+
 Cloudflare Access helpers:
 
 - JWKS retrieval
@@ -292,6 +305,7 @@ Cloudflare Access helpers:
 - getUser(request)
 
 ## **packages/config**
+
 Monorepo-wide:
 
 - eslint
@@ -302,13 +316,13 @@ Monorepo-wide:
 
 # 🌐 Domains & DNS
 
-| Component      | Domain                     | Hosting            |
-|----------------|-----------------------------|--------------------|
-| Web            | https://goldshore.ai        | Pages              |
-| Admin          | https://admin.goldshore.ai  | Pages + Access     |
-| API Worker     | https://api.goldshore.ai    | Workers            |
-| Gateway Worker | https://gw.goldshore.ai     | Workers            |
-| Control Worker | https://ops.goldshore.ai    | Workers            |
+| Component      | Domain                     | Hosting        |
+| -------------- | -------------------------- | -------------- |
+| Web            | https://goldshore.ai       | Pages          |
+| Admin          | https://admin.goldshore.ai | Pages + Access |
+| API Worker     | https://api.goldshore.ai   | Workers        |
+| Gateway Worker | https://gw.goldshore.ai    | Workers        |
+| Control Worker | https://ops.goldshore.ai   | Workers        |
 
 ---
 
@@ -456,8 +470,6 @@ GoldShore Brand Variants
 </tr>
 </table>
 
-
-
 ---
 
 🧭 Monorepo Structure
@@ -465,36 +477,34 @@ GoldShore Brand Variants
 astro-goldshore/
 │
 ├── apps/
-│   ├── web/             → Public website (Astro + CF Pages)
-│   ├── admin/           → Admin Cockpit (Astro SSR)
-│   ├── api-worker/      → Hono API Worker
-│   ├── gateway/         → Edge gateway router
-│   └── control-worker/  → Infra automation (DNS, bindings)
+│ ├── web/ → Public website (Astro + CF Pages)
+│ ├── admin/ → Admin Cockpit (Astro SSR)
+│ ├── api-worker/ → Hono API Worker
+│ ├── gateway/ → Edge gateway router
+│ └── control-worker/ → Infra automation (DNS, bindings)
 │
 ├── packages/
-│   ├── ui/              → GoldShore UI component library
-│   ├── theme/           → Tokens, CSS vars, theming engine
-│   ├── config/          → Shared TS, ESLint, Prettier configs
-│   └── utils/           → Shared helpers
+│ ├── ui/ → GoldShore UI component library
+│ ├── theme/ → Tokens, CSS vars, theming engine
+│ ├── config/ → Shared TS, ESLint, Prettier configs
+│ └── utils/ → Shared helpers
 │
 └── infra/
-    ├── cloudflare/      → wrangler.toml, DNS maps, bindings
-    └── github/          → Workflows for CI/CD
-
+├── cloudflare/ → wrangler.toml, DNS maps, bindings
+└── github/ → Workflows for CI/CD
 
 ---
 
 🔥 Apps Overview
 
 🌐 apps/web — GoldShore Public Website
-	•	Astro SSR
-	•	Powered by the GoldShore UI Kit
-	•	Deploys via Cloudflare Pages
-	•	Theming powered by packages/theme
-	•	Pulls dynamic content from API + Gateway
+• Astro SSR
+• Powered by the GoldShore UI Kit
+• Deploys via Cloudflare Pages
+• Theming powered by packages/theme
+• Pulls dynamic content from API + Gateway
 
 Hero Example
-
 
 ---
 
@@ -509,23 +519,22 @@ This is your hyper-modern operational dashboard.
 </tr>
 </table>
 
-
 Features
-	•	Realtime visitors
-	•	Task manager
-	•	Ad engine metrics
-	•	Trading analytics
-	•	Widgets API
-	•	Inter-app control center
-	•	API/Gateway integration
+• Realtime visitors
+• Task manager
+• Ad engine metrics
+• Trading analytics
+• Widgets API
+• Inter-app control center
+• API/Gateway integration
 
 ---
 
 🧩 packages/ui — GoldShore UI Component Kit
-	•	100% framework-agnostic components
-	•	Works in Astro, Workers, Hono frontends
-	•	Shared design system
-	•	Includes:
+• 100% framework-agnostic components
+• Works in Astro, Workers, Hono frontends
+• Shared design system
+• Includes:
 
 <Button>
 <Card>
@@ -535,7 +544,6 @@ Features
 <MetricCard>
 <GlowPanel>
 <ThemeToggle>
-
 
 ---
 
@@ -553,45 +561,45 @@ tokens.css
 └── Grid
 
 Supports:
-	•	Light mode
-	•	Dark mode
-	•	Neon mode
-	•	Penrose mode (GoldShore default)
-	•	System override
+• Light mode
+• Dark mode
+• Neon mode
+• Penrose mode (GoldShore default)
+• System override
 
 ---
 
 ⚙️ apps/api-worker — Main API (Hono)
-	•	Edge-native API
-	•	Zod schemas
-	•	Hono router
-	•	Cookie/session utilities
-	•	Cloudflare bindings
-	•	Responds to the admin + web apps
-	•	Preconfigured OpenAPI generation
+• Edge-native API
+• Zod schemas
+• Hono router
+• Cookie/session utilities
+• Cloudflare bindings
+• Responds to the admin + web apps
+• Preconfigured OpenAPI generation
 
 ---
 
 🚏 apps/gateway — Routing & AI Gateway
 
 Handles:
-	•	URL-based routing
-	•	Load balancing
-	•	Service binding switching
-	•	AI Gateway proxy
-	•	Authorization pre-checks
+• URL-based routing
+• Load balancing
+• Service binding switching
+• AI Gateway proxy
+• Authorization pre-checks
 
 ---
 
 🛰 apps/control-worker — Infra Automation
 
 Can automatically:
-	•	Create DNS records
-	•	Attach KV / R2 / D1 bindings
-	•	Create preview domains
-	•	Sync environment variables
-	•	Repair worker routes
-	•	Enforce idempotent deployment rules
+• Create DNS records
+• Attach KV / R2 / D1 bindings
+• Create preview domains
+• Sync environment variables
+• Repair worker routes
+• Enforce idempotent deployment rules
 
 This replaces Terraform (optional).
 
@@ -623,7 +631,6 @@ Build all:
 
 pnpm build
 
-
 ---
 
 🧪 Testing
@@ -637,7 +644,6 @@ Run:
 
 pnpm test
 
-
 ---
 
 🌩 Deployment (Cloudflare)
@@ -646,15 +652,12 @@ Deploy is handled by GitHub Actions:
 
 infra/github/workflows/deploy.yml
 
-CI/CD steps:
-	1.	Install dependencies
-	2.	Build workspaces with Turbo
-	3.	Deploy:
-	•	web → Cloudflare Pages
-	•	admin → Cloudflare Pages
-	•	api-worker → Workers
-	•	gateway → Workers
-	•	control-worker → Workers
+CI/CD steps: 1. Install dependencies 2. Build workspaces with Turbo 3. Deploy:
+• web → Cloudflare Pages
+• admin → Cloudflare Pages
+• api-worker → Workers
+• gateway → Workers
+• control-worker → Workers
 
 Preview branches automatically deploy to:
 
@@ -663,11 +666,9 @@ api-preview.goldshore.ai
 gw-preview.goldshore.ai
 admin-preview.goldshore.ai
 
-
 ---
 
 🏁 Closing Preview
-
 
 ---
 

--- a/docs/copy-style-guide.md
+++ b/docs/copy-style-guide.md
@@ -1,0 +1,16 @@
+# GoldShore Copy Style Guide
+
+## Voice and tone
+
+- Use declarative sentences.
+- Prefer domain-specific signals over abstract adjectives.
+- Avoid generic marketing terms like "innovative" or "disruptive".
+- Keep statements outcome-driven and operationally concrete.
+
+## Implementation checklist
+
+- [ ] Headings describe system or delivery intent directly.
+- [ ] Supporting text names operational context or constraints.
+- [ ] Case study copy includes one measurable result where possible.
+- [ ] Team bios explain role contribution and project value.
+- [ ] CTA labels match: Start the Engagement, Contact the Team, Download Docs.

--- a/docs/developer-briefing.md
+++ b/docs/developer-briefing.md
@@ -1,0 +1,38 @@
+# GoldShore Website Developer Briefing
+
+## Rollout controls
+
+Feature toggles and CTA labels are defined in `src/data/site-config.json`.
+
+## How to edit hero copy
+
+Update the hero section in `src/pages/index.astro`.
+
+- Primary statement and supporting sub-text live in the first `<section>` block.
+- CTA button labels are sourced from `site-config.json`.
+
+## How to add case studies
+
+Case studies are defined in `src/data/site-content.ts` under `caseStudies`.
+
+Each record includes:
+
+- `service`
+- `outcome`
+- `result`
+- `technology`
+
+The list renders on `src/pages/services.astro`.
+
+## How to update services
+
+Service panels are defined in `src/data/site-content.ts` under `services`.
+
+Each service includes:
+
+- `name`
+- `objective`
+- `deliverables[]`
+- `timeframe`
+
+The UI is rendered as expandable `<details>` panels on `src/pages/services.astro`.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,62 +1,34 @@
 ---
 const today = new Date();
+import siteConfig from '../data/site-config.json';
 ---
 
 <footer>
-	&copy; {today.getFullYear()} Your name here. All rights reserved.
-	<div class="social-links">
-		<a href="https://m.webtoo.ls/@astro" target="_blank" rel="noopener noreferrer">
-			<span class="sr-only">Follow Astro on Mastodon</span>
-			<svg
-				viewBox="0 0 16 16"
-				aria-hidden="true"
-				width="32"
-				height="32"
-				astro-icon="social/mastodon"
-				><path
-					fill="currentColor"
-					d="M11.19 12.195c2.016-.24 3.77-1.475 3.99-2.603.348-1.778.32-4.339.32-4.339 0-3.47-2.286-4.488-2.286-4.488C12.062.238 10.083.017 8.027 0h-.05C5.92.017 3.942.238 2.79.765c0 0-2.285 1.017-2.285 4.488l-.002.662c-.004.64-.007 1.35.011 2.091.083 3.394.626 6.74 3.78 7.57 1.454.383 2.703.463 3.709.408 1.823-.1 2.847-.647 2.847-.647l-.06-1.317s-1.303.41-2.767.36c-1.45-.05-2.98-.156-3.215-1.928a3.614 3.614 0 0 1-.033-.496s1.424.346 3.228.428c1.103.05 2.137-.064 3.188-.189zm1.613-2.47H11.13v-4.08c0-.859-.364-1.295-1.091-1.295-.804 0-1.207.517-1.207 1.541v2.233H7.168V5.89c0-1.024-.403-1.541-1.207-1.541-.727 0-1.091.436-1.091 1.296v4.079H3.197V5.522c0-.859.22-1.541.66-2.046.456-.505 1.052-.764 1.793-.764.856 0 1.504.328 1.933.983L8 4.39l.417-.695c.429-.655 1.077-.983 1.934-.983.74 0 1.336.259 1.791.764.442.505.661 1.187.661 2.046v4.203z"
-				></path></svg
-			>
-		</a>
-		<a href="https://twitter.com/astrodotbuild" target="_blank" rel="noopener noreferrer">
-			<span class="sr-only">Follow Astro on Twitter</span>
-			<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32" astro-icon="social/twitter"
-				><path
-					fill="currentColor"
-					d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"
-				></path></svg
-			>
-		</a>
-		<a href="https://github.com/withastro/astro" target="_blank" rel="noopener noreferrer">
-			<span class="sr-only">Go to Astro's GitHub repo</span>
-			<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32" astro-icon="social/github"
-				><path
-					fill="currentColor"
-					d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-				></path></svg
-			>
-		</a>
-	</div>
+  <div class="footer-cta-row">
+    <a class="button button-primary" href="/contact">{siteConfig.cta.primary}</a
+    >
+    <a class="button button-secondary" href="/contact"
+      >{siteConfig.cta.secondary}</a
+    >
+    <a class="button button-tertiary" href="/developer-hub#api-overview"
+      >{siteConfig.cta.tertiary}</a
+    >
+  </div>
+  <p>&copy; {today.getFullYear()} GoldShore.ai. All rights reserved.</p>
 </footer>
 <style>
-	footer {
-		padding: 2em 1em 6em 1em;
-		background: linear-gradient(var(--gray-gradient)) no-repeat;
-		color: rgb(var(--gray));
-		text-align: center;
-	}
-	.social-links {
-		display: flex;
-		justify-content: center;
-		gap: 1em;
-		margin-top: 1em;
-	}
-	.social-links a {
-		text-decoration: none;
-		color: rgb(var(--gray));
-	}
-	.social-links a:hover {
-		color: rgb(var(--gray-dark));
-	}
+  footer {
+    padding: 2em 1em 3em;
+    border-top: 1px solid rgb(var(--border));
+    color: rgb(var(--gray));
+    text-align: center;
+    background: rgb(var(--surface));
+  }
+  .footer-cta-row {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+  }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,85 +1,62 @@
 ---
 import HeaderLink from './HeaderLink.astro';
 import { SITE_TITLE } from '../consts';
+import siteConfig from '../data/site-config.json';
 ---
 
 <header>
-	<nav>
-		<h2><a href="/">{SITE_TITLE}</a></h2>
-		<div class="internal-links">
-			<HeaderLink href="/">Home</HeaderLink>
-			<HeaderLink href="/blog">Blog</HeaderLink>
-			<HeaderLink href="/about">About</HeaderLink>
-		</div>
-		<div class="social-links">
-			<a href="https://m.webtoo.ls/@astro" target="_blank" rel="noopener noreferrer">
-				<span class="sr-only">Follow Astro on Mastodon</span>
-				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
-					><path
-						fill="currentColor"
-						d="M11.19 12.195c2.016-.24 3.77-1.475 3.99-2.603.348-1.778.32-4.339.32-4.339 0-3.47-2.286-4.488-2.286-4.488C12.062.238 10.083.017 8.027 0h-.05C5.92.017 3.942.238 2.79.765c0 0-2.285 1.017-2.285 4.488l-.002.662c-.004.64-.007 1.35.011 2.091.083 3.394.626 6.74 3.78 7.57 1.454.383 2.703.463 3.709.408 1.823-.1 2.847-.647 2.847-.647l-.06-1.317s-1.303.41-2.767.36c-1.45-.05-2.98-.156-3.215-1.928a3.614 3.614 0 0 1-.033-.496s1.424.346 3.228.428c1.103.05 2.137-.064 3.188-.189zm1.613-2.47H11.13v-4.08c0-.859-.364-1.295-1.091-1.295-.804 0-1.207.517-1.207 1.541v2.233H7.168V5.89c0-1.024-.403-1.541-1.207-1.541-.727 0-1.091.436-1.091 1.296v4.079H3.197V5.522c0-.859.22-1.541.66-2.046.456-.505 1.052-.764 1.793-.764.856 0 1.504.328 1.933.983L8 4.39l.417-.695c.429-.655 1.077-.983 1.934-.983.74 0 1.336.259 1.791.764.442.505.661 1.187.661 2.046v4.203z"
-					></path></svg
-				>
-			</a>
-			<a href="https://twitter.com/astrodotbuild" target="_blank" rel="noopener noreferrer">
-				<span class="sr-only">Follow Astro on Twitter</span>
-				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
-					><path
-						fill="currentColor"
-						d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"
-					></path></svg
-				>
-			</a>
-			<a href="https://github.com/withastro/astro" target="_blank" rel="noopener noreferrer">
-				<span class="sr-only">Go to Astro's GitHub repo</span>
-				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
-					><path
-						fill="currentColor"
-						d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-					></path></svg
-				>
-			</a>
-		</div>
-	</nav>
+  <nav>
+    <h2><a href="/">{SITE_TITLE}</a></h2>
+    <div class="internal-links">
+      <HeaderLink href="/">Home</HeaderLink>
+      <HeaderLink href="/services">Services</HeaderLink>
+      <HeaderLink href="/about">About</HeaderLink>
+      <HeaderLink href="/risk-radar">Risk Radar</HeaderLink>
+      <HeaderLink href="/developer-hub">Developer Hub</HeaderLink>
+      <HeaderLink href="/contact">Contact</HeaderLink>
+    </div>
+    <a class="button button-secondary" href="/contact"
+      >{siteConfig.cta.secondary}</a
+    >
+  </nav>
 </header>
 <style>
-	header {
-		margin: 0;
-		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
-	}
-	h2 {
-		margin: 0;
-		font-size: 1em;
-	}
+  header {
+    margin: 0;
+    padding: 0 1em;
+    background: rgb(var(--surface));
+    border-bottom: 1px solid rgb(var(--border));
+  }
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
 
-	h2 a,
-	h2 a.active {
-		text-decoration: none;
-	}
-	nav {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-	}
-	nav a {
-		padding: 1em 0.5em;
-		color: var(--black);
-		border-bottom: 4px solid transparent;
-		text-decoration: none;
-	}
-	nav a.active {
-		text-decoration: none;
-		border-bottom-color: var(--accent);
-	}
-	.social-links,
-	.social-links a {
-		display: flex;
-	}
-	@media (max-width: 720px) {
-		.social-links {
-			display: none;
-		}
-	}
+  h2 a,
+  h2 a.active {
+    text-decoration: none;
+    color: rgb(var(--black));
+  }
+  nav {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.4rem 0;
+  }
+  .internal-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.2rem;
+  }
+  @media (max-width: 980px) {
+    nav {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .internal-links {
+      justify-content: flex-start;
+    }
+  }
 </style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,2 @@
-// Place any global data in this file.
-// You can import this data from anywhere in your site by using the `import` keyword.
-
-export const SITE_TITLE = "Astro Blog";
-export const SITE_DESCRIPTION = "Welcome to my website!";
+export const SITE_TITLE = 'GoldShore.ai';
+export const SITE_DESCRIPTION = 'Operational AI infrastructure and observability for mission-critical deployments.';

--- a/src/data/site-config.json
+++ b/src/data/site-config.json
@@ -1,0 +1,16 @@
+{
+  "cta": {
+    "primary": "Start the Engagement",
+    "secondary": "Contact the Team",
+    "tertiary": "Download Docs"
+  },
+  "featureFlags": {
+    "homepageMicroMetrics": true,
+    "servicePanels": true,
+    "serviceCaseStudies": true,
+    "aboutCredibilityStrip": true,
+    "contactGuidedFields": true,
+    "riskRadarExplainer": true,
+    "developerApiOverview": true
+  }
+}

--- a/src/data/site-content.ts
+++ b/src/data/site-content.ts
@@ -1,0 +1,108 @@
+export const offerings = [
+  {
+    title: 'Applied Intelligence',
+    summary: 'Decision support systems tuned for high-stakes operations.',
+    metric: 'Reduced operator triage time by 34% in pilot environments.',
+  },
+  {
+    title: 'Observability Engineering',
+    summary: 'Unified tracing, logging, and event health diagnostics.',
+    metric: 'Alert precision improved to 92% after telemetry redesign.',
+  },
+  {
+    title: 'Resilience Architecture',
+    summary: 'Failure-aware platform design for mission-critical runtimes.',
+    metric: 'Recovery workflows validated under 15-minute RTO constraints.',
+  },
+];
+
+export const services = [
+  {
+    name: 'Operational AI Infrastructure',
+    objective:
+      'Build reliable AI-backed runtime systems with clear ownership and operational controls.',
+    deliverables: [
+      'Reference architecture',
+      'Runbook baseline',
+      'Runtime governance matrix',
+    ],
+    timeframe: '4–8 weeks',
+  },
+  {
+    name: 'Telemetry and Observability Modernisation',
+    objective:
+      'Unify fragmented signals into an actionable observability layer for distributed systems.',
+    deliverables: [
+      'Telemetry schema',
+      'SLO dashboard set',
+      'Escalation playbooks',
+    ],
+    timeframe: '3–6 weeks',
+  },
+  {
+    name: 'Risk and Recovery Readiness',
+    objective:
+      'Model risk vectors and formalise response patterns before incidents become outages.',
+    deliverables: [
+      'Risk map',
+      'Scenario simulations',
+      'Recovery protocol review',
+    ],
+    timeframe: '2–5 weeks',
+  },
+];
+
+export const caseStudies = [
+  {
+    service: 'Operational AI Infrastructure',
+    outcome:
+      'Stabilised deployment flow for a compliance-heavy analytics stack.',
+    result: '41% faster release confidence cycle.',
+    technology: 'ArgoCD + OpenTelemetry',
+  },
+  {
+    service: 'Telemetry and Observability Modernisation',
+    outcome: 'Consolidated alerting into a role-oriented operational cockpit.',
+    result: 'Mean time to isolate incidents dropped from 48 to 19 minutes.',
+    technology: 'Grafana + Prometheus',
+  },
+  {
+    service: 'Risk and Recovery Readiness',
+    outcome:
+      'Introduced dependency-aware recovery protocol for core workloads.',
+    result: 'Quarterly failover tests reached 100% completion.',
+    technology: 'Kubernetes + Chaos Mesh',
+  },
+];
+
+export const team = [
+  {
+    name: 'Ari Morgan',
+    role: 'Principal Infrastructure Lead',
+    bio: 'Ari specialises in distributed AI infrastructure for regulated and latency-sensitive operations. They lead architecture decisions, frame system trade-offs, and translate platform constraints into execution-ready delivery plans for technical stakeholders.',
+  },
+  {
+    name: 'Nadia Chen',
+    role: 'Observability and Reliability Engineer',
+    bio: 'Nadia designs instrumentation and service-level diagnostics for high-pressure runtime environments. She owns telemetry strategy, incident signal quality, and reliability guardrails that help teams respond with confidence during operational volatility.',
+  },
+  {
+    name: 'Theo Reyes',
+    role: 'Applied Intelligence Strategist',
+    bio: 'Theo guides practical adoption of AI in production systems. He maps use cases to measurable operational outcomes and ensures model-enabled workflows integrate cleanly with existing controls, security boundaries, and incident procedures.',
+  },
+];
+
+export const credibility = {
+  domains: [
+    'AI infrastructure',
+    'Observability',
+    'System resilience',
+    'Operational governance',
+  ],
+  signals: [
+    '15+ years in mission-critical systems',
+    'Cross-sector deployments in finance and industrial operations',
+    'Runbooks and controls aligned to reliability-first delivery',
+  ],
+};

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,62 +1,51 @@
 ---
-import Layout from '../layouts/BlogPost.astro';
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { team, credibility } from '../data/site-content';
 ---
 
-<Layout
-	title="About Me"
-	description="Lorem ipsum dolor sit amet"
-	pubDate={new Date('August 08 2021')}
-	heroImage="/blog-placeholder-about.jpg"
->
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-		labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo
-		viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam
-		adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus
-		et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus
-		vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque
-		sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.
-	</p>
-
-	<p>
-		Morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non
-		tellus. Habitasse platea dictumst quisque sagittis purus sit amet. Tellus molestie nunc non
-		blandit massa. Cursus vitae congue mauris rhoncus. Accumsan tortor posuere ac ut. Fringilla urna
-		porttitor rhoncus dolor. Elit ullamcorper dignissim cras tincidunt lobortis. In cursus turpis
-		massa tincidunt dui ut ornare lectus. Integer feugiat scelerisque varius morbi enim nunc.
-		Bibendum neque egestas congue quisque egestas diam. Cras ornare arcu dui vivamus arcu felis
-		bibendum. Dignissim suspendisse in est ante in nibh mauris. Sed tempus urna et pharetra pharetra
-		massa massa ultricies mi.
-	</p>
-
-	<p>
-		Mollis nunc sed id semper risus in. Convallis a cras semper auctor neque. Diam sit amet nisl
-		suscipit. Lacus viverra vitae congue eu consequat ac felis donec. Egestas integer eget aliquet
-		nibh praesent tristique magna sit amet. Eget magna fermentum iaculis eu non diam. In vitae
-		turpis massa sed elementum. Tristique et egestas quis ipsum suspendisse ultrices. Eget lorem
-		dolor sed viverra ipsum. Vel turpis nunc eget lorem dolor sed viverra. Posuere ac ut consequat
-		semper viverra nam. Laoreet suspendisse interdum consectetur libero id faucibus. Diam phasellus
-		vestibulum lorem sed risus ultricies tristique. Rhoncus dolor purus non enim praesent elementum
-		facilisis. Ultrices tincidunt arcu non sodales neque. Tempus egestas sed sed risus pretium quam
-		vulputate. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Fringilla
-		urna porttitor rhoncus dolor purus non. Amet dictum sit amet justo donec enim.
-	</p>
-
-	<p>
-		Mattis ullamcorper velit sed ullamcorper morbi tincidunt. Tortor posuere ac ut consequat semper
-		viverra. Tellus mauris a diam maecenas sed enim ut sem viverra. Venenatis urna cursus eget nunc
-		scelerisque viverra mauris in. Arcu ac tortor dignissim convallis aenean et tortor at. Curabitur
-		gravida arcu ac tortor dignissim convallis aenean et tortor. Egestas tellus rutrum tellus
-		pellentesque eu. Fusce ut placerat orci nulla pellentesque dignissim enim sit amet. Ut enim
-		blandit volutpat maecenas volutpat blandit aliquam etiam. Id donec ultrices tincidunt arcu. Id
-		cursus metus aliquam eleifend mi.
-	</p>
-
-	<p>
-		Tempus quam pellentesque nec nam aliquam sem. Risus at ultrices mi tempus imperdiet. Id porta
-		nibh venenatis cras sed felis eget velit. Ipsum a arcu cursus vitae. Facilisis magna etiam
-		tempor orci eu lobortis elementum. Tincidunt dui ut ornare lectus sit. Quisque non tellus orci
-		ac. Blandit libero volutpat sed cras. Nec tincidunt praesent semper feugiat nibh sed pulvinar
-		proin gravida. Egestas integer eget aliquet nibh praesent tristique magna.
-	</p>
-</Layout>
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="About | GoldShore.ai"
+      description="Team and delivery posture."
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>About</h1>
+      <p>
+        GoldShore.ai is a specialist team focused on operational AI systems that
+        must remain stable under pressure.
+      </p>
+      <section>
+        <h2>Team</h2>
+        <div class="grid">
+          {
+            team.map((member) => (
+              <article class="card">
+                <h3>{member.name}</h3>
+                <p class="small">{member.role}</p>
+                <p>{member.bio}</p>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+      <section class="card">
+        <h2>Credibility strip</h2>
+        <p>
+          <strong>Industry domains:</strong>
+          {credibility.domains.join(' • ')}
+        </p>
+        <ul>
+          {credibility.signals.map((signal) => <li>{signal}</li>)}
+        </ul>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,68 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="Contact | GoldShore.ai"
+      description="Start an engagement with GoldShore.ai."
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>Start the Engagement</h1>
+      <p>
+        Share your operational context and we will align next steps with your
+        constraints.
+      </p>
+      <form class="card" action="/contact/thanks" method="GET">
+        <p>
+          <label for="name">Name</label><br />
+          <input id="name" name="name" required />
+        </p>
+        <p>
+          <label for="email">Email</label><br />
+          <input id="email" name="email" type="email" required />
+        </p>
+        <p>
+          <label for="timeline">Timeline (optional)</label><br />
+          <select id="timeline" name="timeline">
+            <option value="">Select one</option>
+            <option>Immediate (0–2 weeks)</option>
+            <option>Near-term (1–2 months)</option>
+            <option>Planned (quarter+)</option>
+          </select>
+        </p>
+        <p>
+          <label for="budget">Budget range (optional)</label><br />
+          <select id="budget" name="budget">
+            <option value="">Select one</option>
+            <option>&lt; $50k</option>
+            <option>$50k–$150k</option>
+            <option>$150k+</option>
+          </select>
+        </p>
+        <p>
+          <label for="focus">Primary focus area (optional)</label><br />
+          <select id="focus" name="focus">
+            <option value="">Select one</option>
+            <option>Operational AI infrastructure</option>
+            <option>Observability and incident response</option>
+            <option>Risk modelling and resilience</option>
+          </select>
+        </p>
+        <p>
+          <label for="details">Project context</label><br />
+          <textarea id="details" name="details" rows="5" required></textarea>
+        </p>
+        <button class="button button-primary" type="submit">Submit</button>
+      </form>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/contact/thanks.astro
+++ b/src/pages/contact/thanks.astro
@@ -1,0 +1,36 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="Request received | GoldShore.ai"
+      description="Contact confirmation"
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section class="card">
+        <h1>Request received</h1>
+        <p>
+          Thank you for the context. Our team reviews submissions with an
+          operational-first lens and will respond with next-step
+          recommendations.
+        </p>
+        <p class="small">
+          <strong>What happens next:</strong> We triage your request, identify likely
+          engagement shape, and return a proposed discovery call agenda.
+        </p>
+        <p class="small">
+          <strong>Typical response time:</strong> 1–2 business days.
+        </p>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/developer-hub.astro
+++ b/src/pages/developer-hub.astro
@@ -1,0 +1,57 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="Developer Hub | GoldShore.ai"
+      description="Developer onboarding and API overview."
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>Developer Hub</h1>
+      <p>
+        Implementation notes, integration surfaces, and API onboarding
+        references.
+      </p>
+      <section id="api-overview" class="card">
+        <h2>API overview (preview)</h2>
+        <p class="small">
+          A provisional API index is available for interface planning. Contact
+          the team for early access and environment credentials.
+        </p>
+        <pre
+          class="code-block"><code>{`GET /v1/systems/{id}/status
+200 OK
+{
+  "systemId": "ops-17",
+  "health": "degraded",
+  "riskScore": 0.62,
+  "updatedAt": "2026-02-10T10:45:00Z"
+}`}</code></pre>
+        <p>
+          <a class="button button-secondary" href="/contact"
+            >Contact the team for API access</a
+          >
+        </p>
+      </section>
+    </main>
+    <Footer />
+    <style>
+      .code-block {
+        background: #0f172a;
+        color: #e2e8f0;
+        border: 1px solid #1e293b;
+        border-radius: 12px;
+        padding: 1rem;
+        overflow-x: auto;
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,48 +3,54 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import siteConfig from '../data/site-config.json';
+import { offerings } from '../data/site-content';
 ---
 
 <!doctype html>
 <html lang="en">
-	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-	</head>
-	<body>
-		<Header />
-		<main>
-			<h1>🧑‍🚀 Hello, Astronaut!</h1>
-			<p>
-				Welcome to the official <a href="https://astro.build/">Astro</a> blog starter template. This
-				template serves as a lightweight, minimally-styled starting point for anyone looking to build
-				a personal website, blog, or portfolio with Astro.
-			</p>
-			<p>
-				This template comes with a few integrations already configured in your
-				<code>astro.config.mjs</code> file. You can customize your setup with
-				<a href="https://astro.build/integrations">Astro Integrations</a> to add tools like Tailwind,
-				React, or Vue to your project.
-			</p>
-			<p>Here are a few ideas on how to get started with the template:</p>
-			<ul>
-				<li>Edit this page in <code>src/pages/index.astro</code></li>
-				<li>Edit the site header items in <code>src/components/Header.astro</code></li>
-				<li>Add your name to the footer in <code>src/components/Footer.astro</code></li>
-				<li>Check out the included blog posts in <code>src/content/blog/</code></li>
-				<li>Customize the blog post page layout in <code>src/layouts/BlogPost.astro</code></li>
-			</ul>
-			<p>
-				Have fun! If you get stuck, remember to <a href="https://docs.astro.build/"
-					>read the docs
-				</a> or <a href="https://astro.build/chat">join us on Discord</a> to ask questions.
-			</p>
-			<p>
-				Looking for a blog template with a bit more personality? Check out <a
-					href="https://github.com/Charca/astro-blog-template"
-					>astro-blog-template
-				</a> by <a href="https://twitter.com/Charca">Maxi Ferreira</a>.
-			</p>
-		</main>
-		<Footer />
-	</body>
+  <head>
+    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section>
+        <p class="small">Operational systems, engineered for reliability.</p>
+        <h1>GoldShore.ai</h1>
+        <p>
+          Operational AI infrastructure and observability for mission-critical
+          deployments.
+        </p>
+        <p class="small">
+          We help technical teams design resilient AI-enabled operations with
+          clear instrumentation, ownership models, and deployment controls.
+        </p>
+        <div style="display:flex; gap:.75rem; flex-wrap:wrap; margin-top:1rem;">
+          <a class="button button-primary" href="/contact"
+            >{siteConfig.cta.primary}</a
+          >
+          <a class="button button-secondary" href="/contact"
+            >{siteConfig.cta.secondary}</a
+          >
+        </div>
+      </section>
+
+      <section>
+        <h2>Core offerings</h2>
+        <div class="grid">
+          {
+            offerings.map((offering) => (
+              <article class="card">
+                <h3>{offering.title}</h3>
+                <p>{offering.summary}</p>
+                <p class="metric">{offering.metric}</p>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+    </main>
+    <Footer />
+  </body>
 </html>

--- a/src/pages/risk-radar.astro
+++ b/src/pages/risk-radar.astro
@@ -1,0 +1,86 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="Risk Radar | GoldShore.ai"
+      description="Operational risk visualisation for system stability."
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>Risk Radar</h1>
+      <p class="card">
+        This visualisation demonstrates the interplay of risk vectors in
+        operational systems — an observable analogue to real-world stability
+        metrics.
+      </p>
+      <div class="card radar-wrap">
+        <div class="radar" id="radar"></div>
+      </div>
+    </main>
+    <Footer />
+    <script>
+      const radar = document.getElementById('radar');
+      const prefersReduced = window.matchMedia(
+        '(prefers-reduced-motion: reduce)',
+      ).matches;
+      const isMobile = window.matchMedia('(max-width: 720px)').matches;
+      if (radar && (prefersReduced || isMobile)) {
+        radar.classList.add('radar-low-power');
+      }
+    </script>
+    <style>
+      .radar-wrap {
+        min-height: 280px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .radar {
+        width: min(70vw, 380px);
+        height: min(70vw, 380px);
+        border-radius: 50%;
+        border: 1px solid rgb(var(--border));
+        background:
+          radial-gradient(
+            circle at center,
+            rgba(var(--accent), 0.2) 0 25%,
+            transparent 25% 50%,
+            rgba(var(--accent), 0.12) 50% 52%,
+            transparent 52%
+          ),
+          conic-gradient(
+            from 0deg,
+            rgba(var(--accent), 0.6),
+            rgba(var(--accent-strong), 0.15),
+            rgba(var(--accent), 0.6)
+          );
+        animation: spin 10s linear infinite;
+      }
+      .radar-low-power {
+        animation-duration: 30s;
+        opacity: 0.85;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .radar {
+          animation: none;
+        }
+      }
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -1,0 +1,64 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { services, caseStudies } from '../data/site-content';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title="Services | GoldShore.ai"
+      description="Depth-first services for operational AI systems."
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>Services</h1>
+      <p class="small">
+        Depth, not clutter: each engagement is scoped for practical outcomes and
+        operational durability.
+      </p>
+      <section>
+        {
+          services.map((service) => (
+            <details class="card" style="margin-bottom:1rem;">
+              <summary>
+                <strong>{service.name}</strong>
+              </summary>
+              <p>{service.objective}</p>
+              <ul>
+                {service.deliverables.map((deliverable) => (
+                  <li>{deliverable}</li>
+                ))}
+              </ul>
+              <p class="small">
+                <strong>Typical timeframe:</strong> {service.timeframe}
+              </p>
+            </details>
+          ))
+        }
+      </section>
+      <section>
+        <h2>Mini case studies</h2>
+        <div class="grid">
+          {
+            caseStudies.map((caseStudy) => (
+              <article class="card">
+                <h3>{caseStudy.service}</h3>
+                <p>{caseStudy.outcome}</p>
+                <p class="metric">{caseStudy.result}</p>
+                <p class="small">
+                  <strong>System:</strong> {caseStudy.technology}
+                </p>
+              </article>
+            ))
+          }
+        </div>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,53 +1,41 @@
-/*
-  The CSS in this style tag is based off of Bear Blog's default CSS.
-  https://github.com/HermanMartinus/bearblog/blob/297026a877bc2ab2b3bdfbd6b9f7961c350917dd/templates/styles/blog/default.css
-  License MIT: https://github.com/HermanMartinus/bearblog/blob/master/LICENSE.md
- */
-
 :root {
-  --accent: #2337ff;
-  --accent-dark: #000d8a;
+  --accent: 16, 145, 152;
+  --accent-strong: 11, 102, 108;
   --black: 15, 18, 25;
-  --gray: 96, 115, 159;
+  --gray: 77, 89, 117;
   --gray-light: 229, 233, 240;
   --gray-dark: 34, 41, 57;
-  --gray-gradient: rgba(var(--gray-light), 50%), #fff;
-  --box-shadow:
-    0 2px 6px rgba(var(--gray), 25%), 0 8px 24px rgba(var(--gray), 33%),
-    0 16px 32px rgba(var(--gray), 33%);
+  --surface: 252, 254, 255;
+  --border: 206, 219, 234;
 }
+
 @font-face {
-  font-family: "Atkinson";
-  src: url("/fonts/atkinson-regular.woff") format("woff");
+  font-family: 'Atkinson';
+  src: url('/fonts/atkinson-regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
-  font-family: "Atkinson";
-  src: url("/fonts/atkinson-bold.woff") format("woff");
+  font-family: 'Atkinson';
+  src: url('/fonts/atkinson-bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 body {
-  font-family: "Atkinson", sans-serif;
+  font-family: 'Atkinson', sans-serif;
   margin: 0;
-  padding: 0;
-  text-align: left;
-  background: linear-gradient(var(--gray-gradient)) no-repeat;
-  background-size: 100% 600px;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
+  background: #f2f7fb;
   color: rgb(var(--gray-dark));
   font-size: 20px;
-  line-height: 1.7;
+  line-height: 1.65;
 }
 main {
-  width: 720px;
+  width: 980px;
   max-width: calc(100% - 2em);
   margin: auto;
-  padding: 3em 1em;
+  padding: 2.5em 1em;
 }
 h1,
 h2,
@@ -60,96 +48,87 @@ h6 {
   line-height: 1.2;
 }
 h1 {
-  font-size: 3.052em;
+  font-size: 2.5em;
 }
 h2 {
-  font-size: 2.441em;
+  font-size: 1.8em;
 }
 h3 {
-  font-size: 1.953em;
-}
-h4 {
-  font-size: 1.563em;
-}
-h5 {
-  font-size: 1.25em;
-}
-strong,
-b {
-  font-weight: 700;
+  font-size: 1.2em;
 }
 a {
-  color: var(--accent);
+  color: rgb(var(--accent-strong));
 }
 a:hover {
-  color: var(--accent);
+  color: rgb(var(--accent));
 }
-p {
-  margin-bottom: 1em;
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid rgb(var(--accent-strong));
+  outline-offset: 2px;
 }
-.prose p {
-  margin-bottom: 2em;
+section {
+  margin: 2.5rem 0;
 }
-textarea {
-  width: 100%;
-  font-size: 16px;
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
-input {
-  font-size: 16px;
+.card {
+  border: 1px solid rgb(var(--border));
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgb(var(--surface));
 }
-table {
-  width: 100%;
+.button {
+  display: inline-block;
+  border-radius: 10px;
+  padding: 0.55rem 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+  border: 1px solid transparent;
 }
-img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 8px;
+.button-primary {
+  background: rgb(var(--accent-strong));
+  color: white;
 }
-code {
-  padding: 2px 5px;
-  background-color: rgb(var(--gray-light));
-  border-radius: 2px;
+.button-primary:hover {
+  background: rgb(var(--accent));
+  color: white;
 }
-pre {
-  padding: 1.5em;
-  border-radius: 8px;
+.button-secondary {
+  background: white;
+  border-color: rgb(var(--accent-strong));
+  color: rgb(var(--accent-strong));
 }
-pre > code {
-  all: unset;
+.button-tertiary {
+  background: transparent;
+  border-color: rgb(var(--border));
+  color: rgb(var(--gray-dark));
 }
-blockquote {
-  border-left: 4px solid var(--accent);
-  padding: 0 0 0 20px;
-  margin: 0px;
-  font-size: 1.333em;
+.metric {
+  margin-top: 0.4rem;
+  color: rgb(var(--accent-strong));
+  font-size: 0.9rem;
+  font-weight: 700;
 }
-hr {
-  border: none;
-  border-top: 1px solid rgb(var(--gray-light));
+.small {
+  font-size: 0.95rem;
+  color: rgb(var(--gray));
 }
 @media (max-width: 720px) {
   body {
     font-size: 18px;
   }
   main {
-    padding: 1em;
+    padding: 1.2em 0.5em;
   }
-}
-
-.sr-only {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  position: absolute !important;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
-  /* IE6, IE7 - a 0 height clip, off to the bottom right of the visible 1px box */
-  clip: rect(1px 1px 1px 1px);
-  /* maybe deprecated but we need to support legacy browsers */
-  clip: rect(1px, 1px, 1px, 1px);
-  /* modern browsers, clip-path works inwards from each corner */
-  clip-path: inset(50%);
-  /* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
-  white-space: nowrap;
+  .button {
+    width: 100%;
+    text-align: center;
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide a focused first-rollout of the GoldShore website plan: standardise CTAs and feature flags, establish hero/content patterns, and add service, contact, risk, and developer surfaces. 
- Improve content structure and accessibility-ready styling so the site is ready for staged feature flag rollouts and handoff to developers and writers.

### Description
- Add a central site configuration and feature-flag file at `src/data/site-config.json` with standardized CTA labels (`Start the Engagement`, `Contact the Team`, `Download Docs`).
- Introduce structured content data in `src/data/site-content.ts` (offerings, services, case studies, team, credibility) and wire it into new/updated pages: `src/pages/index.astro`, `src/pages/services.astro`, `src/pages/about.astro`, `src/pages/contact.astro`, `src/pages/contact/thanks.astro`, `src/pages/risk-radar.astro`, and `src/pages/developer-hub.astro`.
- Wire header/footer to the shared CTA config and add new navigation links; refresh global styles in `src/styles/global.css` to improve contrast, focus-visible states, responsive grids/cards/buttons, and mobile touch sizing.
- Add rollout documentation and copy guidance in `docs/developer-briefing.md` and `docs/copy-style-guide.md`, and link them from `README.md`.

### Testing
- Ran Prettier formatting and checks (`pnpm exec prettier --check ...`) and fixed style issues with `--write`, resulting in all matched files using the project's Prettier style (success).
- Ran `pnpm exec astro check` which failed in this environment due to a missing dependency referenced by the project config (`@astrojs/mdx`) and did not complete (environment limitation).
- Attempted to run the local dev preview (`pnpm exec astro dev`) which also failed for the same missing `@astrojs/mdx` dependency; page rendering could not be validated locally because of that dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b978eb90883318125c0468661a187)