### PR TITLE
Follow-up: align infra API worker paths with gs-api rename

### DIFF
--- a/infra/AI/AGENT_IDENTITY.yaml
+++ b/infra/AI/AGENT_IDENTITY.yaml
@@ -27,6 +27,6 @@ repo_lock:
   forbidden_paths:
     - apps/web/**
     - apps/admin/**
-    - apps/api-worker/**
+    - apps/gs-api/**
     - apps/gateway/**
     - packages/**

--- a/infra/cf/config.yaml
+++ b/infra/cf/config.yaml
@@ -22,7 +22,7 @@ projects:
 
   workers:
     - script: gs-api
-      entry: apps/api-worker/dist/index.js
+      entry: apps/gs-api/dist/index.js
       routes:
         - pattern: "api.goldshore.org/*"
           zone: goldshore.org

--- a/infra/cloudflare/BINDINGS_MAP.md
+++ b/infra/cloudflare/BINDINGS_MAP.md
@@ -49,7 +49,7 @@
 ### 3. API Worker
 
 - Service Name: `astro-gs-api`
-- Code: `apps/api-worker`
+- Code: `apps/gs-api`
 - Routes:
   - `api.goldshore.ai/*`
   - `api-preview.goldshore.ai/*`

--- a/infra/cloudflare/desired-state.yaml
+++ b/infra/cloudflare/desired-state.yaml
@@ -77,7 +77,7 @@ cloudflare:
   workers:
     services:
       - name: "gs-api"
-        script_path: "apps/api-worker/dist/index.js"
+        script_path: "apps/gs-api/dist/index.js"
         routes:
           - pattern: "api.goldshore.ai/*"
         bindings:

--- a/infra/cloudflare/goldshore-api.wrangler.toml
+++ b/infra/cloudflare/goldshore-api.wrangler.toml
@@ -1,9 +1,9 @@
 # wrangler.toml for the API Worker
 
 name = "gs-api" # Base name, will be suffixed per environment
-main = "../../apps/api-worker/src/index.ts"
+main = "../../apps/gs-api/src/index.ts"
 compatibility_date = "2024-03-20"
-tsconfig = "../../apps/api-worker/tsconfig.json"
+tsconfig = "../../apps/gs-api/tsconfig.json"
 
 [env.dev]
 name = "gs-api-dev"


### PR DESCRIPTION
### Motivation
- The monorepo rename of the API worker from `apps/api-worker` to `apps/gs-api` left several infra references stale which caused deploy tooling to hit `ENOENT` when reading the old paths. 
- Infra deploy and Cloudflare config must point to canonical `gs-*` directories so deployments remain idempotent across tooling. 
- Update docs/state files so infra automation, guards, and agent rules reflect the renamed worker code location.

### Description
- Updated the Cloudflare deploy config worker entry to `apps/gs-api/dist/index.js` in `infra/cf/config.yaml`.
- Updated the API worker Wrangler config to point `main` and `tsconfig` at `../../apps/gs-api/...` in `infra/cloudflare/goldshore-api.wrangler.toml`.
- Replaced remaining `apps/api-worker` occurrences with `apps/gs-api` in `infra/cloudflare/desired-state.yaml`, `infra/cloudflare/BINDINGS_MAP.md`, and `infra/AI/AGENT_IDENTITY.yaml` to keep infra state, docs, and repo lock rules consistent.
- Ensured the repo lock/forbidden paths and desired-state worker `script_path` now reference `apps/gs-api` so CI, infra checks, and agent permissions align.

### Testing
- Ran a repository search with `rg -n "apps/api-worker" infra .github/workflows/deploy-api-worker.yml` to confirm there are no remaining `apps/api-worker` references and it returned no matches, indicating the rename is complete (succeeded).
- Executed a small Python assertion script to verify `infra/cf/config.yaml` contains `apps/gs-api/dist/index.js` and `infra/cloudflare/goldshore-api.wrangler.toml` contains `../../apps/gs-api/src/index.ts` and `../../apps/gs-api/tsconfig.json`, and the assertions passed (succeeded).
- Verified modified infra files contain the expected `apps/gs-api` paths by printing relevant file sections (visual verification completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952e44289c8331a9e7e30bb29d75b7)