### PR TITLE
Pin baseline CI checkout to triggering SHA

### DIFF
--- a/scripts/phase1-ci-baseline.sh
+++ b/scripts/phase1-ci-baseline.sh
@@ -64,8 +64,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main
-        run: git clone ${{ github.server_url }}/${{ github.repository }} .
+      - name: Checkout triggering revision
+        run: |
+          git init .
+          git remote add origin ${{ github.server_url }}/${{ github.repository }}
+          git fetch --no-tags --depth=1 origin ${{ github.sha }}
+          git checkout --detach FETCH_HEAD
 
       - name: Setup Node
         run: |


### PR DESCRIPTION
### Motivation
- Ensure the generated baseline workflow runs against the exact commit that triggered the event rather than the repository default HEAD, so CI results accurately reflect the PR/push under test.

### Description
- Replace the `git clone ${{ github.server_url }}/${{ github.repository }} .` step with an explicit sequence that initializes the repo, adds the remote, fetches the event `SHA`, and checks out the fetched commit using `git init`, `git remote add origin`, `git fetch --no-tags --depth=1 origin ${{ github.sha }}`, and `git checkout --detach FETCH_HEAD`.
- Rename the step from `Checkout main` to `Checkout triggering revision` to make the intent explicit.
- Change applied in `scripts/phase1-ci-baseline.sh` where the baseline workflow template is generated.

### Testing
- Ran `bash -n scripts/phase1-ci-baseline.sh` to verify there are no shell syntax errors and it completes successfully. 
- Verified the updated script produces the modified workflow snippet with the pinned checkout sequence without introducing parse errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a48a1f9848331b73a7dee565c860e)