### PR TITLE
[PR #2280 follow-up] Make merge engine plan mode read-only and ignore VCS dirs

### DIFF
--- a/scripts/merge/merge_engine.py
+++ b/scripts/merge/merge_engine.py
@@ -6,6 +6,9 @@ from workflow_dedupe import merge_workflows
 from asset_fingerprint import fingerprint_asset
 
 
+EXCLUDED_DIRS = {".git", ".hg", ".svn", "__pycache__"}
+
+
 def sha256(path):
     h = hashlib.sha256()
     with open(path, "rb") as f:
@@ -29,9 +32,10 @@ def archive_legacy(src_root, archive_root):
     shutil.copytree(src_root, archive_root)
 
 
-def handle_file(src, dest, report):
+def handle_file(src, dest, report, mutate=True):
     if not dest.exists():
-        copy_file(src, dest)
+        if mutate:
+            copy_file(src, dest)
         report["copied"].append(str(dest))
         return
 
@@ -40,12 +44,14 @@ def handle_file(src, dest, report):
         return
 
     if src.suffix == ".json":
-        deep_merge_json(dest, src)
+        if mutate:
+            deep_merge_json(dest, src)
         report["json_merged"].append(str(dest))
         return
 
     if ".github/workflows" in str(dest):
-        merge_workflows(dest, src)
+        if mutate:
+            merge_workflows(dest, src)
         report["workflow_merged"].append(str(dest))
         return
 
@@ -65,14 +71,17 @@ def run(target, legacy, archive, mode):
     legacy = Path(legacy)
     target = Path(target)
 
-    for root, _, files in os.walk(legacy):
+    mutate = mode == "apply"
+
+    for root, dirs, files in os.walk(legacy):
+        dirs[:] = [d for d in dirs if d not in EXCLUDED_DIRS]
         for f in files:
             src = Path(root) / f
             rel = src.relative_to(legacy)
             dest = target / rel
-            handle_file(src, dest, report)
+            handle_file(src, dest, report, mutate=mutate)
 
-    if mode == "apply":
+    if mutate:
         archive_legacy(legacy, target / archive)
 
     Path("reports/merge").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Motivation

- Prevent the migration `plan` mode from making any filesystem changes so it is a safe dry-run that only reports intended actions.
- Avoid copying VCS metadata or other non-source directories from the legacy tree into the target repository to prevent accidental repository corruption.

### Description

- Added `EXCLUDED_DIRS = {".git", ".hg", ".svn", "__pycache__"}` and pruned `dirs` in the `os.walk` loop to skip VCS and other non-source directories during the legacy tree walk.
- Introduced a `mutate` flag derived from `mode == "apply"` and threaded it into `handle_file(...)` so file-mutating operations run only when `mutate` is true.
- Gated the write operations `copy_file`, `deep_merge_json`, and `merge_workflows` behind the `mutate` flag so `plan` mode only records actions without changing files.
- Only archive the legacy tree when `mutate` is true, preserving existing behavior for `apply` while keeping `plan` read-only.

### Testing

- Ran `python3 -m py_compile scripts/merge/*.py` to verify the modules compile successfully.
- Executed a focused runtime smoke test that created temporary `legacy` and `target` trees (including a `.git` dir and a JSON file), invoked `run(..., mode="plan")`, and asserted that the `.git` directory was not copied and the target JSON file was unchanged, and that the report included the planned JSON merge; the test passed.
- During runtime testing the environment lacked `yaml`, so a small `yaml` stub was injected to exercise the `merge_engine` behavior in this environment, and the assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed3b58cd48331b896466779a1f9fa)