### PR TITLE
feat(ui): add minimal Button component and exports

### DIFF
--- a/packages/ui/components/Button/Button.css
+++ b/packages/ui/components/Button/Button.css
@@ -1,0 +1,37 @@
+.gs-button {
+  align-items: center;
+  border: 0;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.95rem;
+  font-weight: 600;
+  gap: 0.5rem;
+  justify-content: center;
+  line-height: 1.2;
+  padding: 0.625rem 1rem;
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.gs-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.gs-button--primary {
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.gs-button--primary:hover:not(:disabled) {
+  background: #1e293b;
+}
+
+.gs-button--secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.gs-button--secondary:hover:not(:disabled) {
+  background: #cbd5e1;
+}

--- a/packages/ui/components/Button/Button.tsx
+++ b/packages/ui/components/Button/Button.tsx
@@ -1,0 +1,20 @@
+import './Button.css';
+
+export interface ButtonProps {
+  variant?: 'primary' | 'secondary';
+  class?: string;
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  [key: string]: unknown;
+}
+
+export function Button({
+  variant = 'primary',
+  class: className = '',
+  ...props
+}: ButtonProps) {
+  const variantClass = variant === 'secondary' ? 'gs-button--secondary' : 'gs-button--primary';
+  const classes = ['gs-button', variantClass, className].filter(Boolean).join(' ');
+
+  return <button class={classes} {...props} />;
+}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './components/Button/Button';
+export type { ButtonProps } from './components/Button/Button';


### PR DESCRIPTION
### Motivation
- The `packages/ui` package declares `main: index.ts` and is referenced by apps, so expose a minimal working component to satisfy the package contract and consume it from apps.
- Replace the previously-empty UI surface with a small, usable `Button` so consuming code can import `@goldshore/ui` without hitting a non-functional entrypoint.

### Description
- Added a minimal `Button` component in `packages/ui/components/Button/Button.tsx` with `variant`, `class`, `type`, `disabled`, and passthrough props and simple class-name composition for variants.
- Implemented base and variant styles in `packages/ui/components/Button/Button.css` including disabled and hover states.
- Exported `Button` and `ButtonProps` from `packages/ui/index.ts` to ensure the `main: index.ts` entrypoint exposes the component API.

### Testing
- Ran TypeScript checks with `pnpm exec tsc --noEmit --jsx preserve packages/ui/index.ts packages/ui/components/Button/Button.tsx` and the check completed successfully.
- Performed a visual render script (Playwright) to capture a screenshot of the button variants and saved the artifact, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be526a3488331adae3195b12e57bb)