### PR TITLE
[Follow-up] Fix merge engine VCS pruning and file/dir collision handling

### DIFF
--- a/scripts/merge/merge_engine.py
+++ b/scripts/merge/merge_engine.py
@@ -5,6 +5,13 @@ from json_merge import deep_merge_json
 from workflow_dedupe import merge_workflows
 from asset_fingerprint import fingerprint_asset
 
+SKIP_LEGACY_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+}
+
 
 def sha256(path):
     h = hashlib.sha256()
@@ -34,6 +41,10 @@ def handle_file(src, dest, report, mode):
         if mode == "apply":
             copy_file(src, dest)
         report["copied"].append(str(dest))
+        return
+
+    if dest.is_dir():
+        report["conflicts"].append(f"{dest} (file-vs-directory)")
         return
 
     if sha256(src) == sha256(dest):
@@ -69,7 +80,8 @@ def run(target, legacy, archive, mode):
     legacy = Path(legacy)
     target = Path(target)
 
-    for root, _, files in os.walk(legacy):
+    for root, dirs, files in os.walk(legacy):
+        dirs[:] = [d for d in dirs if d not in SKIP_LEGACY_DIRS]
         for f in files:
             src = Path(root) / f
             rel = src.relative_to(legacy)


### PR DESCRIPTION
### Motivation
- Prevent copying VCS and cache metadata (for example `.git`) from the `legacy` tree into the `target` repo which can corrupt repository internals. 
- Ensure file-vs-directory collisions are reported instead of raising `IsADirectoryError` and aborting the merge run.

### Description
- Add `SKIP_LEGACY_DIRS` containing `.git`, `.hg`, `.svn`, and `__pycache__`, and prune these directories from the `os.walk` traversal by mutating `dirs[:]` before processing files. 
- Add a `dest.is_dir()` guard in `handle_file` that records a `file-vs-directory` conflict and returns before attempting to compute checksums. 
- Preserve existing behaviors for identical files, JSON merges (`deep_merge_json`), and workflow merges (`merge_workflows`), and continue to write the report to `reports/merge/merge-report.json`. 
- Request review with the tag `@Jules-Bot [review-request]`.

### Testing
- Executed a targeted Python validation that injected stub modules for `json_merge`, `workflow_dedupe`, and `asset_fingerprint`, created temporary `legacy` and `target` trees, and asserted that `.git/config` was not copied, a normal file was reported as copied, and a file-vs-directory collision was recorded; this test passed. 
- Attempted to run the script without stubbing, but a missing runtime dependency (`yaml`) in this environment prevented a direct full run. 
- Confirmed that a `reports/merge/merge-report.json` file is produced and contains the expected `copied` and `conflicts` entries during the validation run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed8a8ab648331a1635f69f3fa774f)