### PR TITLE
Resolve remaining merge-conflict overlap in workflow/docs and package scripts

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -25,8 +25,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BUILD_PATH: '.' # default value when not using subfolders
-  # BUILD_PATH: subfolder
+  BUILD_PATH: 'apps/gs-web'
 
 jobs:
   build:
@@ -44,11 +43,11 @@ jobs:
             echo "runner=yarn" >> $GITHUB_OUTPUT
             echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
             exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            echo "lockfile=package-lock.json" >> $GITHUB_OUTPUT
+          elif [ -f "${{ github.workspace }}/pnpm-lock.yaml" ]; then
+            echo "manager=pnpm" >> $GITHUB_OUTPUT
+            echo "command=install --frozen-lockfile" >> $GITHUB_OUTPUT
+            echo "runner=pnpm" >> $GITHUB_OUTPUT
+            echo "lockfile=pnpm-lock.yaml" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine package manager"

--- a/JULES_CLOUDFLARE_MANUAL.md
+++ b/JULES_CLOUDFLARE_MANUAL.md
@@ -94,9 +94,9 @@ For gs-web and gs-admin, always create:
 gs-web
 
 name: gs-web
-root: apps/web
-build_command: pnpm --filter @goldshore/web build
-build_output: apps/web/dist
+root: apps/gs-web
+build_command: pnpm --filter @goldshore/gs-web build
+build_output: apps/gs-web/dist
 adapter: @astrojs/cloudflare
 domains:
 
@@ -106,9 +106,9 @@ domains:
 gs-admin
 
 name: gs-admin
-root: apps/admin
-build_command: pnpm --filter @goldshore/admin build
-build_output: apps/admin/dist
+root: apps/gs-admin
+build_command: pnpm --filter @goldshore/gs-admin build
+build_output: apps/gs-admin/dist
 adapter: @astrojs/cloudflare
 domains:
 
@@ -131,9 +131,9 @@ PUT /accounts/:account_id/workers/scripts/:script_name
 Worker → Directory Map:
 
 Worker Folder entrypoint
-gs-api apps/api-worker src/index.ts
-gs-gateway apps/gateway src/index.ts
-gs-control apps/control-worker src/index.ts
+gs-api apps/gs-api src/index.ts
+gs-gateway apps/gs-gateway src/index.ts
+gs-control apps/gs-control src/index.ts
 gs-mail no folder required via CF editor
 
 ⸻
@@ -166,7 +166,7 @@ GATEWAY → gs-gateway
 
 Jules MUST generate & maintain:
 
-apps/api-worker/wrangler.toml
+apps/gs-api/wrangler.toml
 
 name = "gs-api"
 main = "src/index.ts"
@@ -188,7 +188,7 @@ database_id = "gs_db_001"
 [ai]
 binding = "AI"
 
-apps/gateway/wrangler.toml
+apps/gs-gateway/wrangler.toml
 
 name = "gs-gateway"
 main = "src/index.ts"
@@ -202,7 +202,7 @@ environment = "production"
 [ai]
 binding = "AI"
 
-apps/control-worker/wrangler.toml
+apps/gs-control/wrangler.toml
 
 name = "gs-control"
 main = "src/index.ts"

--- a/README-v2.md
+++ b/README-v2.md
@@ -81,7 +81,6 @@ Diagram source: [`docs/architecture/diagram.mmd`](docs/architecture/diagram.mmd)
 │   ├── gs-api/            # Hono API (Workers)
 │   ├── gs-gateway/        # Router + jobs (Workers)
 │   ├── gs-agent/          # Autonomous AI service (Workers)
-│   ├── gs-agent/          # Deprecated agent shim (legacy workflows)
 │   ├── gs-control/        # Infra automation
 │   ├── jules-bot/         # GitHub automation bot
 │   └── legacy/            # Legacy services
@@ -214,7 +213,7 @@ D1 = gs-db
 AI = AI (AI Gateway)
 ```
 
-### 4) `apps/gateway` — gs-gateway
+### 4) `apps/gs-gateway` — gs-gateway
 
 ```
 Route: https://gw.goldshore.ai/*
@@ -234,7 +233,7 @@ Responsibilities:
 - External AI model integration
 - Workflow orchestration
 
-### 6) `apps/control-worker` — Automation Worker
+### 6) `apps/gs-control` — Automation Worker
 
 ```
 Route: https://ops.goldshore.ai/*
@@ -393,7 +392,7 @@ Run individual apps:
 pnpm --filter ./apps/gs-web dev
 pnpm --filter ./apps/gs-admin dev
 pnpm --filter ./apps/gs-api dev
-pnpm --filter ./apps/gateway dev
+pnpm --filter ./apps/gs-gateway dev
 pnpm --filter ./apps/gs-agent dev
 ```
 
