### PR TITLE
Fix action allowlist parsing for workflow `uses` entries

### DIFF
--- a/scripts/stabilization-check.mjs
+++ b/scripts/stabilization-check.mjs
@@ -134,13 +134,32 @@ try {
 
   // Check for unauthorized actions
   let unauthorizedActions = [];
+  const collectUsesValues = (node, accumulator = []) => {
+    if (Array.isArray(node)) {
+      node.forEach(item => collectUsesValues(item, accumulator));
+      return accumulator;
+    }
+
+    if (node && typeof node === 'object') {
+      Object.entries(node).forEach(([key, value]) => {
+        if (key === 'uses' && typeof value === 'string') {
+          accumulator.push(value);
+        }
+        collectUsesValues(value, accumulator);
+      });
+    }
+
+    return accumulator;
+  };
+
   workflows.forEach(w => {
     if (w.endsWith('.yml') || w.endsWith('.yaml')) {
       const content = fs.readFileSync(path.join(WORKFLOW_DIR, w), 'utf8');
-      const usesLines = content.split('\n').filter(l => l.trim().startsWith('uses:'));
-      usesLines.forEach(line => {
-        const actionPart = line.split('uses:')[1].trim();
-        const action = actionPart.split('@')[0];
+      const parsedWorkflow = parse(content);
+      const usesValues = collectUsesValues(parsedWorkflow);
+
+      usesValues.forEach(actionPart => {
+        const action = actionPart.split('@')[0].trim();
         // Allow local paths
         if (action.startsWith('./')) return;
         if (!ALLOWED_ACTIONS.includes(action)) {


### PR DESCRIPTION
### Motivation

- The workflow allowlist audit missed common step syntax because it only matched lines that trimmed to `uses:`, which skips typical `- uses: owner/action@ref` entries and can fail to detect unauthorized Actions.

### Description

- Updated `scripts/stabilization-check.mjs` to parse workflow YAML and recursively collect all `uses` keys instead of performing fragile line-prefix matching. 
- Added a `collectUsesValues` recursive traversal that extracts `uses` values from the parsed YAML and trims the action portion before the `@` to compare against `ALLOWED_ACTIONS`. 
- Continued to allow local actions that start with `./` and deduplicate reported unauthorized actions. 
- The change preserves the previous reporting behavior while closing the gap that could produce false "CI Actions compliant" results.

### Testing

- Ran `node --check scripts/stabilization-check.mjs` to validate the script syntax and it succeeded. 
- Executed a focused Node/YAML smoke test that parsed a sample workflow with `- uses:` entries and verified the recursive extractor returned `actions/checkout@v4,./local-action`. 
- Verified the script reports unauthorized external actions and ignores local actions as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a446afd5c8331a238921d5f634e98)