### PR TITLE
refactor(theme): align typography with Atkinson baseline

### DIFF
--- a/packages/theme/styles/base.css
+++ b/packages/theme/styles/base.css
@@ -1,4 +1,18 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap");
+@font-face {
+  font-family: "Atkinson";
+  src: url("../../../public/fonts/atkinson-regular.woff") format("woff");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Atkinson";
+  src: url("../../../public/fonts/atkinson-bold.woff") format("woff");
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+}
 
 *,
 *::before,
@@ -47,13 +61,13 @@ h1 {
   font-size: clamp(2.5rem, 5.8vw, 4rem);
   line-height: 1.02;
   margin: 0 0 1.25rem 0;
-  font-weight: 650;
+  font-weight: 700;
 }
 
 h2 {
   font-size: clamp(1.75rem, 3.4vw, 2.2rem);
   margin: 0 0 0.75rem 0;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 p {

--- a/packages/theme/styles/tokens.css
+++ b/packages/theme/styles/tokens.css
@@ -19,8 +19,8 @@
   --gs-pad: 2rem;
   --gs-section: 6rem;
   --gs-section-m: 4rem;
-  --gs-font-sans: Inter, system-ui, -apple-system, sans-serif;
-  --gs-font-serif: "Playfair Display", ui-serif, Georgia, serif;
+  --gs-font-sans: "Atkinson", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --gs-font-serif: "Atkinson", system-ui, -apple-system, "Segoe UI", sans-serif;
   --gs-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
   --gs-fast: 160ms;
   --gs-mid: 300ms;


### PR DESCRIPTION
### Motivation
- Ensure GS theme typography uses the canonical admin/brand font family (Atkinson) and avoid external font divergence.
- Centralize font sourcing inside the theme package so web and admin surfaces share the same baseline.

### Description
- Updated theme tokens in `packages/theme/styles/tokens.css` to set `--gs-font-sans` and `--gs-font-serif` to the `Atkinson` family.
- Replaced the external Google Fonts import in `packages/theme/styles/base.css` with local `@font-face` definitions that point at the existing assets under `public/fonts`.
- Adjusted heading weights in `packages/theme/styles/base.css` to use available local weights (`700`) for consistent rendering with the local Atkinson files.
- Confirmed pages `apps/gs-web/src/pages/index.astro` and `apps/gs-web/src/pages/risk-radar.astro` already inherit theme classes (`.gs-display`, `h1`, `h2`, `p`) so no page-level overrides were needed.

### Testing
- Ran `pnpm -C apps/gs-web dev --host 0.0.0.0 --port 4321` and manually validated rendering, capturing screenshots at `artifacts/typography-home.png` and `artifacts/typography-risk-radar.png` (successful).
- Executed `pnpm -C apps/gs-web check` which failed due to pre-existing TypeScript/Astro diagnostics unrelated to these CSS changes.
- Executed `pnpm -C apps/gs-web build` which failed due to a pre-existing package export resolution issue unrelated to these CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3d06662408331a93598cdad879c68)