### PR TITLE
Configure merge drivers for root coordination docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Prefer branch lockfile to avoid manual conflict resolution; regenerate as needed.
 pnpm-lock.yaml merge=ours
+
+# Keep branch-local top-level docs during conflict resolution.
+# These files are frequently edited in long-lived feature branches, and preserving
+# the branch version avoids accidentally dropping branch-specific context.
+README.md merge=ours
+CURRENT_MONOREPO_STATE.md merge=ours

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Unified platform for the **GoldShore** ecosystem, built with **Astro**, **Cloudf
 - [Testing](#testing)
 - [Deployment](#deployment)
 - [Versioning Strategy](#versioning-strategy)
+- [Contributor Note: Merge Strategy for Top-Level Docs](#contributor-note-merge-strategy-for-top-level-docs)
 - [License](#license)
 
 ## Vibe Coding & Human-in-the-Loop
@@ -418,6 +419,15 @@ pnpm --filter ./apps/gs-agent deploy
 - `main` → Production
 - `feature/*` → Preview Deployments
 - `release/*` → Staging
+
+## Contributor Note: Merge Strategy for Top-Level Docs
+
+To reduce noisy merge/rebase conflicts on frequently edited coordination docs, `.gitattributes` uses `merge=ours` for:
+
+- `README.md`: the active branch's README should win so branch-scoped documentation work is not overwritten by unrelated upstream edits.
+- `CURRENT_MONOREPO_STATE.md`: the active branch's status snapshot should win for the same reason, preserving branch-local planning/state notes.
+
+If you need to intentionally adopt upstream changes to either file, resolve that manually after the merge by reviewing both versions.
 
 ## License
 


### PR DESCRIPTION
### Motivation
- Add `merge=ours` rules for top-level coordination docs to preserve branch-local documentation and reduce noisy merge/rebase conflicts.

### Description
- Update `.gitattributes` to add `README.md merge=ours` and `CURRENT_MONOREPO_STATE.md merge=ours` with explanatory comments, and add a short contributor note in `README.md` (plus a TOC entry) documenting the rationale and when to manually reconcile upstream changes.

### Testing
- Ran `git diff -- .gitattributes README.md`, `git status --short`, and committed the changes with `git commit`, all of which completed successfully; please review with `@Jules-Bot [review-request]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920e3611988331b49167df0d9ed1e8)