@@ -426,8 +425,8 @@ Workers deploy:
 
 ```bash
 pnpm --filter ./apps/gs-api deploy
-pnpm --filter ./apps/gateway deploy
-pnpm --filter ./apps/control-worker deploy
+pnpm --filter ./apps/gs-gateway deploy
+pnpm --filter ./apps/gs-control deploy
 pnpm --filter ./apps/gs-agent deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Diagram source: [`docs/architecture/diagram.mmd`](docs/architecture/diagram.mmd)
 │   ├── gs-api/            # Hono API (Workers)
 │   ├── gs-gateway/        # Router + jobs (Workers)
 │   ├── gs-agent/          # AI Agent Service (Workers)
-│   ├── gs-agent/          # Deprecated agent shim (legacy workflows)
 │   ├── gs-control/        # Infra automation
 │   └── jules-bot/         # GitHub Automation Bot
 │
@@ -189,7 +188,7 @@ AI = AI (AI Gateway)
 
 ---
 
-## **4. apps/gateway – gs-gateway**
+## **4. apps/gs-gateway – gs-gateway**
 
 Request router + queue dispatcher.
 
@@ -219,7 +218,7 @@ Responsibilities:
 
 ---
 
-## **6. gs-control (optional)**
+## **6. apps/gs-control (optional)**
 
 System worker for automation:
 
@@ -267,7 +266,7 @@ Template pages are kept alongside each app so navigation, menus, containers, and
 | Web        | `apps/gs-web/src/pages/templates/index.astro`   | Marketing + search composition  |
 | Admin      | `apps/gs-admin/src/pages/templates/index.astro` | Dashboard shell + table samples |
 | API Worker | `apps/gs-api/src/routes/templates.ts`    | Module checklist for API growth |
-| Gateway    | `apps/gateway/src/index.ts` (`/templates`)   | Routing + AI dispatch template  |
+| Gateway    | `apps/gs-gateway/src/index.ts` (`/templates`)   | Routing + AI dispatch template  |
 | Agent      | `apps/gs-agent/src/index.ts` (`/templates`)  | HITL orchestration template     |
 
 ---
@@ -591,7 +590,7 @@ Supports:
 
 ---
 
-🚏 apps/gateway — Routing & AI Gateway
+🚏 apps/gs-gateway — Routing & AI Gateway
 
 Handles:
 • URL-based routing
@@ -602,7 +601,7 @@ Handles:
 
 ---
 
-🛰 apps/control-worker — Infra Automation
+🛰 apps/gs-control — Infra Automation
 
 Can automatically:
 • Create DNS records

--- a/ops/pr-playbook.md
+++ b/ops/pr-playbook.md
@@ -81,7 +81,7 @@ git fetch origin main
 
 ### 2.2 Special Case: Lockfile Conflicts (pnpm-lock.yaml)
 
-If pnpm-lock.yaml shows conflict markers (<<<<<<<, =======, >>>>>>>):
+If pnpm-lock.yaml shows conflict markers (`<<<`, `===`, `>>>`):
 
 Do NOT open or edit the lockfile manually.
 
@@ -131,11 +131,9 @@ If Git shows conflicts:
    - Open the file
    - Look for:
      ```
-     <<<<<<< HEAD
+     [current branch changes]
      ...
-     =======
-     ...
-     >>>>>>> branch-name
+     [incoming branch changes]
      ```
    - Decide:
      - Keep current (HEAD, which is main)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "dev": "turbo run dev --parallel",
     "build:openapi": "node scripts/build-openapi.mjs",
     "build": "pnpm build:openapi && turbo run build",
-    "build": "turbo run build",
     "build:web": "turbo run build --filter=@goldshore/gs-web",
     "build:admin": "turbo run build --filter=@goldshore/gs-admin",
     "build:api": "turbo run build --filter=@goldshore/gs-api-worker",


### PR DESCRIPTION
### Motivation
- Remove leftover merge-conflict artifacts and legacy path drift in workflow and docs to restore consistent, buildable repository metadata. 
- Normalize directory and package references to the current `apps/gs-*` conventions and keep the canonical `build` script in `package.json`.

### Description
- Update `.github/workflows/astro.yml` to set `BUILD_PATH` to `apps/gs-web` and detect/use `pnpm-lock.yaml` with `pnpm install --frozen-lockfile` for installs. 
- Normalize Cloudflare mapping and wrangler path examples in `JULES_CLOUDFLARE_MANUAL.md` to `apps/gs-*` directories and update worker entrypoints. 
- Clean path/name drift and duplicate entries in `README.md` and `README-v2.md`, including `gs-gateway` / `gs-control` naming and `pnpm --filter` command examples. 
- Remove literal git conflict marker examples from `ops/pr-playbook.md` to avoid confusion while preserving the conflict-resolution guidance. 
- Remove the duplicate `build` script in `package.json`, keeping the canonical `pnpm build:openapi && turbo run build` pipeline command.

### Testing
- Searched target files for unresolved git conflict markers with `rg` and found no matches (success). 
- Ran `git diff --check` to validate there are no whitespace/merge residue problems (success). 
- Parsed `package.json` with Node (`JSON.parse`) to confirm valid JSON after edits (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e839d3b1c8331b89d761828142dae)