### PR TITLE
Harden gs-web deploy integrity checks and add status diagnostics

### DIFF
--- a/.github/workflows/deploy-gs-web.yml
+++ b/.github/workflows/deploy-gs-web.yml
@@ -43,7 +43,13 @@ jobs:
 
       - name: Build web app
         working-directory: apps/gs-web
+        env:
+          PUBLIC_BUILD_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
+          PUBLIC_COMMIT_SHA: ${{ github.sha }}
         run: pnpm build
+
+      - name: Verify web dist integrity
+        run: pnpm verify:web-dist
 
       - name: Deploy to Cloudflare Pages (production)
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/preview-gs-web.yml
+++ b/.github/workflows/preview-gs-web.yml
@@ -54,7 +54,12 @@ jobs:
         env:
           PUBLIC_API: https://api-preview.goldshore.ai
           PUBLIC_GATEWAY: https://gw-preview.goldshore.ai
+          PUBLIC_BUILD_TIMESTAMP: ${{ github.event.pull_request.updated_at }}
+          PUBLIC_COMMIT_SHA: ${{ github.sha }}
         run: pnpm build
+
+      - name: Verify web dist integrity
+        run: pnpm verify:web-dist
 
       - name: Deploy to Cloudflare Pages (preview)
         uses: cloudflare/pages-action@v1

