### PR TITLE
Update Gold Shore logo assets to glow SVG variant

### DIFF
--- a/apps/gs-admin/public/assets/logo.svg
+++ b/apps/gs-admin/public/assets/logo.svg
@@ -1,5 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200">
-  <title>Gold Shore Labs</title>
-  <path d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z" fill="none" stroke="#0b3a5f" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 190" role="img" aria-labelledby="title desc">
+  <title id="title">Gold Shore Labs logo</title>
+  <desc id="desc">Penrose mark with blue fill, navy stroke, glow, and Gold Shore wordmark.</desc>
+
+  <defs>
+    <filter id="gs-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <g filter="url(#gs-glow)">
+    <path
+      d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z"
+      fill="#0A4C8A"
+      stroke="#052F54"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
+  </g>
+
+  <text
+    x="64"
+    y="170"
+    text-anchor="middle"
+    font-size="14"
+    font-weight="600"
+    letter-spacing="2"
+    fill="#0A4C8A"
+    style="font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  >
+    GOLD SHORE
+  </text>
 </svg>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200"><title>Gold Shore Labs</title><path d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z" fill="none" stroke="#0b3a5f" stroke-linejoin="round"/></svg>

--- a/apps/gs-admin/src/assets/logo.svg
+++ b/apps/gs-admin/src/assets/logo.svg
@@ -1,27 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 220" role="img" aria-labelledby="title desc">
-  <title id="title">Penrose Triangle Logo</title>
-  <desc id="desc">Interlocking triangular mark used for the GoldShore identity.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 190" role="img" aria-labelledby="title desc">
+  <title id="title">Gold Shore Labs logo</title>
+  <desc id="desc">Penrose mark with blue fill, navy stroke, glow, and Gold Shore wordmark.</desc>
+
   <defs>
-    <linearGradient id="penroseFill" x1="18" y1="18" x2="142" y2="142" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#fef3c7" />
-      <stop offset="45%" stop-color="#fbbf24" />
-      <stop offset="100%" stop-color="#d97706" />
-    </linearGradient>
-    <linearGradient id="penroseStroke" x1="18" y1="18" x2="142" y2="142" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#fde68a" />
-      <stop offset="55%" stop-color="#f59e0b" />
-      <stop offset="100%" stop-color="#b45309" />
-    </linearGradient>
+    <filter id="gs-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
   </defs>
-  <g fill="url(#penroseFill)" stroke="url(#penroseStroke)" stroke-width="12" stroke-linejoin="round">
-    <path d="M130 14 68 122h48l31-54-29-54Z" />
-    <path d="m133 146 62-108-23-4-31 54 12 58Z" />
-    <path d="M96 131h94l-12-21H115l-19 21Z" />
+
+  <g filter="url(#gs-glow)">
+    <path
+      d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z"
+      fill="#0A4C8A"
+      stroke="#052F54"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
   </g>
-  <text x="130" y="190" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="20" letter-spacing="6" fill="url(#penroseFill)" stroke="none" style="text-transform: uppercase;">GOLD SHORE</text>
-</svg>
-    <path d="M80 14 18 122h48l31-54-29-54Z" />
-    <path d="m83 146 62-108-23-4-31 54 12 58Z" />
-    <path d="M46 131h94l-12-21H65l-19 21Z" />
-  </g>
+
+  <text
+    x="64"
+    y="170"
+    text-anchor="middle"
+    font-size="14"
+    font-weight="600"
+    letter-spacing="2"
+    fill="#0A4C8A"
+    style="font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  >
+    GOLD SHORE
+  </text>
 </svg>

--- a/apps/gs-web/public/assets/logo.svg
+++ b/apps/gs-web/public/assets/logo.svg
@@ -1,4 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200">
-  <title>Gold Shore Labs</title>
-  <path d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z" fill="none" stroke="#0b3a5f" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 190" role="img" aria-labelledby="title desc">
+  <title id="title">Gold Shore Labs logo</title>
+  <desc id="desc">Penrose mark with blue fill, navy stroke, glow, and Gold Shore wordmark.</desc>
+
+  <defs>
+    <filter id="gs-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <g filter="url(#gs-glow)">
+    <path
+      d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z"
+      fill="#0A4C8A"
+      stroke="#052F54"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
+  </g>
+
+  <text
+    x="64"
+    y="170"
+    text-anchor="middle"
+    font-size="14"
+    font-weight="600"
+    letter-spacing="2"
+    fill="#0A4C8A"
+    style="font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  >
+    GOLD SHORE
+  </text>
 </svg>

--- a/apps/gs-web/public/logo.svg
+++ b/apps/gs-web/public/logo.svg
@@ -1,5 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200">
-  <title>Gold Shore Labs</title>
-  <path d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z" fill="none" stroke="#0b3a5f" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 190" role="img" aria-labelledby="title desc">
+  <title id="title">Gold Shore Labs logo</title>
+  <desc id="desc">Penrose mark with blue fill, navy stroke, glow, and Gold Shore wordmark.</desc>
+
+  <defs>
+    <filter id="gs-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <g filter="url(#gs-glow)">
+    <path
+      d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z"
+      fill="#0A4C8A"
+      stroke="#052F54"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
+  </g>
+
+  <text
+    x="64"
+    y="170"
+    text-anchor="middle"
+    font-size="14"
+    font-weight="600"
+    letter-spacing="2"
+    fill="#0A4C8A"
+    style="font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  >
+    GOLD SHORE
+  </text>
 </svg>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200"><title>Gold Shore Labs</title><path d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z" fill="none" stroke="#0b3a5f" stroke-linejoin="round"/></svg>

--- a/apps/gs-web/src/assets/logo.svg
+++ b/apps/gs-web/src/assets/logo.svg
@@ -1,27 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 220" role="img" aria-labelledby="title desc">
-  <title id="title">Penrose Triangle Logo</title>
-  <desc id="desc">Interlocking triangular mark used for the GoldShore identity.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 190" role="img" aria-labelledby="title desc">
+  <title id="title">Gold Shore Labs logo</title>
+  <desc id="desc">Penrose mark with blue fill, navy stroke, glow, and Gold Shore wordmark.</desc>
+
   <defs>
-    <linearGradient id="penroseFill" x1="18" y1="18" x2="142" y2="142" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#fef3c7" />
-      <stop offset="45%" stop-color="#fbbf24" />
-      <stop offset="100%" stop-color="#d97706" />
-    </linearGradient>
-    <linearGradient id="penroseStroke" x1="18" y1="18" x2="142" y2="142" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#fde68a" />
-      <stop offset="55%" stop-color="#f59e0b" />
-      <stop offset="100%" stop-color="#b45309" />
-    </linearGradient>
+    <filter id="gs-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
   </defs>
-  <g fill="url(#penroseFill)" stroke="url(#penroseStroke)" stroke-width="12" stroke-linejoin="round">
-    <path d="M130 14 68 122h48l31-54-29-54Z" />
-    <path d="m133 146 62-108-23-4-31 54 12 58Z" />
-    <path d="M96 131h94l-12-21H115l-19 21Z" />
+
+  <g filter="url(#gs-glow)">
+    <path
+      d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z"
+      fill="#0A4C8A"
+      stroke="#052F54"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
   </g>
-  <text x="130" y="190" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="20" letter-spacing="6" fill="url(#penroseFill)" stroke="none" style="text-transform: uppercase;">GOLD SHORE</text>
-</svg>
-    <path d="M80 14 18 122h48l31-54-29-54Z" />
-    <path d="m83 146 62-108-23-4-31 54 12 58Z" />
-    <path d="M46 131h94l-12-21H65l-19 21Z" />
-  </g>
+
+  <text
+    x="64"
+    y="170"
+    text-anchor="middle"
+    font-size="14"
+    font-weight="600"
+    letter-spacing="2"
+    fill="#0A4C8A"
+    style="font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  >
+    GOLD SHORE
+  </text>
 </svg>

--- a/packages/theme/assets/logo.svg
+++ b/packages/theme/assets/logo.svg
@@ -1,1 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 200"><title>Gold Shore Labs</title><path d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z" fill="none" stroke="#0b3a5f" stroke-linejoin="round"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 190" role="img" aria-labelledby="title desc">
+  <title id="title">Gold Shore Labs logo</title>
+  <desc id="desc">Penrose mark with blue fill, navy stroke, glow, and Gold Shore wordmark.</desc>
+
+  <defs>
+    <filter id="gs-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2.5" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <g filter="url(#gs-glow)">
+    <path
+      d="m111.87 92.505-41-72A1 1 0 0 0 70 20H57a1 1 0 0 0-.87.505l-41 72a1 1 0 0 0 0 .99l6.5 11.414a1 1 0 0 0 .87.506h82a1 1 0 0 0 .87-.506l6.5-11.414a1 1 0 0 0 0-.99M109.28 92H43.72l5.361-9.415H91.5a1 1 0 0 0 .87-1.494L58.72 22h10.698ZM63.5 57.265l13.28 23.32H50.22ZM17.15 93 57 23.021l32.78 57.564h-10.7l-21.21-37.25a1.04 1.04 0 0 0-1.738 0L22.5 102.392Zm86.768 10.415H24.22L57 45.85l5.35 9.394-21.22 37.261A1 1 0 0 0 42 94h67.28Z"
+      fill="#0A4C8A"
+      stroke="#052F54"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+    />
+  </g>
+
+  <text
+    x="64"
+    y="170"
+    text-anchor="middle"
+    font-size="14"
+    font-weight="600"
+    letter-spacing="2"
+    fill="#0A4C8A"
+    style="font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  >
+    GOLD SHORE
+  </text>
+</svg>


### PR DESCRIPTION
### Motivation
- Replace multiple inconsistent/duplicated Penrose logo assets with a single production-ready glow variant to standardize branding across web, admin, and theme packages. 
- Preserve the original Penrose path geometry while separating fill and stroke to allow consistent theming and easier overrides. 
- Provide a scalable SVG that includes a subtle glow and a centered wordmark using the Inter-first font stack for parity with GS admin UI.

### Description
- Replaced logo files at `apps/gs-web/src/assets/logo.svg`, `apps/gs-web/public/logo.svg`, `apps/gs-web/public/assets/logo.svg`, `apps/gs-admin/src/assets/logo.svg`, `apps/gs-admin/public/assets/logo.svg`, and `packages/theme/assets/logo.svg` with the glow variant. 
- Added the `gs-glow` filter and applied it to the Penrose group, set fill to `#0A4C8A` and stroke to `#052F54` while keeping the provided Penrose path coordinates unchanged. 
- Centered the `GOLD SHORE` wordmark beneath the mark and applied an Inter-first font stack in the `style` attribute for the text element. 
- Removed previously duplicated/invalid trailing SVG fragments and ensured each file is a single valid SVG document, and requested a visual review via `@Jules-Bot [review-request]`.

### Testing
- Parsed each updated SVG with Python's `xml.etree.ElementTree` (`ET.parse`) to validate XML well-formedness and the parser reported success for all modified files. 
- Rendered a preview screenshot via a Playwright script and saved `artifacts/logo-glow.png` to confirm the glow and layout render as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977b4eb7a08331a207046faf28b696)