### PR TITLE
Follow-up: restore @goldshore/jules-bot package name and fix gs-agent Wrangler config

### DIFF
--- a/apps/jules-bot/package.json
+++ b/apps/jules-bot/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@goldshore/jules-bot",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.mjs"
+  }
+}

--- a/apps/jules-bot/src/index.mjs
+++ b/apps/jules-bot/src/index.mjs
@@ -1,0 +1,1 @@
+console.log('jules-bot placeholder entrypoint');

--- a/infra/cloudflare/gs-agent.wrangler.toml
+++ b/infra/cloudflare/gs-agent.wrangler.toml
@@ -1,9 +1,9 @@
 # wrangler.toml for the background Agent Worker
 
 name = "gs-agent" # Base name, will be suffixed per environment
+main = "../../apps/gs-agent/src/index.ts"
 compatibility_date = "2024-11-01"
 compatibility_flags = ["nodejs_compat"]
-# Using CLI to pass tsconfig to avoid relative path confusion with external config
 
 [env.dev]
 name = "gs-agent-dev"
@@ -19,27 +19,9 @@ queue = "gs-jobs"
 name = "gs-agent-prod"
 [[env.prod.queues.consumers]]
 queue = "gs-jobs"
-main = "../../apps/gs-agent/src/index.ts"
-compatibility_date = "2024-03-20"
-tsconfig = "../../apps/gs-agent/tsconfig.json"
 
 # This worker is queue-driven, so we define the consumer here.
 [[queues.consumers]]
-  # The queue binding name should match what's in the environment bindings.
-  # Example: QUEUES_JOBS
-  queue = "goldshore-jobs"
-
-[env.dev]
-name = "gs-agent-dev"
-# Dev bindings for the agent
-# [[queues.producers]]
-# binding = "QUEUES_JOBS"
-# queue = "goldshore-jobs-dev"
-
-[env.preview]
-name = "gs-agent-preview"
-# Preview bindings for the agent
-
-[env.prod]
-name = "gs-agent-prod"
-# Production bindings for the agent
+# The queue binding name should match what's in the environment bindings.
+# Example: QUEUES_JOBS
+queue = "goldshore-jobs"


### PR DESCRIPTION
### Motivation
- Fix CI failures flagged by the stabilization audit by restoring a naming-safe package for the Jules bot so `pnpm check:naming` passes. 
- Ensure the preview/deploy Wrangler config for the agent is parseable so the preview workflow can complete instead of failing on TOML parsing errors. 
- Confirm workflow job keys comply with repository kebab-case naming rules so the naming-lint workflow does not block CI.

### Description
- Added `apps/jules-bot/package.json` with a scoped name of `@goldshore/jules-bot` and a minimal `start` script, plus a placeholder entrypoint at `apps/jules-bot/src/index.mjs`. 
- Cleaned up `infra/cloudflare/gs-agent.wrangler.toml` to remove duplicate `[env.*]` table declarations, moved the `main` setting to the top-level, and removed the broken `tsconfig` reference that caused a TOML/parse error. 
- Verified that `.github/workflows/sonarcloud.yml` and `.github/workflows/neuralegion.yml` already use kebab-case job keys and required no edits. 

### Testing
- Ran `pnpm check:naming` and it passed. 
- Ran `pnpm validate:workspace` and it passed. 
- Executed `pnpm exec wrangler deploy --config infra/cloudflare/gs-agent.wrangler.toml --env preview --dry-run` and the dry-run completed successfully without TOML parse errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43c7475ac8331a0da9eb53be92666)