--- a/apps/gs-web/package.json
+++ b/apps/gs-web/package.json
@@ -12,7 +12,8 @@
     "check": "astro check",
     "lint": "eslint .",
     "test": "playwright test",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "verify:dist": "node ../../scripts/verify-web-dist.mjs"
   },
   "dependencies": {
     "@goldshore/config": "workspace:^",

--- a/apps/gs-web/src/pages/status.astro
+++ b/apps/gs-web/src/pages/status.astro
@@ -1,5 +1,16 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import logo from '../assets/logo.svg';
+
+const buildTimestamp =
+  import.meta.env.PUBLIC_BUILD_TIMESTAMP ||
+  import.meta.env.CF_PAGES_COMMIT_TIMESTAMP ||
+  new Date().toISOString();
+const commitHash =
+  import.meta.env.PUBLIC_COMMIT_SHA ||
+  import.meta.env.CF_PAGES_COMMIT_SHA ||
+  'unknown';
+const shortCommitHash = commitHash === 'unknown' ? commitHash : commitHash.slice(0, 12);
 ---
 
 <BaseLayout title="Status | GoldShore" description="System status">
@@ -23,18 +34,42 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li style="display: flex; justify-content: space-between; align-items: center;">
           <span>Web Application</span>
           <span style="color: #4ade80; display: flex; align-items: center; gap: 0.5rem;">
-             <span style="width: 8px; height: 8px; border-radius: 50%; background: currentColor;"></span>
-             Operational
+            <span style="width: 8px; height: 8px; border-radius: 50%; background: currentColor;"></span>
+            Operational
           </span>
         </li>
         <li style="display: flex; justify-content: space-between; align-items: center;">
           <span>Background Workers</span>
           <span style="color: #4ade80; display: flex; align-items: center; gap: 0.5rem;">
-             <span style="width: 8px; height: 8px; border-radius: 50%; background: currentColor;"></span>
-             Operational
+            <span style="width: 8px; height: 8px; border-radius: 50%; background: currentColor;"></span>
+            Operational
           </span>
         </li>
       </ul>
     </div>
   </section>
+
+  <section class="gs-section">
+    <div class="gs-card">
+      <h2>Frontend Deployment Diagnostics</h2>
+      <p>Use this section to verify that the deployed HTML has linked CSS/JS bundles and the logo asset resolves.</p>
+      <ul style="list-style: none; padding: 0; margin: 1rem 0 0; display: grid; gap: 0.75rem;">
+        <li><strong>Build timestamp:</strong> <code>{buildTimestamp}</code></li>
+        <li><strong>Commit hash:</strong> <code>{shortCommitHash}</code></li>
+        <li><strong>Logo path:</strong> <code>{logo.src}</code></li>
+        <li><strong>Stylesheet link count:</strong> <span id="status-css-count">…</span></li>
+        <li><strong>Script tag count:</strong> <span id="status-js-count">…</span></li>
+      </ul>
+    </div>
+  </section>
+
+  <script is:inline>
+    const cssCount = document.querySelectorAll('link[rel="stylesheet"]').length;
+    const jsCount = document.querySelectorAll('script').length;
+    const cssNode = document.getElementById('status-css-count');
+    const jsNode = document.getElementById('status-js-count');
+
+    if (cssNode) cssNode.textContent = String(cssCount);
+    if (jsNode) jsNode.textContent = String(jsCount);
+  </script>
 </BaseLayout>

--- a/docs/infra/FRONTEND_GUARDRAILS.md
+++ b/docs/infra/FRONTEND_GUARDRAILS.md
@@ -1,0 +1,27 @@
+# gs-web Frontend Guardrails
+
+## Must-hold invariants
+
+1. **Pages configuration is fixed**
+   - Root: `apps/gs-web`
+   - Output: `dist`
+2. **Layout integrity**
+   - Pages in `apps/gs-web/src/pages/*` should render through `WebLayout` (or wrappers around it).
+3. **Global style source of truth**
+   - Global imports are enforced at layout level.
+   - Avoid duplicate global style imports in page files.
+4. **Asset strategy**
+   - Use Astro-imported assets for local files not in `public/`.
+   - Do not hardcode absolute `/assets/...` URLs unless those assets are actually in `public/assets`.
+5. **CSP compatibility**
+   - `script-src` and `style-src` must not block `/_astro/*` bundle execution/loading.
+6. **Pre-deploy integrity check required**
+   - `pnpm --filter @goldshore/gs-web build`
+   - `node scripts/verify-web-dist.mjs`
+
+## PR expectations for risky frontend changes
+
+For PRs that modify `apps/gs-web/src/layouts/WebLayout.astro` or shared theme globals:
+
+- Include dist verification output in the PR body.
+- Include one screenshot from local dev or preview showing layout and nav render correctly.

--- a/docs/infra/FRONTEND_INTEGRITY.md
+++ b/docs/infra/FRONTEND_INTEGRITY.md
@@ -1,0 +1,51 @@
+# Frontend Integrity (gs-web)
+
+This document defines the minimum checks that prevent unstyled or partially-loaded deploys for `apps/gs-web`.
+
+## Canonical Cloudflare Pages settings
+
+- Root directory: `apps/gs-web`
+- Build command: `corepack enable && pnpm install --frozen-lockfile && pnpm --filter @goldshore/gs-web build`
+- Build output directory: `dist`
+
+Framework preset is optional when command/output are explicitly set.
+
+## Layout and asset rules
+
+1. Pages should render through `src/layouts/WebLayout.astro` (directly or via wrappers).
+2. Global styling is imported at layout level; avoid duplicate page-level global imports.
+3. Prefer Astro/Vite asset imports for non-public assets:
+   - `import logo from '../assets/logo.svg'`
+   - `<img src={logo.src} />`
+4. Only use hardcoded absolute paths for files that are guaranteed under `public/`.
+
+## CSP rules
+
+CSP must allow Astro-emitted bundles under `/_astro/*` and any approved external font/icon providers.
+
+Minimum CSP baseline for gs-web:
+
+- `default-src 'self'`
+- `script-src 'self' 'unsafe-inline'`
+- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com`
+- `font-src 'self' https://fonts.gstatic.com`
+- `img-src 'self' data:`
+- `connect-src 'self'`
+
+If API calls require external origins, add explicit `connect-src` entries.
+
+## Dist verification
+
+Run after every build:
+
+```bash
+pnpm --filter @goldshore/gs-web build
+node scripts/verify-web-dist.mjs
+```
+
+The verification script fails if:
+
+- `apps/gs-web/dist/index.html` is missing
+- `apps/gs-web/dist/_astro/*.css` is missing
+- `apps/gs-web/dist/_astro/*.js` is missing
+- `index.html` does not reference `/_astro/` assets

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "branch:bootstrap": "bash scripts/branch-bootstrap.sh",
     "scaffold:worker": "node scripts/scaffold-worker.mjs",
     "workspaces:list": "pnpm -r list --depth -1",
-    "verify:workspace-filters": "turbo run build --filter=@goldshore/gs-api --dry && turbo run build --filter=@goldshore/gs-control --dry"
+    "verify:workspace-filters": "turbo run build --filter=@goldshore/gs-api --dry && turbo run build --filter=@goldshore/gs-control --dry",
+    "verify:web-dist": "node scripts/verify-web-dist.mjs"
   },
   "devDependencies": {
     "@astrojs/mdx": "^4.0.8",

--- a/scripts/verify-web-dist.mjs
+++ b/scripts/verify-web-dist.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.resolve('apps/gs-web/dist');
+const astroDir = path.join(distDir, '_astro');
+const indexPath = path.join(distDir, 'index.html');
+
+const errors = [];
+
+if (!existsSync(distDir)) {
+  errors.push(`Missing dist directory: ${distDir}`);
+}
+
+if (!existsSync(indexPath)) {
+  errors.push(`Missing index.html: ${indexPath}`);
+}
+
+const astroFiles = existsSync(astroDir) ? readdirSync(astroDir) : [];
+const cssFiles = astroFiles.filter((file) => file.endsWith('.css'));
+const jsFiles = astroFiles.filter((file) => file.endsWith('.js'));
+
+if (cssFiles.length === 0) {
+  errors.push('No CSS bundles found at apps/gs-web/dist/_astro/*.css');
+}
+
+if (jsFiles.length === 0) {
+  errors.push('No JS bundles found at apps/gs-web/dist/_astro/*.js');
+}
+
+if (existsSync(indexPath)) {
+  const indexHtml = readFileSync(indexPath, 'utf8');
+
+  if (!indexHtml.includes('<link')) {
+    errors.push('index.html does not include any <link tags.');
+  }
+
+  if (!indexHtml.includes('/_astro/')) {
+    errors.push('index.html does not reference /_astro/ assets.');
+  }
+
+  if (!indexHtml.includes('<script')) {
+    errors.push('index.html does not include any <script tags.');
+  }
+}
+
+if (errors.length > 0) {
+  console.error('❌ gs-web dist integrity check failed:\n');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ gs-web dist integrity check passed');
+console.log(`- CSS bundles: ${cssFiles.length}`);
+console.log(`- JS bundles: ${jsFiles.length}`);


### PR DESCRIPTION
## Summary
- added pre-deploy `gs-web` artifact validation to both production and preview Pages workflows
- added `scripts/verify-web-dist.mjs` and wired it as `pnpm verify:web-dist` (root) and `pnpm --filter @goldshore/gs-web verify:dist`
- enhanced `apps/gs-web/src/pages/status.astro` with deployment diagnostics (build timestamp, commit hash, resolved logo path, CSS/JS tag counts)
- documented integrity expectations in:
  - `docs/infra/FRONTEND_INTEGRITY.md`
  - `docs/infra/FRONTEND_GUARDRAILS.md`

## Why
This blocks broken deployments where HTML ships without required `/_astro` CSS/JS bundles and adds a live page for quick forensic verification.

## Validation
- `pnpm --filter @goldshore/gs-web build`
- `node scripts/verify-web-dist.mjs`
- `pnpm verify:web-dist`

@Jules-Bot [review-request]
Please review workflow gate placement, script failure semantics, and status-page diagnostic coverage for regressions related to unstyled/partially-loaded deploys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a41b622108331b27ce2ddbc7a21d2)