### PR TITLE
Resolve Astro config merge-conflict remnants in apps (goldshore-admin, goldshore-web)

### DIFF
--- a/apps/goldshore-admin/astro.config.mjs
+++ b/apps/goldshore-admin/astro.config.mjs
@@ -4,14 +4,3 @@ import { createGoldshoreAstroConfig } from '@goldshore/config/astro';
 
 // https://astro.build/config
 export default defineConfig(createGoldshoreAstroConfig());
-import { sharedNoExternal } from '../../packages/config/astro-shared.mjs';
-
-// https://astro.build/config
-export default defineConfig({
-  vite: {
-    ssr: {
-      // Include shared packages in the SSR build
-      noExternal: sharedNoExternal,
-    },
-  },
-});

--- a/apps/goldshore-web/astro.config.mjs
+++ b/apps/goldshore-web/astro.config.mjs
@@ -4,14 +4,3 @@ import { createGoldshoreAstroConfig } from '@goldshore/config/astro';
 
 // https://astro.build/config
 export default defineConfig(createGoldshoreAstroConfig());
-import { sharedNoExternal } from '../../packages/config/astro-shared.mjs';
-
-// https://astro.build/config
-export default defineConfig({
-  vite: {
-    ssr: {
-      // Include shared packages in the SSR build
-      noExternal: sharedNoExternal,
-    },
-  },
-});


### PR DESCRIPTION
### Motivation
- Branch merge left duplicate/conflicting `export default defineConfig(...)` blocks in app-level `astro.config.mjs` files which can break Astro/Vite config loading.
- Clean-up is required to restore a single shared config entrypoint and unblock mergeability and deployment.

### Description
- Removed duplicated/conflicting config blocks and kept `export default defineConfig(createGoldshoreAstroConfig())` in `apps/goldshore-admin/astro.config.mjs`.
- Applied the same cleanup in `apps/goldshore-web/astro.config.mjs` so both apps use the shared `@goldshore/config/astro` entrypoint.

### Testing
- Ran `bash scripts/check-conflicts.sh` which found no unresolved merge markers and exited successfully.
- Ran `node --check apps/goldshore-admin/astro.config.mjs` and `node --check apps/goldshore-web/astro.config.mjs`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e840ceec483319df215df522e22d4)