### PR TITLE
Add Option A canonical memory lock, docs, CI check, and drift validator

### DIFF
--- a/.github/workflows/canonical-structure-check.yml
+++ b/.github/workflows/canonical-structure-check.yml
@@ -1,0 +1,24 @@
+name: Canonical Structure Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  canonical-structure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate canonical structure memory lock
+        run: node scripts/validate-canonical-structure.mjs

--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -1,4 +1,19 @@
 ---
+/*
+CANONICAL ASSET POLICY (Option A)
+
+Assets must be located in:
+- apps/gs-web/public
+- apps/gs-web/src/assets
+
+Do NOT reference:
+- /public at root
+- astro-goldshore assets
+- legacy paths
+
+All logos must be imported via Astro or placed in public/.
+*/
+
 import '@goldshore/theme';
 import '/src/styles/global.css';
 import { GSButton } from '@goldshore/ui';

--- a/docs/infra/AGENT_MEMORY_LOCK.md
+++ b/docs/infra/AGENT_MEMORY_LOCK.md
@@ -1,0 +1,37 @@
+# Agent Memory Lock (Option A)
+
+## PHASE: MONOREPO MEMORY LOCK (Option A)
+
+You are operating under Canonical Structure Option A.
+
+Rules:
+1. Only mutate paths under:
+   - `apps/gs-*`
+   - `packages/*`
+   - `infra/*`
+2. Treat the following as read-only legacy:
+   - `astro-goldshore/*`
+   - `apps/web/*`
+   - `apps/admin/*`
+   - `root/public/*`
+   - `root/src/*`
+3. If both canonical and legacy equivalents exist, canonical wins.
+4. Never introduce new top-level apps.
+5. Never duplicate web or admin directories.
+6. Never modify Cloudflare root build target without explicit instruction.
+7. All build assumptions must use `BUILD_ROOT = apps/gs-web`.
+
+Violation handling:
+- Abort and report structural drift.
+
+## Jules memory protocol
+
+Jules is documentation and audit only.
+
+1. Never propose structural changes outside Option A canonical paths.
+2. If duplicate app surfaces are detected, flag **Structural Drift Warning**.
+3. Maintain `docs/infra/MONOREPO_CANONICAL_STATE.md`.
+4. Weekly audit confirms:
+   - No new root-level app directories.
+   - No duplicate theme systems.
+   - No new astro-goldshore modifications.

--- a/docs/infra/DEPLOYMENT_SOURCE_OF_TRUTH.md
+++ b/docs/infra/DEPLOYMENT_SOURCE_OF_TRUTH.md
@@ -1,0 +1,16 @@
+# Deployment Source of Truth
+
+## Cloudflare Pages lock (Option A)
+
+Gold Shore web deployments must use the canonical app surface only.
+
+- **Root directory:** `apps/gs-web`
+- **Build output directory:** `dist`
+
+## Change control
+
+Agents must not alter the Cloudflare root build target unless explicitly authorized with phase label:
+
+- `infra/build-root-change`
+
+Any proposed change without this phase label is structural drift and must be rejected.

--- a/docs/infra/MONOREPO_CANONICAL_STATE.md
+++ b/docs/infra/MONOREPO_CANONICAL_STATE.md
@@ -1,0 +1,61 @@
+# Monorepo Canonical State (Option A)
+
+## Canonical structure lock
+
+Gold Shore agents are locked to **Option A canonicalization**.
+
+### Mutable production surfaces
+
+- `apps/gs-web`
+- `apps/gs-admin`
+- `apps/gs-api`
+- `apps/gs-gateway`
+- `apps/gs-control`
+- `packages/*`
+- `infra/*`
+
+### Read-only legacy surfaces
+
+The following surfaces are considered legacy/read-only for agent operations:
+
+- `astro-goldshore/*`
+- `apps/web/*`
+- `apps/admin/*`
+- `public/*` (repo root)
+- `src/*` (repo root)
+
+## Single Canonical Surface Rule (SCSR)
+
+Before mutating a file, agents must verify the target path is canonical.
+
+```txt
+if path not in CANONICAL_PATHS:
+    abort("Mutation outside canonical scope")
+```
+
+## Cross-tree collision guard
+
+Agents must abort when a change set contains both canonical and legacy twins.
+
+Examples:
+
+- `apps/gs-web/**` and `apps/web/**`
+- `apps/gs-admin/**` and `apps/admin/**`
+
+## Build-root memory lock
+
+All web build assumptions must use:
+
+- `BUILD_ROOT = apps/gs-web`
+
+## Weekly audit checklist (Jules governance)
+
+- No new root-level app directories.
+- No duplicate theme systems.
+- No new modifications under `astro-goldshore`.
+
+## Memory anchor
+
+The machine-readable source of truth is:
+
+- `infra/AGENT_CANONICAL_STATE.json`

