### PR TITLE
Explicit server output and Cloudflare adapter in gs-web Astro config

### DIFF
--- a/apps/gs-web/astro.config.mjs
+++ b/apps/gs-web/astro.config.mjs
@@ -1,7 +1,10 @@
 import baseConfig from "@goldshore/config/astro";
+import cloudflare from "@astrojs/cloudflare";
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
   ...baseConfig,
+  output: "server",
+  adapter: cloudflare(),
   // Web specific overrides if any
 });


### PR DESCRIPTION
### Motivation
- Ensure the gs-web app defines `output: 'server'` and `adapter: cloudflare()` locally so app-specific settings deterministically override the shared base config and avoid ambiguous/implicit adapter resolution.

### Description
- Updated `apps/gs-web/astro.config.mjs` to import `@astrojs/cloudflare`, keep the existing `...baseConfig` spread, and add `output: "server"` and `adapter: cloudflare()` after the spread so app-local values take precedence, and requested review via @Jules-Bot [review-request].

### Testing
- No automated tests were run for this tiny config change; repository-level verification was performed to confirm the new keys are present and positioned after the `...baseConfig` spread.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d23cf4348331b4f8d15d8f3c5b6c)