### PR TITLE
[PR #1926 follow-up] Fix gs-web WebLayout stylesheet import regression

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '@goldshore/theme/styles/global.css';
-import '../styles/global.css';
+import '../styles/gs-effects.css';
+import '../styles/layout.css';
 import { GSButton } from '@goldshore/ui';
 import logo from '../assets/logo.svg';
 


### PR DESCRIPTION
### Motivation
- Restore a valid stylesheet import chain in `apps/gs-web/src/layouts/WebLayout.astro` to eliminate a release-blocking regression caused by relying on an incorrect/aggregation import path.

### Description
- Replace the broken `../styles/global.css` import with direct imports of `../styles/gs-effects.css` and `../styles/layout.css` in `WebLayout.astro` so the layout references concrete existing stylesheet files.
- Commit the change and open a targeted follow-up PR on top of the original "Stabilize gs-web layout stylesheet import chain" work.

### Testing
- Ran `pnpm -C apps/gs-web astro build` after the change and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699adda491048331ab8897b83a5b9215)