### PR TITLE
Fix CI-blocking naming and admin theme import regressions for #1834

### DIFF
--- a/.github/workflows/neuralegion.yml
+++ b/.github/workflows/neuralegion.yml
@@ -160,7 +160,7 @@ on:
     - cron: '38 10 * * 2'
 
 jobs:
-  neuralegion_scan:
+  neuralegion-scan:
     runs-on: ubuntu-18.04
     name: A job to run a Nexploit scan
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,7 +39,7 @@ permissions:
   pull-requests: read # allows SonarCloud to decorate PRs with analysis results
 
 jobs:
-  Analysis:
+  analysis:
     runs-on: ubuntu-latest
 
     steps:

--- a/apps/gs-admin/src/layouts/AdminLayout.astro
+++ b/apps/gs-admin/src/layouts/AdminLayout.astro
@@ -1,10 +1,10 @@
 ---
 import Sidebar from '../components/Sidebar.astro';
 import Topbar from '../components/Topbar.astro';
-import '@goldshore/theme/styles/tokens.css';
-import '@goldshore/theme/styles/base.css';
-import '@goldshore/theme/styles/components.css';
-import '@goldshore/theme/styles/layout.css';
+import '@goldshore/theme/src/styles/tokens.css';
+import '@goldshore/theme/src/styles/base.css';
+import '@goldshore/theme/src/styles/components.css';
+import '@goldshore/theme/src/styles/layout.css';
 import type { AdminPermission, AdminRole } from '@goldshore/auth';
 
 interface Props {

--- a/apps/jules-bot/package.json
+++ b/apps/jules-bot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jules-bot",
+  "name": "@goldshore/jules-bot",
   "version": "0.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
### Motivation
- Address CI-blocking regressions discovered in the docs/stabilization audit that break admin builds and repository naming/workflow linting.
- Restore correct package naming and workflow job keys to satisfy `pnpm check:naming` and downstream pipelines.

### Description
- Update `apps/gs-admin/src/layouts/AdminLayout.astro` to import theme CSS from `@goldshore/theme/src/styles/*` so the files resolve to existing sources instead of the missing `@goldshore/theme/styles/*` paths.
- Restore the scoped package name in `apps/jules-bot/package.json` by changing `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69975dfef7308331b12cf279d63bb498)