### PR TITLE
Fix gs-admin theme CSS alias import paths

### DIFF
--- a/apps/gs-admin/src/layouts/AdminLayout.astro
+++ b/apps/gs-admin/src/layouts/AdminLayout.astro
@@ -1,10 +1,10 @@
 ---
 import Sidebar from '../components/Sidebar.astro';
 import Topbar from '../components/Topbar.astro';
-import '@goldshore/theme/styles/tokens.css';
-import '@goldshore/theme/styles/base.css';
-import '@goldshore/theme/styles/components.css';
-import '@goldshore/theme/styles/layout.css';
+import '@goldshore/theme/src/styles/tokens.css';
+import '@goldshore/theme/src/styles/base.css';
+import '@goldshore/theme/src/styles/components.css';
+import '@goldshore/theme/src/styles/layout.css';
 import type { AdminPermission, AdminRole } from '@goldshore/auth';
 
 interface Props {


### PR DESCRIPTION
### Motivation
- A Codex review identified a CI-blocking missing-theme import when `@goldshore/theme` aliases to `../../packages/theme`, causing builds to fail during admin preview/deploy.
- The branch shows naming-related findings already resolved, so the immediate fix is to correct the admin layout stylesheet imports to match the aliased package layout.

### Description
- Updated stylesheet imports in `apps/gs-admin/src/layouts/AdminLayout.astro` to reference `@goldshore/theme/src/styles/*` instead of `@goldshore/theme/styles/*` so the paths resolve under the app's Vite alias.
- The change affects the four theme imports at the top of the admin layout (`tokens.css`, `base.css`, `components.css`, `layout.css`).

### Testing
- Ran `pnpm check:naming` which passed, confirming workflow/job and package naming linting are currently compliant.
- Ran `pnpm -C apps/gs-admin build`; the build now proceeds past the prior missing-theme CSS resolution point and fails later due to a pre-existing syntax error in `apps/gs-admin/src/pages/index.astro`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ce8d5b1c83318e5effa580a7fb57)