### PR TITLE
🧹 fix: add missing reduced motion imports and utilities

### DIFF
--- a/packages/theme/index.ts
+++ b/packages/theme/index.ts
@@ -1,3 +1,5 @@
+import { prefersReducedMotion, onReducedMotionChange } from './src/motion';
+
 export function initGoldShoreUI() {
   initNav();
   initModal();

--- a/packages/theme/src/motion.test.ts
+++ b/packages/theme/src/motion.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { prefersReducedMotion, onReducedMotionChange } from './motion.ts';
+
+test('prefersReducedMotion', async (t) => {
+  await t.test('returns true if media query matches', (t) => {
+    const matchMediaMock = t.mock.fn((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+
+    // @ts-ignore
+    global.window = { matchMedia: matchMediaMock };
+
+    assert.strictEqual(prefersReducedMotion(), true);
+    assert.strictEqual(matchMediaMock.mock.callCount(), 1);
+  });
+
+  await t.test('returns false if media query does not match', (t) => {
+    const matchMediaMock = t.mock.fn(() => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+
+    // @ts-ignore
+    global.window = { matchMedia: matchMediaMock };
+
+    assert.strictEqual(prefersReducedMotion(), false);
+  });
+
+  await t.test('returns false if window is undefined', () => {
+    // @ts-ignore
+    global.window = undefined;
+    assert.strictEqual(prefersReducedMotion(), false);
+  });
+});
+
+test('onReducedMotionChange', async (t) => {
+  await t.test('registers and unregisters listener', (t) => {
+    const addEventListenerMock = t.mock.fn();
+    const removeEventListenerMock = t.mock.fn();
+    const matchMediaMock = t.mock.fn(() => ({
+      matches: false,
+      addEventListener: addEventListenerMock,
+      removeEventListener: removeEventListenerMock,
+    }));
+
+    // @ts-ignore
+    global.window = { matchMedia: matchMediaMock };
+
+    const callback = t.mock.fn();
+    const cleanup = onReducedMotionChange(callback);
+
+    assert.strictEqual(addEventListenerMock.mock.callCount(), 1);
+    assert.strictEqual(addEventListenerMock.mock.calls[0].arguments[0], 'change');
+
+    cleanup();
+    assert.strictEqual(removeEventListenerMock.mock.callCount(), 1);
+    assert.strictEqual(removeEventListenerMock.mock.calls[0].arguments[0], 'change');
+  });
+
+  await t.test('callback is executed when media query changes', (t) => {
+    let listener: (event: any) => void = () => {};
+    const addEventListenerMock = t.mock.fn((_type: string, l: any) => {
+      listener = l;
+    });
+
+    const matchMediaMock = t.mock.fn(() => ({
+      matches: false,
+      addEventListener: addEventListenerMock,
+      removeEventListener: () => {},
+    }));
+
+    // @ts-ignore
+    global.window = { matchMedia: matchMediaMock };
+
+    const callback = t.mock.fn();
+    onReducedMotionChange(callback);
+
+    listener({ matches: true });
+    assert.strictEqual(callback.mock.callCount(), 1);
+    assert.strictEqual(callback.mock.calls[0].arguments[0], true);
+
+    listener({ matches: false });
+    assert.strictEqual(callback.mock.callCount(), 2);
+    assert.strictEqual(callback.mock.calls[1].arguments[0], false);
+  });
+});

--- a/packages/theme/src/motion.ts
+++ b/packages/theme/src/motion.ts
@@ -1,0 +1,31 @@
+/**
+ * Detects if the user has requested reduced motion at the system level.
+ * @returns boolean
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Listens for changes in the user's reduced motion preference.
+ * @param callback Function to call when preference changes
+ * @returns Cleanup function to remove the listener
+ */
+export function onReducedMotionChange(callback: (reduced: boolean) => void): () => void {
+  if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+
+  const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  const handler = (event: MediaQueryListEvent) => callback(event.matches);
+
+  if (mediaQuery.addEventListener) {
+    mediaQuery.addEventListener('change', handler);
+    return () => mediaQuery.removeEventListener('change', handler);
+  } else {
+    // Fallback for older browsers
+    // @ts-ignore
+    mediaQuery.addListener(handler);
+    // @ts-ignore
+    return () => mediaQuery.removeListener(handler);
+  }
+}


### PR DESCRIPTION
Added prefersReducedMotion and onReducedMotionChange utility functions to packages/theme/src/motion.ts and imported them in packages/theme/index.ts to resolve missing function errors.

- Implemented prefersReducedMotion utility
- Implemented onReducedMotionChange utility with legacy fallback
- Added comprehensive unit tests for new utilities
- Updated theme runtime entrypoint with necessary imports