### PR TITLE
Fix P1: initialize stabilization-check arrays and correct naming-guard ripgrep behavior

### DIFF
--- a/.github/workflows/naming-guard.yml
+++ b/.github/workflows/naming-guard.yml
@@ -17,7 +17,10 @@ jobs:
         run: |
           set -euo pipefail
           legacy_pattern='apps/(api-worker|control-worker|gateway)|Astro-'
-          rg -n "$legacy_pattern" .github/workflows
+          if rg -n "$legacy_pattern" .github/workflows --glob '!naming-guard.yml'; then
+            echo "Found forbidden legacy workflow references."
+            exit 1
+          fi
 
       - name: Block legacy workflow filenames from active workflow directory
         run: |

--- a/scripts/stabilization-check.mjs
+++ b/scripts/stabilization-check.mjs
@@ -61,6 +61,8 @@ const ALLOWED_ACTIONS = [
 
 let report = `# Stabilization Sync Check Report\n\n**Date:** ${new Date().toUTCString()}\n\n`;
 let violations = [];
+let governanceViolations = [];
+let appLevelIssues = [];
 
 // 1. Governance Compliance Check
 report += `## 1. Governance Compliance Check\n\n`;
@@ -255,7 +257,7 @@ if (governanceViolations.length === 0 && appLevelIssues.length === 0) {
   report += `If CI is green across all required checks for 48 consecutive hours and no branch divergence >5 commits exists, recommend terminating recurring stabilization sync.\n`;
 } else {
   report += `### ❌ Actions Required\n\n`;
-  violations.forEach(v => report += `- ${v}\n`);
+  [...new Set([...governanceViolations, ...violations])].forEach(v => report += `- ${v}\n`);
   report += `\n**Do not self-fix. Escalate governance violations.**\n`;
   report += `**App-level repairs (types, imports) are permitted in apps/* only.**\n`;
 }
@@ -268,7 +270,7 @@ if (!fs.existsSync(path.dirname(REPORT_PATH))) {
 fs.writeFileSync(REPORT_PATH, report);
 console.log(`Report generated at ${REPORT_PATH}`);
 
-if (violations.length > 0) {
+if (governanceViolations.length > 0 || violations.length > 0) {
   console.error('Violations detected.');
   process.exit(1);
 } else if (appLevelIssues.length > 0) {


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` in `scripts/stabilization-check.mjs` where `appLevelIssues` and `governanceViolations` were referenced before initialization, which prevented the stabilization workflow from completing and writing its report.
- Ensure `.github/workflows/naming-guard.yml` actually fails when forbidden legacy patterns are present and avoid the workflow self-matching its own `legacy_pattern` definition.

### Description
- Declare `governanceViolations` and `appLevelIssues` at the top of `scripts/stabilization-check.mjs`, include governance violations in the report output (deduplicated with other violations), and update the exit condition to fail when governance or workflow violations exist.
- Update `.github/workflows/naming-guard.yml` to invert the `rg` check so the step exits nonzero when matches are found and exclude `naming-guard.yml` from the scan to prevent self-matching.

### Testing
- Ran `node --check scripts/stabilization-check.mjs` and it completed successfully.
- Ran `bash -n .github/workflows/naming-guard.yml` and the workflow file passed syntax checks.
- Simulated the naming-guard `rg` step in shell with `if rg -n "$legacy_pattern" .github/workflows --glob '!naming-guard.yml'; then echo "MATCHES_FOUND"; else echo "NO_MATCHES"; fi` and observed the expected behavior (no false-positive self-match).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43ab6d7c08331873d4859b6726f27)