### PR TITLE
Add Phase 1 CI baseline stabilization helper script

### DIFF
--- a/docs/ci/PHASE1_BASELINE.md
+++ b/docs/ci/PHASE1_BASELINE.md
@@ -1,0 +1,28 @@
+# Phase 1 CI Baseline Script
+
+This repository includes an idempotent helper script for stabilization-mode workflow reduction:
+
+- Script: `scripts/phase1-ci-baseline.sh`
+- Default mode: dry-run (prints intended file operations)
+- Apply mode: `--apply`
+
+## What it does
+
+1. Ensures `.github/workflows/_DISABLED_ARCHIVE/` exists.
+2. Ensures `.github/workflows/ci-main.yml` exists with a minimal, no-`uses:` build pipeline.
+3. Ensures `.github/workflows/.placeholder` exists.
+4. Moves all other workflow YAML files to `.github/workflows/_DISABLED_ARCHIVE/`.
+
+## Usage
+
+```bash
+# Preview only
+bash scripts/phase1-ci-baseline.sh
+
+# Apply changes
+bash scripts/phase1-ci-baseline.sh --apply
+```
+
+## Why this is useful
+
+This isolates CI to a single deterministic baseline workflow while preserving historical workflows in archive for controlled reintroduction.

--- a/scripts/phase1-ci-baseline.sh
+++ b/scripts/phase1-ci-baseline.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Phase 1 CI baseline stabilizer.
+# Default mode is dry-run. Use --apply to perform filesystem changes.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOWS_DIR="$ROOT_DIR/.github/workflows"
+ARCHIVE_DIR="$WORKFLOWS_DIR/_DISABLED_ARCHIVE"
+BASELINE_WORKFLOW="$WORKFLOWS_DIR/ci-main.yml"
+PLACEHOLDER_FILE="$WORKFLOWS_DIR/.placeholder"
+
+MODE="dry-run"
+if [[ "${1:-}" == "--apply" ]]; then
+  MODE="apply"
+fi
+
+KEEP_WORKFLOWS=(
+  "ci-main.yml"
+  ".placeholder"
+)
+
+is_keep_file() {
+  local filename="$1"
+  for keep in "${KEEP_WORKFLOWS[@]}"; do
+    if [[ "$filename" == "$keep" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_cmd() {
+  if [[ "$MODE" == "apply" ]]; then
+    "$@"
+  else
+    echo "[dry-run] $*"
+  fi
+}
+
+echo "==> Running phase1-ci-baseline in $MODE mode"
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+  echo "Error: workflows directory not found at $WORKFLOWS_DIR" >&2
+  exit 1
+fi
+
+run_cmd mkdir -p "$ARCHIVE_DIR"
+
+if [[ ! -f "$BASELINE_WORKFLOW" ]]; then
+  echo "==> Writing minimal baseline workflow: $BASELINE_WORKFLOW"
+  if [[ "$MODE" == "apply" ]]; then
+    cat > "$BASELINE_WORKFLOW" <<'YAML'
+name: CI (Minimal)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        run: git clone ${{ github.server_url }}/${{ github.repository }} .
+
+      - name: Setup Node
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+          sudo apt-get install -y nodejs
+
+      - name: Setup PNPM
+        run: npm install -g pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all
+        run: pnpm build
+YAML
+  else
+    echo "[dry-run] create $BASELINE_WORKFLOW"
+  fi
+else
+  echo "==> Baseline workflow already exists: $BASELINE_WORKFLOW"
+fi
+
+if [[ ! -f "$PLACEHOLDER_FILE" ]]; then
+  run_cmd touch "$PLACEHOLDER_FILE"
+fi
+
+shopt -s nullglob
+for file in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
+  filename="$(basename "$file")"
+
+  if is_keep_file "$filename"; then
+    continue
+  fi
+
+  target="$ARCHIVE_DIR/$filename"
+  if [[ "$MODE" == "apply" ]]; then
+    mv "$file" "$target"
+  else
+    echo "[dry-run] mv $file $target"
+  fi
+done
+shopt -u nullglob
+
+echo "==> Done. Active workflows now intended to be:"
+echo "  - ci-main.yml"
+echo "  - .placeholder"
+echo
+echo "Tip: run with --apply to make changes."


### PR DESCRIPTION
### Motivation

- Provide a safe, idempotent way to reduce active GitHub workflows to a single deterministic baseline during stabilization.
- Preserve historical workflows in an archive so they can be reintroduced in a controlled manner.
- Avoid marketplace `uses:` steps in the baseline to minimize external variability during containment.

### Description

- Add `scripts/phase1-ci-baseline.sh`, a script that defaults to dry-run and supports `--apply`, which ensures an archive directory, writes a minimal `ci-main.yml` if missing, ensures `.placeholder`, and moves all other workflow YAML files into `.github/workflows/_DISABLED_ARCHIVE/` while keeping `ci-main.yml` and `.placeholder`.
- The baseline workflow created is a minimal Node/PNPM build pipeline (no marketplace `uses:`) intended to be deterministic for Phase 1 stabilization.
- The script is idempotent and implements a `KEEP_WORKFLOWS` whitelist and a dry-run `run_cmd` mode to preview actions.
- Add `docs/ci/PHASE1_BASELINE.md` documenting usage, behavior, and rationale, and include a PR review tag per repo guidance (`@Jules-Bot [review-request]`).

### Testing

- Ran `bash scripts/phase1-ci-baseline.sh` in dry-run mode and observed planned creation of `ci-main.yml`, creation of `.placeholder`, and planned moves of existing workflow files; the command completed successfully.
- Verified repository changes with `git status --short` and verified file contents with `nl -ba` outputs; both commands succeeded.
- Committed the two new files and generated the PR entry; all automated steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69961e06e33c8331b38c6866f2024f70)