### PR TITLE
[PR #2281 follow-up] Fix plan-mode side effects and Turbo task detection

### DIFF
--- a/scripts/merge/merge_engine.py
+++ b/scripts/merge/merge_engine.py
@@ -29,9 +29,10 @@ def archive_legacy(src_root, archive_root):
     shutil.copytree(src_root, archive_root)
 
 
-def handle_file(src, dest, report):
+def handle_file(src, dest, report, mode):
     if not dest.exists():
-        copy_file(src, dest)
+        if mode == "apply":
+            copy_file(src, dest)
         report["copied"].append(str(dest))
         return
 
@@ -40,12 +41,14 @@ def handle_file(src, dest, report):
         return
 
     if src.suffix == ".json":
-        deep_merge_json(dest, src)
+        if mode == "apply":
+            deep_merge_json(dest, src)
         report["json_merged"].append(str(dest))
         return
 
     if ".github/workflows" in str(dest):
-        merge_workflows(dest, src)
+        if mode == "apply":
+            merge_workflows(dest, src)
         report["workflow_merged"].append(str(dest))
         return
 
@@ -55,6 +58,7 @@ def handle_file(src, dest, report):
 def run(target, legacy, archive, mode):
     report = {
         "timestamp": datetime.utcnow().isoformat(),
+        "mode": mode,
         "copied": [],
         "identical": [],
         "json_merged": [],
@@ -70,7 +74,7 @@ def run(target, legacy, archive, mode):
             src = Path(root) / f
             rel = src.relative_to(legacy)
             dest = target / rel
-            handle_file(src, dest, report)
+            handle_file(src, dest, report, mode)
 
     if mode == "apply":
         archive_legacy(legacy, target / archive)

--- a/scripts/merge/turbo_validator.py
+++ b/scripts/merge/turbo_validator.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 def validate_turbo():
     config = json.loads(Path("turbo.json").read_text())
-    pipelines = config.get("pipeline", {})
-    if "build" not in pipelines:
+    tasks = config.get("tasks")
+    if not isinstance(tasks, dict):
+        tasks = config.get("pipeline", {})
+
+    if "build" not in tasks:
         raise Exception("Turbo build pipeline missing")


### PR DESCRIPTION
### Motivation
- Prevent destructive side effects during `plan` runs by ensuring the merge engine does not write or modify target files while still reporting intended actions.
- Make Turbo pipeline validation compatible with modern Turbo configuration files that use the `tasks` root key to avoid false negatives.

### Description
- Updated `scripts/merge/merge_engine.py` so `handle_file()` accepts a `mode` argument and only performs write operations (`copy_file`, `deep_merge_json`, `merge_workflows`) when `mode == "apply"`.
- Added the `mode` field to the merge report and threaded `mode` through `run()` so `plan` runs are non-destructive but still record intended changes.
- Updated `scripts/merge/turbo_validator.py` to check `tasks` first and fall back to `pipeline` for backward compatibility, preventing exceptions when `build` is defined under `tasks`.

### Testing
- Ran `python3 -m compileall scripts/merge` which compiled all modules successfully.
- Executed an automated smoke test that asserted `run(..., mode="plan")` does not copy or modify target files and `run(..., mode="apply")` performs expected copies and JSON merges; the test passed.
- Executed a validation test for `validate_turbo()` using a `turbo.json` with `tasks.build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed2f174ac8331abea8d53537e4ee7)