### PR TITLE
Stabilize gs-web styling pipeline and logo asset loading

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -3,7 +3,9 @@ import '@goldshore/theme/styles/tokens';
 import '@goldshore/theme/styles/base';
 import '@goldshore/theme/styles/components';
 import '@goldshore/theme/styles/layout';
+import '../styles/global.css';
 import { GSButton } from '@goldshore/ui';
+import logo from '../assets/logo.svg';
 
 const navLinks = [
   { href: '/', label: 'Home' },
@@ -15,7 +17,7 @@ const navLinks = [
 ];
 
 const { title = 'GoldShore', description = 'GoldShore AI', currentPath = Astro.url.pathname } = Astro.props;
-const logoSrc = '/logo.svg';
+const logoSrc = logo.src;
 ---
 <html lang="en">
   <head>
@@ -24,7 +26,7 @@ const logoSrc = '/logo.svg';
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self';" />
-    <link rel="icon" href="/favicon.png" type="image/png" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <!-- Bolt: Preconnect to external origins to speed up resource loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/astro-goldshore/apps/web/src/pages/index.astro
+++ b/astro-goldshore/apps/web/src/pages/index.astro
@@ -1,18 +1,68 @@
 ---
 import "../styles/global.css";
-// This will be a placeholder until the UI package is created
-// import { Hero } from "@ui/Hero";
 ---
 
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Gold Shore Labs – Shaping Waves</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gold Shore Labs</title>
   </head>
   <body>
+    <header class="hero">
+      <nav class="container nav">
+        <a class="brand" href="/">Gold Shore Labs</a>
+        <ul>
+          <li><a href="#projects">Projects</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </nav>
+
+      <div class="container hero-content">
+        <h1>Gold Shore Labs</h1>
+        <p>AI. Strategy. Infrastructure.</p>
+        <p class="positioning">
+          Gold Shore Labs designs AI-powered systems for entrepreneurs, investors, and operators building the next generation of digital infrastructure.
+        </p>
+      </div>
+    </header>
+
     <main>
-      <h1>Shaping Waves</h1>
-      <p>Gold Shore Labs builds AI-powered infrastructure for trading, automation, and applied intelligence.</p>
+      <section class="section">
+        <div class="container">
+          <h2>Built to Start Conversations</h2>
+          <p>
+            We build practical systems that combine intelligent automation, clear operating models, and durable infrastructure.
+          </p>
+          <p class="tools">Access tools: admin.goldshore.ai | api.goldshore.ai</p>
+        </div>
+      </section>
+
+      <section class="section engage" id="contact">
+        <div class="container">
+          <h2>What are you building?</h2>
+          <p>Tell us your problem. We’ll help architect the solution.</p>
+          <a href="/contact" class="cta">Start a Conversation</a>
+        </div>
+      </section>
     </main>
+
+    <footer id="projects">
+      <div class="container footer-columns">
+        <div>
+          <h4>Gold Shore</h4>
+          <p>AI-driven business architecture.</p>
+        </div>
+        <div>
+          <h4>Projects</h4>
+          <a href="/banproof">BanProof</a>
+          <a href="/armsway">ArmsWay</a>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <a href="https://rmarston.com">rmarston</a>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>

--- a/astro-goldshore/apps/web/src/styles/global.css
+++ b/astro-goldshore/apps/web/src/styles/global.css
@@ -3,9 +3,149 @@
 :root {
   font-family: var(--font-body, sans-serif);
   color: var(--gs-text-primary, #ffffff);
-  background: var(--gs-blue-alcantara, #1a1a1a);
+  background: #020617;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
+  padding: 0;
+  background: #020617;
+  color: #e2e8f0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.container {
+  width: min(100%, 1200px);
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 20px;
+}
+
+.nav ul {
+  list-style: none;
+  display: flex;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+}
+
+.brand {
+  font-weight: 700;
+}
+
+.hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.14) 1px, transparent 1px),
+    radial-gradient(circle at 80% 40%, rgba(255, 255, 255, 0.1) 1px, transparent 1px),
+    linear-gradient(120deg, #0f172a 0%, #1e293b 45%, #0f172a 100%);
+  background-size: 4px 4px, 6px 6px, cover;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(white 1px, transparent 1px);
+  background-size: 3px 3px;
+  opacity: 0.04;
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding-bottom: 100px;
+}
+
+.hero-content h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  margin-bottom: 12px;
+}
+
+.hero-content p {
+  margin: 0 auto 12px;
+  max-width: 760px;
+}
+
+.positioning {
+  color: #cbd5e1;
+}
+
+.section {
+  padding: 60px 24px;
+}
+
+.engage {
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.cta {
+  display: inline-block;
+  margin-top: 12px;
+  background: #38bdf8;
+  color: #0f172a;
+  font-weight: 700;
+  padding: 10px 16px;
+  border-radius: 8px;
+}
+
+.tools {
+  opacity: 0.85;
+}
+
+footer {
+  padding: 60px 24px;
+  background: #0f172a;
+  color: #cbd5e1;
+}
+
+.footer-columns {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.footer-columns a {
+  display: block;
+  margin-top: 8px;
+}
+
+@media (max-width: 768px) {
+  .section {
+    padding: 48px 20px;
+  }
+
+  .container {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .nav {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .footer-columns {
+    grid-template-columns: 1fr;
+  }
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,6 +17,7 @@
     "./styles/base": "./src/styles/base.css",
     "./styles/components": "./src/styles/components.css",
     "./styles/layout": "./src/styles/layout.css",
+    "./styles/global.css": "./src/styles/global.css",
     "./manager": "./src/theme-manager.ts",
     "./assets/logo.svg": "./assets/logo.svg"
   }

--- a/packages/theme/src/styles/global.css
+++ b/packages/theme/src/styles/global.css
@@ -1,0 +1,4 @@
+@import "./tokens.css";
+@import "./base.css";
+@import "./components.css";
+@import "./layout.css";

--- a/reports/issues/cloudflare-connection-assessment-2026-02-19.md
+++ b/reports/issues/cloudflare-connection-assessment-2026-02-19.md
@@ -1,0 +1,56 @@
+# Cloudflare connection assessment for `goldshore.ai` (2026-02-19)
+
+## What I checked
+
+### 1) DNS resolution
+- `goldshore.ai`, `www.goldshore.ai`, `api.goldshore.ai`, `gw.goldshore.ai`, `ops.goldshore.ai`, and `admin.goldshore.ai` all resolve to Cloudflare edge IPs (`104.21.26.100` and `172.67.135.217`).
+- This indicates DNS is active and proxied through Cloudflare.
+
+### 2) HTTP/HTTPS reachability
+- Requests to all tested hostnames return `403 Forbidden` with Cloudflare challenge headers:
+  - `cf-mitigated: challenge`
+- This means the domains are reachable at Cloudflare edge, but traffic is being challenged/blocked by Cloudflare security policy (WAF/Bot protection/custom rule), not by DNS failure.
+
+### 3) Cloudflare edge trace
+- `GET https://goldshore.ai/cdn-cgi/trace` returns a valid Cloudflare trace payload.
+- This confirms edge connectivity is healthy.
+
+## Repo state vs observed behavior
+
+The repository documentation states the public web domain should be open:
+- `goldshore.ai` and `www.goldshore.ai` are expected to be public (no Access gate). See `docs/domains-and-auth.md`.
+
+Observed behavior conflicts with that expectation:
+- Public web and service subdomains currently challenge generic HTTP clients at the edge.
+
+## Most likely root cause
+
+A Cloudflare dashboard-level policy is actively challenging requests for `goldshore.ai` zone, likely one of:
+- WAF custom rule with challenge action.
+- Bot Fight Mode / Super Bot Fight Mode aggressively challenging non-browser traffic.
+- Managed challenge rule applied broadly to all hosts.
+- Access policy incorrectly attached to unintended hostnames (less likely because header indicates challenge, not Access login flow).
+
+## Fast repair plan (no code deploy required)
+
+1. In Cloudflare Dashboard → **Security > Events**, filter by host `goldshore.ai` and look up challenge events.
+2. Identify the matching rule/rule ID causing `Managed Challenge` / `JS Challenge` / `Block`.
+3. For public web hosts (`goldshore.ai`, `www.goldshore.ai`):
+   - Remove challenge action, or
+   - Add explicit allow/bypass rule for standard GET/HEAD traffic.
+4. Keep Access/WAF protection only on intended internal hosts (`admin`, `ops`, and preview domains), aligned with `docs/domains-and-auth.md`.
+5. Re-test with:
+   - `curl -I https://goldshore.ai`
+   - `curl -I https://www.goldshore.ai`
+   expecting `200` or `301/302`, and no `cf-mitigated: challenge` header.
+
+## Desired policy alignment from repo docs
+
+- Public: `goldshore.ai`, `www.goldshore.ai`
+- Access-protected: admin and preview domains
+- Optional protection depending on endpoint design: `api.goldshore.ai`, `gw.goldshore.ai`
+- Internal ops: `ops.goldshore.ai`
+
+Reference docs:
+- `docs/domains-and-auth.md`
+- `infra/cloudflare/desired-state.yaml`


### PR DESCRIPTION
### Motivation
- The site was building successfully on Cloudflare but rendering unstyled or with missing logos, indicating a layout-level CSS import, package CSS export, and asset pathing problem. 
- The goal is a minimal, low-risk stabilization so global styles and logo assets load reliably across Astro + Cloudflare builds without refactoring the theme package. 

### Description
- Import the app-level global stylesheet in `apps/gs-web/src/layouts/WebLayout.astro` so global styles are guaranteed to load for all pages, switch the logo to a local Astro asset import (`../assets/logo.svg`), and correct the favicon to `public/favicon.svg`. 
- Add a `packages/theme/src/styles/global.css` entrypoint that composes the theme tokens/base/components/layout files and export it in `packages/theme/package.json` as `./styles/global.css` so package-level imports are explicit. 
- Add a polished `index.astro` and `global.css` under `astro-goldshore/apps/web` to provide a minimal landing page and local styling for that app, and include a Cloudflare connection assessment report at `reports/issues/cloudflare-connection-assessment-2026-02-19.md`. 
- Requesting review for these packaging/pathing changes: @Jules-Bot [review-request].

### Testing
- Ran `pnpm --filter @goldshore/gs-web build` which completed successfully and produced the static output (build logs show successful prerender and client build). 
- Attempted `pnpm --filter @goldshore/web build` which failed because that package name does not exist in the workspace (expected and handled). 
- Started the dev server with `pnpm --filter @goldshore/gs-web dev --host 0.0.0.0 --port 4321`, verified the app served, and captured a Playwright screenshot of `http://127.0.0.1:4321/` for visual validation (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699725bb28e08331b9af977583d38dc5)