### PR TITLE
Document deterministic merge=ours policy for high-churn files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Prefer branch lockfile to avoid manual conflict resolution; regenerate as needed.
+# High-churn files auto-resolve to the branch version (`merge=ours`) to keep rebases deterministic.
 pnpm-lock.yaml merge=ours
 README.md merge=ours
 CURRENT_MONOREPO_STATE.md merge=ours

--- a/docs/ops/DEVELOPER_SOP.md
+++ b/docs/ops/DEVELOPER_SOP.md
@@ -20,3 +20,20 @@ If a Pull Request (PR) shows merge conflicts, the Agent MUST execute a **Forcefu
 | **Error 1101** (Worker Crash) | Missing dependency or unhandled runtime exception (e.g., trying to read KV before initialization). | Must verify asynchronous KV config loading in `apps/gs-api/src/index.(ts|js)`. |
 | **Error 522** (Connection Timeout) | Incorrect DNS CNAME or Pages Build Output path. | Execute `infra/scripts/enforce-dns.sh` to correct CNAMEs and ensure Pages settings are manually fixed to target `apps/gs-web/dist` or `apps/gs-admin/dist`. |
 | **Build Error** (e.g., `wrangler.toml` invalid) | Incorrect placement of `wrangler.toml` in the Pages project. | Ensure `wrangler.toml` only lives at the Worker root (`apps/gs-api/`) and Pages settings are manually configured. |
+
+## 3. Deterministic Conflict Handling for High-Churn Files (SOP-003)
+
+Certain files are updated very frequently and are not a reliable source of semantic review signal during rebases.
+To avoid repeated manual conflict resolution noise, this repo uses `.gitattributes` with `merge=ours` for:
+
+- `pnpm-lock.yaml`
+- `README.md`
+- `CURRENT_MONOREPO_STATE.md`
+
+### Contributor policy
+
+1. During merges/rebases, Git will prefer the current branch version for these files.
+2. If upstream changes to one of these files are needed, re-apply them intentionally in a follow-up commit after synchronization.
+3. For `pnpm-lock.yaml`, regenerate the lockfile (`pnpm install`) when dependency changes require it.
+
+This policy keeps branch synchronization deterministic while still allowing explicit, intentional updates to these files.


### PR DESCRIPTION
### Motivation

- Reduce noisy manual conflict resolution for files that change frequently by preferring branch versions during merges and rebases.
- Make the repository behavior explicit so contributors know when these files are auto-resolved and how to intentionally apply upstream changes.

### Description

- Clarified the `.gitattributes` comment to state that high-churn files auto-resolve to the branch version using `merge=ours` and left the entries for `pnpm-lock.yaml`, `README.md`, and `CURRENT_MONOREPO_STATE.md` in place.
- Added `SOP-003` to `docs/ops/DEVELOPER_SOP.md` describing the deterministic conflict handling policy and listing the affected files.
- Documented contributor guidance for intentional updates, including regenerating `pnpm-lock.yaml` via `pnpm install` when dependency changes require it.

### Testing

- Verified the working tree and diff with `git status --short` and `git diff -- .gitattributes docs/ops/DEVELOPER_SOP.md`, which showed the intended changes and succeeded.
- Displayed file contents with `nl -ba .gitattributes` and `nl -ba docs/ops/DEVELOPER_SOP.md` to validate the new comment and `SOP-003` addition, which matched expectations.
- Committed the changes with `git commit` and created the PR record using the repository `make_pr` tool; both actions completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920c31cd1483319b7ef4a76f2258d4)