### PR TITLE
Add PR workflow guard for pnpm lockfile changes

### DIFF
--- a/.github/workflows/lockfile-guard.yml
+++ b/.github/workflows/lockfile-guard.yml
@@ -1,16 +1,24 @@
 name: Lockfile Guard
-on: pull_request
+
+on:
+  pull_request:
+
 jobs:
-  prevent-lockfile-drift:
+  prevent-lockfile-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Prevent lockfile drift
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Guard pnpm lockfile
         run: |
+          set -euo pipefail
           git fetch origin main
-          if git diff --name-only origin/main...HEAD | grep -q "pnpm-lock.yaml"; then
-            echo "❌ Lockfile changes are only allowed on main."
+
+          if git diff --name-only origin/main...HEAD | grep -q '^pnpm-lock.yaml$'; then
+            echo "❌ Detected changes to pnpm-lock.yaml in this pull request."
+            echo "Lockfile updates must go through the designated lockfile update branch/process."
             exit 1
-          else
-            echo "✅ No lockfile drift."
           fi
+
+          echo "✅ No pnpm-lock.yaml changes detected."


### PR DESCRIPTION
### Motivation
- Prevent accidental or unauthorized changes to `pnpm-lock.yaml` in regular pull requests by enforcing updates via the designated lockfile update branch/process.

### Description
- Add `.github/workflows/lockfile-guard.yml` to run on `pull_request` and introduce a job that checks for lockfile edits.
- Checkout the repository, `git fetch origin main`, and run `git diff --name-only origin/main...HEAD` to detect changes.
- Fail the job when an exact `pnpm-lock.yaml` path is present and emit a clear message directing contributors to the lockfile update process, otherwise print a success message.
- Add `set -euo pipefail` and rename the job/steps for clarity.

### Testing
- Ran `git diff -- .github/workflows/lockfile-guard.yml` to validate the workflow diff and it succeeded.
- Ran `nl -ba .github/workflows/lockfile-guard.yml` to inspect the resulting file contents and it succeeded.
- Created a commit for the change with `git commit` and the commit operation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920c2f57988331a3a1c51aef4779dd)