### PR TITLE
chore: resolve conflict markers in .vscode/extensions.json and add audit log

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,16 +1,10 @@
 {
-<<<<<<< Updated upstream
   "recommendations": [
     "astro-build.astro-vscode",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "bradlc.vscode-tailwindcss",
-    "unifiedjs.vscode-mdx"
+    "unifiedjs.vscode-mdx",
+    "openai.chatgpt"
   ]
 }
-=======
-    "recommendations": [
-        "openai.chatgpt"
-    ]
-}
->>>>>>> Stashed changes

--- a/reports/branch-audit-log.txt
+++ b/reports/branch-audit-log.txt
@@ -1,0 +1,13 @@
+Branch conflict audit log
+=========================
+
+Timestamp: 2026-02-13T03:36:38Z
+Branch: work
+
+Findings:
+- No git index unmerged entries were present (`git ls-files -u` returned empty).
+- Conflict markers were found in `.vscode/extensions.json`.
+- Resolved `.vscode/extensions.json` by merging both recommendation lists and removing conflict markers.
+
+Verification:
+- `rg -n "^(<<<<<<<|=======|>>>>>>>)" --hidden -g '!.git' .` now returns no matches.


### PR DESCRIPTION
### Motivation
- Fix unresolved merge conflict markers in ` .vscode/extensions.json` to restore valid JSON and preserve both sets of VS Code recommendations. 
- Provide an audit record of the conflict detection and resolution for traceability.

### Description
- Merged conflicting recommendation lists in `.vscode/extensions.json` into a single valid `recommendations` array and added `"openai.chatgpt"` to the list. 
- Removed all conflict marker lines (`<<<<<<<`, `=======`, `>>>>>>>`) from the file to ensure valid JSON. 
- Added `reports/branch-audit-log.txt` that records a timestamp, findings, resolution steps, and the verification command used. 
- Verified that the repository no longer contains conflict markers.

### Testing
- Ran `rg -n "^(<<<<<<<|=======|>>>>>>>)" --hidden -g '!.git' .` which returned no matches to confirm no conflict markers remain. 
- Ran `git ls-files -u` which returned no unmerged index entries to confirm no merge conflicts in the index. 
- Ran `git status --short --branch` and inspected `nl -ba .vscode/extensions.json` and `nl -ba reports/branch-audit-log.txt` to validate file contents and presence of the audit log. 
- All automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd2dcbed083319606cd35a47176fb)