### PR TITLE
Consolidate gs-web theme CSS imports

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -1,9 +1,5 @@
 ---
-import '@goldshore/theme';
-import '@goldshore/theme/styles/tokens';
-import '@goldshore/theme/styles/base';
-import '@goldshore/theme/styles/components';
-import '@goldshore/theme/styles/layout';
+import '@goldshore/theme/styles/global.css';
 import '../styles/global.css';
 import { GSButton } from '@goldshore/ui';
 import logo from '../assets/logo.svg';

--- a/apps/gs-web/src/styles/global.css
+++ b/apps/gs-web/src/styles/global.css
@@ -1,7 +1,3 @@
-@import "@goldshore/theme/styles/tokens";
-@import "@goldshore/theme/styles/base";
-@import "@goldshore/theme/styles/components";
-@import "@goldshore/theme/styles/layout";
 @import "./gs-effects.css";
 
 :root {


### PR DESCRIPTION
### Motivation
- Ensure theme CSS is resolved through a single canonical entry point to avoid duplicate or conflicting partial imports.
- Preserve app-level overrides by keeping the gs-web local stylesheet import separate from the theme entry.

### Description
- Replace multiple theme partial imports in `apps/gs-web/src/layouts/WebLayout.astro` with a single import: `import '@goldshore/theme/styles/global.css';`.
- Keep `import '../styles/global.css';` in `WebLayout.astro` for gs-web-specific styles and local overrides.
- Remove theme partial `@import`s from `apps/gs-web/src/styles/global.css` so that file now only contains gs-web-local styles and `@import "./gs-effects.css"`; request review with `@Jules-Bot [review-request]`.

### Testing
- Ran `git diff` on the modified files and inspected the output to confirm the imports were updated and removed as expected, which succeeded.
- Verified the commit with `git show --stat --oneline HEAD` and workspace status with `git status --short`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997bb21a6348331822116716186da22)