### PR TITLE
fix(gs-web): allow head slot injection in WebLayout

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -38,6 +38,7 @@ const logoSrc = logo.src;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <slot name="head" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://api.goldshore.ai https://api-preview.goldshore.ai; object-src 'none'; base-uri 'self';" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <!-- Bolt: Preconnect to external origins to speed up resource loading -->


### PR DESCRIPTION
### Motivation
- Allow route-specific pages to inject metadata and head tags into the shared web layout without breaking the global layout or duplicating head markup.

### Description
- Add a named `<slot name="head" />` to `apps/gs-web/src/layouts/WebLayout.astro` inside the `<head>` so pages can provide page-scoped head content.

### Testing
- Ran `pnpm -C apps/gs-web build` which completed successfully; @Jules-Bot [review-request]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa56b58088331ae95ff4c97ac4c2a)