### PR TITLE
[PR #1836 follow-up] Pin baseline CI checkout to triggering revision

### DIFF
--- a/scripts/phase1-ci-baseline.sh
+++ b/scripts/phase1-ci-baseline.sh
@@ -64,8 +64,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main
-        run: git clone ${{ github.server_url }}/${{ github.repository }} .
+      - name: Checkout triggering revision
+        run: |
+          git init .
+          git remote add origin ${{ github.server_url }}/${{ github.repository }}
+          git fetch --no-tags --depth=1 origin ${{ github.sha }}
+          git checkout --detach FETCH_HEAD
 
       - name: Setup Node
         run: |


### PR DESCRIPTION
### Motivation

- Fix a P1 issue where the generated baseline workflow cloned the repository default branch HEAD, which could make CI run against the wrong revision and allow regressions to pass.

### Description

- Update `scripts/phase1-ci-baseline.sh` so the baseline workflow no longer runs `git clone`; instead it initializes the repo, adds the `origin` remote, runs `git fetch --no-tags --depth=1 origin ${{ github.sha }}`, and `git checkout --detach FETCH_HEAD` to ensure the workflow builds the exact triggering commit.

### Testing

- Ran `bash -n scripts/phase1-ci-baseline.sh` and `bash scripts/phase1-ci-baseline.sh` (dry-run) and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699759c3ab24833185ca098a23f97d4b)