### PR TITLE
Standardize worker package naming and Turbo filters

### DIFF
--- a/apps/api-worker/package.json
+++ b/apps/api-worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gs-api",
+  "name": "@goldshore/api",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "pnpm build:openapi && turbo run build",
     "build:web": "turbo run build --filter=@goldshore/web",
     "build:admin": "turbo run build --filter=@goldshore/admin",
-    "build:api": "turbo run build --filter=@goldshore/api-worker",
+    "build:api": "turbo run build --filter=@goldshore/api",
     "build:gateway": "turbo run build --filter=@goldshore/gateway",
-    "build:control": "turbo run build --filter=@goldshore/control-worker",
+    "build:control": "turbo run build --filter=@goldshore/control",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "scan:pii": "node scripts/pii-scan.mjs --mode local --output apps/admin/src/data/pii-scan-results.json --summary reports/pii-scan-summary.md"


### PR DESCRIPTION
### Motivation
- Standardize worker package naming to the scoped `@goldshore/*` convention and align Turbo `--filter` script values with actual workspace package names.
- Replace stale/unscoped names to avoid broken `pnpm --filter` resolution and inconsistent developer experience.
- Requesting review per repository guidance: `@Jules-Bot [review-request]`.

### Description
- Updated root `package.json` scripts to set `build:api` -> `@goldshore/api` and `build:control` -> `@goldshore/control`.
- Renamed the API worker package in `apps/api-worker/package.json` from `gs-api` to `@goldshore/api`.
- Searched for remaining stale filters `@goldshore/api-worker|@goldshore/control-worker` and confirmed there are no remaining matches.
- Aligned worker filters with existing workspace names to enforce a consistent scoped naming policy.

### Testing
- Ran `rg -n '@goldshore/api-worker|@goldshore/control-worker'` and confirmed no matches, indicating stale filters were cleared.
- Ran `pnpm run` and verified the root scripts list shows `build:api` and `build:control` updated to the new filters.
- Ran `pnpm --filter @goldshore/api exec node -p "require('./package.json').name" && pnpm --filter @goldshore/control exec node -p "require('./package.json').name" && pnpm --filter @goldshore/gateway exec node -p "require('./package.json').name"` and confirmed the filters resolved to `@goldshore/api`, `@goldshore/control`, and `@goldshore/gateway`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9a4437e483318534d4a6eb1ef717)