### PR TITLE
Fix Turbo build filters and update PII scan output path

### DIFF
--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20
 
       - name: Run PII scan
-        run: node scripts/pii-scan.mjs --mode ci --output apps/admin/src/data/pii-scan-results.json --summary reports/pii-scan-summary.md
+        run: node scripts/pii-scan.mjs --mode ci --output apps/gs-admin/src/data/pii-scan-results.json --summary reports/pii-scan-summary.md
 
       - name: Publish summary
         run: cat reports/pii-scan-summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "build": "pnpm build:openapi && turbo run build",
     "build:web": "turbo run build --filter=@goldshore/web",
     "build:admin": "turbo run build --filter=@goldshore/admin",
-    "build:api": "turbo run build --filter=@goldshore/api-worker",
+    "build:api": "turbo run build --filter=gs-api",
     "build:gateway": "turbo run build --filter=@goldshore/gateway",
-    "build:control": "turbo run build --filter=@goldshore/control-worker",
+    "build:control": "turbo run build --filter=@goldshore/control",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "check:pages": "tsx scripts/check-pages-200.ts",
-    "scan:pii": "node scripts/pii-scan.mjs --mode local --output apps/admin/src/data/pii-scan-results.json --summary reports/pii-scan-summary.md",
+    "scan:pii": "node scripts/pii-scan.mjs --mode local --output apps/gs-admin/src/data/pii-scan-results.json --summary reports/pii-scan-summary.md",
     "check:docs-consistency": "node scripts/check-doc-consistency.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation

- Ensure Turbo `--filter` values in the root `package.json` match actual package names under `apps/*/package.json` to avoid build target mismatches.
- Ensure the local and CI PII scan write their results to the correct admin app data path for `gs-admin`.

### Description

- Updated `package.json` scripts so `build:api` uses `--filter=gs-api` and `build:control` uses `--filter=@goldshore/control` to match actual package names.
- Updated the `scan:pii` script in `package.json` to output to `apps/gs-admin/src/data/pii-scan-results.json` instead of the old `apps/admin/...` path.
- Updated `.github/workflows/pii-scan.yml` to write the CI PII scan output to `apps/gs-admin/src/data/pii-scan-results.json` to match the local script change.
- Verified other `--filter=` script values against `apps/*/package.json` names and confirmed they already matched.

### Testing

- Ran a Node script to extract all `--filter=` values from root scripts and compare them against `name` fields in `apps/*/package.json`, which reported no mismatches (success).
- Confirmed the pipeline workflow file now references the corrected `apps/gs-admin/src/data/pii-scan-results.json` path (visual verification successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cac8bcb848331a25b39ca4397e4c9)