### PR TITLE
Fix Cloudflare metrics typing and mock payload in gs-admin

### DIFF
--- a/apps/gs-admin/src/lib/cloudflare.ts
+++ b/apps/gs-admin/src/lib/cloudflare.ts
@@ -13,11 +13,20 @@ export type ChartMetrics = {
 };
 
 export type CloudflareMetrics = {
+  source: 'live' | 'mock';
+  refreshedAt: string;
+  note: string;
   highlights: {
     totalRequests: string;
     cacheHitRate: string;
     threatsBlocked: string;
     dnsChanges: string;
+  };
+  charts: {
+    traffic: ChartMetrics;
+    cache: ChartMetrics;
+    threats: ChartMetrics;
+    dns: ChartMetrics;
   };
 };
 
@@ -25,11 +34,78 @@ export function getCloudflareContext(locals: any) {
   return locals.runtime?.env || process.env;
 }
 
-export async function getCloudflareMetrics() {
+export async function getCloudflareMetrics(): Promise<CloudflareMetrics> {
   return {
-    requests: 0,
-    bandwidth: 0,
-    threats: 0,
-    pageViews: 0
+    source: 'mock',
+    refreshedAt: new Date().toISOString(),
+    note: 'Demo metrics while Cloudflare API integration is being finalized.',
+    highlights: {
+      totalRequests: '12.4M',
+      cacheHitRate: '92.8%',
+      threatsBlocked: '18.2K',
+      dnsChanges: '14',
+    },
+    charts: {
+      traffic: {
+        title: 'Traffic Volume',
+        description: 'Request totals by day for the last week.',
+        summary: '+11%',
+        trend: 'up',
+        series: [
+          { label: 'Mon', value: 1400000, display: '1.4M' },
+          { label: 'Tue', value: 1560000, display: '1.56M' },
+          { label: 'Wed', value: 1710000, display: '1.71M' },
+          { label: 'Thu', value: 1650000, display: '1.65M' },
+          { label: 'Fri', value: 1880000, display: '1.88M' },
+          { label: 'Sat', value: 1760000, display: '1.76M' },
+          { label: 'Sun', value: 1820000, display: '1.82M' },
+        ],
+      },
+      cache: {
+        title: 'Cache Performance',
+        description: 'Edge cache hit rate trends over seven days.',
+        summary: 'Stable',
+        trend: 'neutral',
+        series: [
+          { label: 'Mon', value: 91, display: '91%' },
+          { label: 'Tue', value: 92, display: '92%' },
+          { label: 'Wed', value: 93, display: '93%' },
+          { label: 'Thu', value: 92, display: '92%' },
+          { label: 'Fri', value: 94, display: '94%' },
+          { label: 'Sat', value: 93, display: '93%' },
+          { label: 'Sun', value: 92, display: '92%' },
+        ],
+      },
+      threats: {
+        title: 'Security Events',
+        description: 'Blocked threats across WAF and bot protection layers.',
+        summary: '-6%',
+        trend: 'down',
+        series: [
+          { label: 'Mon', value: 2900, display: '2.9K' },
+          { label: 'Tue', value: 2800, display: '2.8K' },
+          { label: 'Wed', value: 2700, display: '2.7K' },
+          { label: 'Thu', value: 2600, display: '2.6K' },
+          { label: 'Fri', value: 2500, display: '2.5K' },
+          { label: 'Sat', value: 2400, display: '2.4K' },
+          { label: 'Sun', value: 2300, display: '2.3K' },
+        ],
+      },
+      dns: {
+        title: 'DNS Change Activity',
+        description: 'Recent DNS record updates and propagation events.',
+        summary: '+2 changes',
+        trend: 'up',
+        series: [
+          { label: 'Mon', value: 1, display: '1' },
+          { label: 'Tue', value: 3, display: '3' },
+          { label: 'Wed', value: 2, display: '2' },
+          { label: 'Thu', value: 2, display: '2' },
+          { label: 'Fri', value: 1, display: '1' },
+          { label: 'Sat', value: 3, display: '3' },
+          { label: 'Sun', value: 2, display: '2' },
+        ],
+      },
+    },
   };
 }


### PR DESCRIPTION
### Motivation

- Resolve a TypeScript/frontmatter regression that caused admin builds to fail due to an unclosed/mismatched Cloudflare metrics type and ensure the admin index page frontmatter is valid for Astro rendering.

### Description

- Closed and tightened the `CloudflareMetrics` contract in `apps/gs-admin/src/lib/cloudflare.ts` by adding `source`, `refreshedAt`, `note`, `highlights`, and `charts` fields and ensuring the type is syntactically correct.
- Updated `getCloudflareMetrics()` to return `Promise<CloudflareMetrics>` and provide a realistic mock payload that matches the shape consumed by `apps/gs-admin/src/pages/admin/analytics.astro`.
- Verified the admin index page frontmatter is a single valid block in `apps/gs-admin/src/pages/index.astro` so imports remain in scope for the page (no changes required to fix it).

### Testing

- Built the admin app successfully with `pnpm --filter @goldshore/gs-admin build`, and the build completed without errors.
- Confirmed the updated `apps/gs-admin/src/lib/cloudflare.ts` compiles and aligns with usages in `apps/gs-admin/src/pages/admin/analytics.astro` by running the build which includes type generation and bundling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4e4ea6e08331a1d1ce40ee5aebd6)