### PR TITLE
[Draft] docs: add fetch/auth status update for blocked origin/main diff

### DIFF
--- a/reports/fetch-status.md
+++ b/reports/fetch-status.md
@@ -1,0 +1,14 @@
+# Fetch/Auth Status Update
+
+## Summary
+- Configured `origin` remote to use SSH: `git@github.com:goldshore/goldshore-ai.git`.
+- Fetch is blocked in this environment due network reachability to GitHub SSH endpoint.
+- `origin/main` is unavailable locally, so branch-delta diff against main cannot be computed here.
+
+## Latest command results
+- `git fetch --all --prune` -> `ssh: connect to host github.com port 22: Network is unreachable`
+- `git show-ref --verify refs/remotes/origin/main` -> ref not found
+- `git diff --name-status origin/main...HEAD` -> base ref unresolved
+
+## Next step
+Run the same fetch and diff commands from an environment that can reach GitHub, then attach the resulting changed-file list for review.


### PR DESCRIPTION
### Motivation
- Record the current fetch/auth boundary and failure mode so reviewers understand why a branch-delta against `origin/main` cannot be produced from this environment.

### Description
- Add `reports/fetch-status.md` which documents the configured SSH remote, the network reachability failure, the observed command outputs, and recommended next steps.
- Include a short explanation that `origin/main` is unavailable locally and therefore `origin/main...HEAD` comparisons cannot be generated here.
- Mark the PR as a review request using `@Jules-Bot [review-request]` so reviewers can follow the next steps to reproduce and unblock the fetch.

### Testing
- Ran `git status --short` to confirm workspace state and locate changed files, which succeeded.
- Created `reports/fetch-status.md` and verified the file contents were written, which succeeded.
- Executed `git fetch --all --prune`, which failed with `ssh: connect to host github.com port 22: Network is unreachable`.
- Executed `git show-ref --verify refs/remotes/origin/main` which returned the ref as not found, and `git diff --name-status origin/main...HEAD` which could not compute a base ref.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9a3f34b08331aba10b141de5032e)