### PR TITLE
⚡ optimize: remove redundant database schema check in media routes

### DIFF
--- a/apps/gs-api/db/media.sql
+++ b/apps/gs-api/db/media.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS media_assets (
+  id TEXT PRIMARY KEY,
+  filename TEXT NOT NULL,
+  url TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  type TEXT NOT NULL,
+  object_key TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/apps/gs-api/src/routes/media.ts
+++ b/apps/gs-api/src/routes/media.ts
@@ -31,26 +31,9 @@ const sanitizeSvg = (rawSvg: string) => {
   return sanitized;
 };
 
-const ensureTable = async (db: D1Database) => {
-  await db
-    .prepare(
-      `CREATE TABLE IF NOT EXISTS media_assets (
-        id TEXT PRIMARY KEY,
-        filename TEXT NOT NULL,
-        url TEXT NOT NULL,
-        size INTEGER NOT NULL,
-        type TEXT NOT NULL,
-        object_key TEXT NOT NULL,
-        created_at TEXT NOT NULL
-      )`
-    )
-    .run();
-};
-
 const media = new Hono<{ Bindings: { DB: D1Database; ASSETS: R2Bucket } }>();
 
 media.get('/', async (c) => {
-  await ensureTable(c.env.DB);
   const { results } = await c.env.DB
     .prepare('SELECT id, filename, url, size, type, created_at FROM media_assets ORDER BY created_at DESC LIMIT 100')
     .all<MediaRecord>();
@@ -58,7 +41,6 @@ media.get('/', async (c) => {
 });
 
 media.get('/:id', async (c) => {
-  await ensureTable(c.env.DB);
   const id = c.req.param('id');
   const result = await c.env.DB
     .prepare('SELECT object_key, type FROM media_assets WHERE id = ?')
@@ -84,7 +66,6 @@ media.get('/:id', async (c) => {
 });
 
 media.post('/upload', async (c) => {
-  await ensureTable(c.env.DB);
   const formData = await c.req.formData();
   const file = formData.get('file');
 


### PR DESCRIPTION
Removed the `ensureTable` function and its invocations from the `gs-api` media routes. Schema creation should be handled during initialization or migrations, not on every request.

Added `apps/gs-api/db/media.sql` to maintain the schema definition.

Performance impact: Reduces request latency by eliminating an unnecessary D1 operation on every media request.