### PR TITLE
chore(theme): canonicalize theme package manifest and consumer imports

### DIFF
--- a/apps/gs-admin/src/layouts/AdminLayout.astro
+++ b/apps/gs-admin/src/layouts/AdminLayout.astro
@@ -1,7 +1,7 @@
 ---
 import Sidebar from '../components/Sidebar.astro';
 import Topbar from '../components/Topbar.astro';
-import '@goldshore/theme/styles/global.css';
+import '@goldshore/theme';
 import type { AdminPermission, AdminRole } from '@goldshore/auth';
 
 interface Props {

--- a/packages/config/src/scaffold/index.astro
+++ b/packages/config/src/scaffold/index.astro
@@ -1,5 +1,5 @@
 ---
-import '@goldshore/theme/src/styles/tokens.css';
+import '@goldshore/theme';
 import { GSButton } from '@goldshore/ui';
 import MarketingLayout from '../layouts/MarketingLayout.astro';
 import '../styles/home.css';

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goldshore/theme",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "index.css",
@@ -11,15 +11,7 @@
     "assets/*"
   ],
   "exports": {
-    ".": "./index.css",
-    "./tokens": "./src/styles/tokens.css",
-    "./styles/tokens": "./src/styles/tokens.css",
-    "./styles/base": "./src/styles/base.css",
-    "./styles/components": "./src/styles/components.css",
-    "./styles/layout": "./src/styles/layout.css",
-    "./styles/global.css": "./src/styles/global.css",
-    "./manager": "./src/theme-manager.ts",
-    "./assets/logo.svg": "./assets/logo.svg"
+    ".": "./index.css"
   },
   "scripts": {
     "test": "node --experimental-strip-types --test src/*.test.ts"


### PR DESCRIPTION
### Motivation
- Provide a single, canonical CSS entrypoint for the theme package and bump the package to a stable `1.0.0` to prevent consumers from importing internal CSS subpaths and creating multiple entrypoints.

### Description
- Updated `packages/theme/package.json` to set `version` to `1.0.0`, keep `name` as `@goldshore/theme` and `type` as `module`, and reduce the `exports` map to only `".": "./index.css"` while removing per-file subpath exports (tokens, styles, manager, assets). 
- Replaced consumer imports that referenced internal CSS files with the package-root import `@goldshore/theme` in `apps/gs-admin/src/layouts/AdminLayout.astro` and `packages/config/src/scaffold/index.astro`.
- Left other package fields (e.g. `main`, `files`, `scripts`) intact to preserve packaging behavior.

### Testing
- Ran `rg -n "@goldshore/theme/(styles|src/styles|tokens|layout)"` to verify there are no remaining per-file CSS subpath imports and the search returned no active matches.
- Ran `rg -n "@goldshore/theme" apps packages --glob '!**/*.md'` to confirm active app/package consumers now reference the package root and the search verified the updated imports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acab5c7748331a8ef45b5681bfb2f)