### PR TITLE
Add dynamic reduced-motion guards for theme motion features

### DIFF
--- a/packages/theme/index.ts
+++ b/packages/theme/index.ts
@@ -6,67 +6,88 @@ export function initGoldShoreUI() {
   initReveal();
 }
 
+const reducedMotionQuery =
+  window.matchMedia?.('(prefers-reduced-motion: reduce)') ?? null;
+
+function prefersReducedMotion(): boolean {
+  return reducedMotionQuery?.matches ?? false;
+}
+
+function onReducedMotionChange(listener: (reduceMotion: boolean) => void) {
+  if (!reducedMotionQuery?.addEventListener) return;
+  reducedMotionQuery.addEventListener('change', (event) =>
+    listener(event.matches),
+  );
+}
+
 function initNav() {
-  const toggle = document.querySelector<HTMLButtonElement>("[data-gs-nav-toggle]");
-  const panel = document.querySelector<HTMLElement>("[data-gs-mobile-panel]");
+  const toggle = document.querySelector<HTMLButtonElement>(
+    '[data-gs-nav-toggle]',
+  );
+  const panel = document.querySelector<HTMLElement>('[data-gs-mobile-panel]');
   if (!toggle || !panel) return;
 
   const setOpen = (open: boolean) => {
-    toggle.setAttribute("aria-expanded", open ? "true" : "false");
-    panel.classList.toggle("is-open", open);
-    document.documentElement.classList.toggle("gs-lock", open);
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    panel.classList.toggle('is-open', open);
+    document.documentElement.classList.toggle('gs-lock', open);
   };
 
-  toggle.addEventListener("click", () => {
-    const open = toggle.getAttribute("aria-expanded") === "true";
+  toggle.addEventListener('click', () => {
+    const open = toggle.getAttribute('aria-expanded') === 'true';
     setOpen(!open);
   });
 
-  panel.addEventListener("click", (e) => {
+  panel.addEventListener('click', (e) => {
     const t = e.target as HTMLElement;
-    if (t.matches("[data-gs-nav-close]") || t.matches("[data-gs-mobile-panel]")) setOpen(false);
+    if (t.matches('[data-gs-nav-close]') || t.matches('[data-gs-mobile-panel]'))
+      setOpen(false);
   });
 
-  window.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") setOpen(false);
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') setOpen(false);
   });
 }
 
 function initModal() {
-  const root = document.querySelector<HTMLElement>("[data-gs-modal]");
+  const root = document.querySelector<HTMLElement>('[data-gs-modal]');
   if (!root) return;
 
-  const backdrop = root.querySelector<HTMLElement>("[data-gs-modal-backdrop]");
-  const closeBtn = root.querySelector<HTMLButtonElement>("[data-gs-modal-close]");
-  const body = root.querySelector<HTMLElement>("[data-gs-modal-body]");
+  const backdrop = root.querySelector<HTMLElement>('[data-gs-modal-backdrop]');
+  const closeBtn = root.querySelector<HTMLButtonElement>(
+    '[data-gs-modal-close]',
+  );
+  const body = root.querySelector<HTMLElement>('[data-gs-modal-body]');
 
   const openModal = (html: string) => {
     if (body) body.innerHTML = html;
-    root.classList.add("is-open");
-    document.documentElement.classList.add("gs-lock");
+    root.classList.add('is-open');
+    document.documentElement.classList.add('gs-lock');
   };
 
   const closeModal = () => {
-    root.classList.remove("is-open");
-    document.documentElement.classList.remove("gs-lock");
+    root.classList.remove('is-open');
+    document.documentElement.classList.remove('gs-lock');
   };
 
-  document.addEventListener("click", (e) => {
+  document.addEventListener('click', (e) => {
     const el = e.target as HTMLElement;
-    const trigger = el.closest<HTMLElement>("[data-gs-modal-open]");
+    const trigger = el.closest<HTMLElement>('[data-gs-modal-open]');
     if (!trigger) return;
 
-    const variant = trigger.getAttribute("data-gs-modal-open") || "subscribe";
+    const variant = trigger.getAttribute('data-gs-modal-open') || 'subscribe';
     openModal(getModalTemplate(variant));
   });
 
-  backdrop?.addEventListener("click", closeModal);
-  closeBtn?.addEventListener("click", closeModal);
-  window.addEventListener("keydown", (e) => (e.key === "Escape" ? closeModal() : null));
+  backdrop?.addEventListener('click', closeModal);
+  closeBtn?.addEventListener('click', closeModal);
+  window.addEventListener('keydown', (e) =>
+    e.key === 'Escape' ? closeModal() : null,
+  );
 }
 
 function getModalTemplate(variant: string): string {
-  if (variant === "admin") {
+  if (variant === 'admin') {
     return `
       <div class="gs-modal-head">
         <div class="gs-kicker gs-signal">Secure Access</div>
@@ -97,83 +118,201 @@ function getModalTemplate(variant: string): string {
 
 function initParallax() {
   const root = document.documentElement;
+  const hero = document.querySelector<HTMLElement>('[data-gs-hero]');
+  const layers =
+    hero?.querySelectorAll<HTMLElement>('[data-gs-parallax]') ?? [];
+  let scrollBound = false;
+  let pointerBound = false;
+
   const onScroll = () => {
     const y = window.scrollY || 0;
-    root.style.setProperty("--gs-parallax", `${y * -0.15}px`);
+    root.style.setProperty('--gs-parallax', `${y * -0.15}px`);
   };
 
-  onScroll();
-  window.addEventListener("scroll", onScroll, { passive: true });
-
-  const hero = document.querySelector<HTMLElement>("[data-gs-hero]");
-  if (!hero) return;
-
-  const layers = hero.querySelectorAll<HTMLElement>("[data-gs-parallax]");
-  if (!layers.length) return;
-
   const onMove = (e: PointerEvent) => {
+    if (!hero || !layers.length) return;
+
     const r = hero.getBoundingClientRect();
     const px = (e.clientX - r.left) / r.width - 0.5;
     const py = (e.clientY - r.top) / r.height - 0.5;
 
     layers.forEach((layer) => {
-      const depth = Number(layer.getAttribute("data-gs-parallax")) || 1;
+      const depth = Number(layer.getAttribute('data-gs-parallax')) || 1;
       const x = px * depth * 10;
       const y = py * depth * 10;
       layer.style.transform = `translate3d(${x}px, ${y}px, 0)`;
     });
   };
 
-  const rm = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
-  if (!rm) hero.addEventListener("pointermove", onMove);
+  const resetParallax = () => {
+    root.style.setProperty('--gs-parallax', '0px');
+    layers.forEach((layer) => {
+      layer.style.transform = 'translate3d(0px, 0px, 0px)';
+    });
+  };
+
+  const disableParallax = () => {
+    if (scrollBound) {
+      window.removeEventListener('scroll', onScroll);
+      scrollBound = false;
+    }
+
+    if (pointerBound && hero) {
+      hero.removeEventListener('pointermove', onMove);
+      pointerBound = false;
+    }
+
+    resetParallax();
+  };
+
+  const enableParallax = () => {
+    if (!scrollBound) {
+      window.addEventListener('scroll', onScroll, { passive: true });
+      scrollBound = true;
+    }
+
+    onScroll();
+
+    if (!pointerBound && hero && layers.length) {
+      hero.addEventListener('pointermove', onMove);
+      pointerBound = true;
+    }
+  };
+
+  const syncParallaxMotion = (reduceMotion: boolean) => {
+    if (reduceMotion) {
+      disableParallax();
+      return;
+    }
+
+    enableParallax();
+  };
+
+  syncParallaxMotion(prefersReducedMotion());
+  onReducedMotionChange(syncParallaxMotion);
 }
 
 function initTilt() {
-  const cards = document.querySelectorAll<HTMLElement>(".gs-tilt");
+  const cards = document.querySelectorAll<HTMLElement>('.gs-tilt');
   if (!cards.length) return;
 
-  const isFine = window.matchMedia?.("(pointer:fine)")?.matches;
+  const isFine = window.matchMedia?.('(pointer:fine)')?.matches;
   if (!isFine) return;
 
-  cards.forEach((el) => {
-    const max = 7;
-    const onMove = (e: PointerEvent) => {
-      const r = el.getBoundingClientRect();
-      const px = (e.clientX - r.left) / r.width;
-      const py = (e.clientY - r.top) / r.height;
-      const tiltY = (px - 0.5) * (max * 2);
-      const tiltX = (0.5 - py) * (max * 2);
-      el.style.setProperty("--tiltX", `${tiltX.toFixed(2)}deg`);
-      el.style.setProperty("--tiltY", `${tiltY.toFixed(2)}deg`);
-    };
-    const reset = () => {
-      el.style.setProperty("--tiltX", "0deg");
-      el.style.setProperty("--tiltY", "0deg");
-    };
+  const listeners = new Map<
+    HTMLElement,
+    {
+      onMove: (e: PointerEvent) => void;
+      reset: () => void;
+    }
+  >();
 
-    el.addEventListener("pointermove", onMove);
-    el.addEventListener("pointerleave", reset);
-  });
+  const resetTilt = () => {
+    cards.forEach((el) => {
+      el.style.setProperty('--tiltX', '0deg');
+      el.style.setProperty('--tiltY', '0deg');
+    });
+  };
+
+  const disableTilt = () => {
+    cards.forEach((el) => {
+      const bound = listeners.get(el);
+      if (!bound) return;
+
+      el.removeEventListener('pointermove', bound.onMove);
+      el.removeEventListener('pointerleave', bound.reset);
+      listeners.delete(el);
+    });
+
+    resetTilt();
+  };
+
+  const enableTilt = () => {
+    cards.forEach((el) => {
+      if (listeners.has(el)) return;
+
+      const max = 7;
+      const onMove = (e: PointerEvent) => {
+        const r = el.getBoundingClientRect();
+        const px = (e.clientX - r.left) / r.width;
+        const py = (e.clientY - r.top) / r.height;
+        const tiltY = (px - 0.5) * (max * 2);
+        const tiltX = (0.5 - py) * (max * 2);
+        el.style.setProperty('--tiltX', `${tiltX.toFixed(2)}deg`);
+        el.style.setProperty('--tiltY', `${tiltY.toFixed(2)}deg`);
+      };
+      const reset = () => {
+        el.style.setProperty('--tiltX', '0deg');
+        el.style.setProperty('--tiltY', '0deg');
+      };
+
+      listeners.set(el, { onMove, reset });
+      el.addEventListener('pointermove', onMove);
+      el.addEventListener('pointerleave', reset);
+    });
+  };
+
+  const syncTiltMotion = (reduceMotion: boolean) => {
+    if (reduceMotion) {
+      disableTilt();
+      return;
+    }
+
+    enableTilt();
+  };
+
+  syncTiltMotion(prefersReducedMotion());
+  onReducedMotionChange(syncTiltMotion);
 }
 
 function initReveal() {
-  const rm = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
-  if (rm) return;
-
-  const els = Array.from(document.querySelectorAll<HTMLElement>("[data-gs-reveal]"));
+  const els = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-gs-reveal]'),
+  );
   if (!els.length) return;
 
-  const io = new IntersectionObserver(
-    (entries) => {
-      for (const ent of entries) {
-        if (ent.isIntersecting) {
-          (ent.target as HTMLElement).classList.add("is-in");
-          io.unobserve(ent.target);
-        }
-      }
-    },
-    { threshold: 0.15 }
-  );
+  let io: IntersectionObserver | null = null;
 
-  els.forEach((el) => io.observe(el));
+  const revealAll = () => {
+    els.forEach((el) => el.classList.add('is-in'));
+  };
+
+  const disconnectReveal = () => {
+    if (!io) return;
+    io.disconnect();
+    io = null;
+  };
+
+  const observeReveal = () => {
+    if (io) return;
+
+    io = new IntersectionObserver(
+      (entries) => {
+        for (const ent of entries) {
+          if (ent.isIntersecting) {
+            (ent.target as HTMLElement).classList.add('is-in');
+            io?.unobserve(ent.target);
+          }
+        }
+      },
+      { threshold: 0.15 },
+    );
+
+    els
+      .filter((el) => !el.classList.contains('is-in'))
+      .forEach((el) => io?.observe(el));
+  };
+
+  const syncRevealMotion = (reduceMotion: boolean) => {
+    if (reduceMotion) {
+      disconnectReveal();
+      revealAll();
+      return;
+    }
+
+    observeReveal();
+  };
+
+  syncRevealMotion(prefersReducedMotion());
+  onReducedMotionChange(syncRevealMotion);
 }


### PR DESCRIPTION
### Motivation
- Ensure the UI respects the `prefers-reduced-motion` setting consistently across parallax, tilt, and reveal behaviors.\
- Allow motion features to disable or re-enable at runtime when the user updates system motion preferences without requiring a page reload.

### Description
- Add a module-scoped `matchMedia('(prefers-reduced-motion: reduce)')` helper and expose `prefersReducedMotion()` and `onReducedMotionChange()` to centralize detection and change handling.\
- Refactor `initParallax` to attach/detach scroll and pointer listeners dynamically, reset the `--gs-parallax` CSS variable to `0px`, and reset layer transforms when reduced motion is active.\
- Refactor `initTilt` to manage per-card pointer listeners, reset `--tiltX`/`--tiltY` to neutral values when disabled, and toggle listeners based on preference changes.\
- Refactor `initReveal` to either observe elements via `IntersectionObserver` or force-add `.is-in` and disconnect the observer when reduced motion is enabled, and to toggle behavior on preference changes.

### Testing
- Ran `pnpm exec prettier --check packages/theme/index.ts` which passed after formatting was applied.\
- Ran `pnpm lint` which failed due to unrelated, pre-existing lint errors in other packages/apps and not due to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b713633c48331b4a03a426dfffe32)