### PR TITLE
Stabilize gs-web homepage rendering by deduplicating theme/CSS imports

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -1,8 +1,4 @@
 ---
-import '@goldshore/theme/styles/tokens';
-import '@goldshore/theme/styles/base';
-import '@goldshore/theme/styles/components';
-import '@goldshore/theme/styles/layout';
 import '../styles/global.css';
 import { GSButton } from '@goldshore/ui';
 import logo from '../assets/logo.svg';

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import '@goldshore/theme/tokens';
 import { GSButton } from '@goldshore/ui';
 import MarketingLayout from '../layouts/MarketingLayout.astro';
 import '../styles/home.css';

--- a/apps/gs-web/src/styles/home.css
+++ b/apps/gs-web/src/styles/home.css
@@ -1,5 +1,3 @@
-@import './gs-effects.css';
-
 .home-hero,
 .home-features,
 .blueprint-section {


### PR DESCRIPTION
### Motivation
- The cinematic homepage suffered cascade and asset regressions after duplicate theme/style imports and theme refactors, breaking visual rendering.
- This change aims to perform a surgical, rendering-only stabilization limited to `apps/gs-web/**` to restore deterministic homepage styling without touching CI/workflows or admin code.

### Description
- Removed duplicate theme stylesheet imports from `apps/gs-web/src/layouts/WebLayout.astro` so the global theme chain is imported in one place (`global.css`).
- Removed redundant `@goldshore/theme/tokens` import from `apps/gs-web/src/pages/index.astro` to avoid duplicate token injection at the page entrypoint.
- Removed a duplicate `@import './gs-effects.css'` line from `apps/gs-web/src/styles/home.css` because effects are already included via the global theme chain.
- Scope-limited edits to `apps/gs-web/**` only and avoided changes to `.github/workflows`, admin, or infra files to prevent further merge/regression risk.

### Testing
- Ran `pnpm --filter @goldshore/gs-web build` which completed successfully and produced server + client artifacts under `apps/gs-web/dist/_astro` (CSS and JS bundles present).
- Verified presence of generated client assets with `find apps/gs-web/dist/_astro` returning the expected CSS/JS and logo files.
- Launched a dev preview and captured an automated screenshot of the homepage to confirm visual rendering; the dev server run did report an unrelated style parsing error in `DocsSearch.astro` (an existing parse issue) but the homepage build artifacts were produced successfully.

@Jules-Bot [review-request]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4f1ac9d883319a195196e15c1a00)