--- a/infra/AGENT_CANONICAL_STATE.json
+++ b/infra/AGENT_CANONICAL_STATE.json
@@ -1,0 +1,28 @@
+{
+  "canonical_structure": "Option-A-gs",
+  "production_apps": [
+    "apps/gs-web",
+    "apps/gs-admin",
+    "apps/gs-api",
+    "apps/gs-gateway",
+    "apps/gs-control"
+  ],
+  "legacy_paths": [
+    "astro-goldshore",
+    "apps/web",
+    "apps/admin",
+    "public",
+    "src"
+  ],
+  "build_root": "apps/gs-web",
+  "asset_policy": {
+    "public_dir": "apps/gs-web/public",
+    "src_assets": "apps/gs-web/src/assets",
+    "disallowed": [
+      "astro-goldshore",
+      "root/public",
+      "root/src"
+    ]
+  },
+  "memory_lock_version": "1.0"
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "scaffold:worker": "node scripts/scaffold-worker.mjs",
     "workspaces:list": "pnpm -r list --depth -1",
     "verify:workspace-filters": "turbo run build --filter=@goldshore/gs-api --dry && turbo run build --filter=@goldshore/gs-control --dry",
-    "verify:web-dist": "node scripts/verify-web-dist.mjs"
+    "verify:web-dist": "node scripts/verify-web-dist.mjs",
+    "memory:check": "node scripts/validate-canonical-structure.mjs"
   },
   "devDependencies": {
     "@astrojs/mdx": "^4.0.8",

--- a/scripts/validate-canonical-structure.mjs
+++ b/scripts/validate-canonical-structure.mjs
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const canonicalRoots = ['apps/gs-', 'packages/', 'infra/'];
+const canonicalTopLevelFiles = new Set(['package.json', 'pnpm-workspace.yaml', 'turbo.json', 'README.md']);
+const disallowed = ['apps/web', 'apps/admin', 'astro-goldshore', 'public', 'src'];
+
+const trackedChangedFiles = execSync('git diff --name-only HEAD', { encoding: 'utf8' })
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const mutableOutsideCanonical = trackedChangedFiles.filter((file) => {
+  if (file.startsWith('.github/workflows/')) return false;
+  if (file.startsWith('docs/')) return false;
+  if (file.startsWith('scripts/')) return false;
+  if (canonicalTopLevelFiles.has(file)) return false;
+  return !canonicalRoots.some((root) => file.startsWith(root));
+});
+
+if (mutableOutsideCanonical.length > 0) {
+  console.error('❌ Mutation outside canonical scope detected:');
+  mutableOutsideCanonical.forEach((file) => console.error(`  - ${file}`));
+  process.exit(1);
+}
+
+const changedSet = new Set(trackedChangedFiles);
+const hasGsWeb = trackedChangedFiles.some((f) => f.startsWith('apps/gs-web/'));
+const hasLegacyWeb = trackedChangedFiles.some((f) => f.startsWith('apps/web/'));
+const hasGsAdmin = trackedChangedFiles.some((f) => f.startsWith('apps/gs-admin/'));
+const hasLegacyAdmin = trackedChangedFiles.some((f) => f.startsWith('apps/admin/'));
+
+if ((hasGsWeb && hasLegacyWeb) || (hasGsAdmin && hasLegacyAdmin)) {
+  console.error('❌ Duplicate surface mutation detected (canonical + legacy trees changed together).');
+  process.exit(1);
+}
+
+let drift = false;
+for (const path of disallowed) {
+  if (fs.existsSync(path) && Array.from(changedSet).some((f) => f === path || f.startsWith(`${path}/`))) {
+    console.warn(`⚠ Structural drift detected: ${path}`);
+    drift = true;
+  }
+}
+
+if (drift) {
+  process.exit(1);
+}
+
+console.log('✅ Canonical structure valid.');


### PR DESCRIPTION
### Motivation
- Establish a single canonical mutation surface (Option A) so agents only modify `apps/gs-*`, `packages/*`, and `infra/*` to prevent deployment and asset drift. 
- Provide a machine-readable anchor and human governance docs so automated agents and auditors can reference a single source of truth. 
- Fail CI early on structural-drift changes to keep build root and asset policies stable and deterministic.

### Description
- Add `infra/AGENT_CANONICAL_STATE.json` as the machine-readable canonical memory anchor for Option A. 
- Add governance documentation `docs/infra/MONOREPO_CANONICAL_STATE.md`, `docs/infra/AGENT_MEMORY_LOCK.md`, and `docs/infra/DEPLOYMENT_SOURCE_OF_TRUTH.md`. 
- Add a drift-detection script `scripts/validate-canonical-structure.mjs` that enforces canonical mutation scope, allows selected top-level workspace files, detects canonical/legacy twin edits, and fails on legacy-path mutations. 
- Wire up `memory:check` in `package.json` and add a GitHub Actions job `.github/workflows/canonical-structure-check.yml` to run the script on PRs and pushes to `main`, and add a canonical asset policy header to `apps/gs-web/src/layouts/WebLayout.astro`.

### Testing
- Ran `node scripts/validate-canonical-structure.mjs` during development, which initially reported a non-canonical change for `package.json` and after allowing top-level workspace files the script ran again and returned `✅ Canonical structure valid.`. 
- Committed the changes and the new workflow will exercise the same validation in CI on future PRs. 
- Requesting review: `@Jules-Bot [review-request]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a930c120c8331b05f449a19d67afb)