### PR TITLE
Fix duplicate YAML keys in workflows and correct preview paths (follow-up to #1834)

### DIFF
--- a/.github/workflows/palette-manual.yml
+++ b/.github/workflows/palette-manual.yml
@@ -18,7 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
         uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
         uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -36,7 +35,6 @@ jobs:
         run: cat reports/pii-scan-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
         uses: actions/upload-artifact@v6
         with:
           name: pii-scan-report

--- a/.github/workflows/preview-agent.yml
+++ b/.github/workflows/preview-agent.yml
@@ -56,7 +56,6 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm exec wrangler deploy --env preview --config wrangler.toml
         run: pnpm exec wrangler deploy --env preview --config ../../infra/cloudflare/gs-agent.wrangler.toml
 
 # // [AUTO-UPDATE] Updated by Jules AI on 2026-01-23 01:43

--- a/.github/workflows/preview-control-worker.yml
+++ b/.github/workflows/preview-control-worker.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Deploy Control worker (preview)
         working-directory: apps/gs-control
-      - name: Deploy Control worker (preview)
-        working-directory: apps/control-worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Build web app (preview)
         working-directory: apps/gs-web
-      - name: Build web app (preview)
-        working-directory: apps/web
         env:
           PUBLIC_API: https://api-preview.goldshore.ai
           PUBLIC_GATEWAY: https://gw-preview.goldshore.ai

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -47,7 +47,6 @@ jobs:
 
         # You can pin the exact commit or the version.
         # uses: SonarSource/sonarcloud-github-action@v2.2.0
-        uses: SonarSource/sonarcloud-github-action@4006f663ecaf1f8093e8e4abb9227f6041f52216
         uses: SonarSource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -18,7 +18,6 @@ jobs:
 
       - name: Run AI inference
         id: inference
-        uses: actions/ai-inference@v1
         uses: actions/ai-inference@v2
         with:
           prompt: |

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -32,7 +32,6 @@ jobs:
           sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
         uses: github/codeql-action/upload-sarif@v4
         with:
           # Path to SARIF file relative to the root of the repository


### PR DESCRIPTION
### Motivation
- Remove duplicate YAML map keys that caused strict workflow parsing to fail and blocked CI validation. 
- Collapse duplicated/incorrect preview steps and fix working directories so preview build/deploy steps target existing apps.

### Description
- Removed duplicate `uses`/`run` entries across workflow files to eliminate duplicate YAML map keys in `summary.yml`, `preview-agent.yml`, `pii-scan.yml`, `palette-manual.yml`, `sonarcloud.yml`, and `tfsec.yml`.
- Collapsed the duplicated deploy block in `preview-control-worker.yml` and ensured the deploy step targets the existing `apps/gs-control` directory with a complete deploy `run` step.
- Collapsed the duplicated build block in `preview-web.yml` and ensured the build step uses the existing `apps/gs-web` working directory and includes the `pnpm build` `run` step.
- Kept the preview-agent deploy command that uses the repo infra config path (`../../infra/cloudflare/gs-agent.wrangler.toml`) and removed the stray duplicate `run` entry.

### Testing
- Parsed all updated workflow files with strict YAML (`YAML.parseDocument(..., { uniqueKeys: true })`) and all updated files reported no duplicate-key errors.
- Ran `pnpm check:naming`, which now progresses past YAML parsing but still fails on pre-existing naming lint issues in `apps/jules-bot/package.json`, `.github/workflows/neuralegion.yml`, and `.github/workflows/sonarcloud.yml` (these issues are unrelated to the duplicate-key fixes).
- Verified the repository-level check that previously failed on duplicate keys now completes the parsing stage successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975afc60648331b6ee3f1f160167ec)