### PR TITLE
Fix stabilization-check ReferenceError and violation tracking

### DIFF
--- a/scripts/stabilization-check.mjs
+++ b/scripts/stabilization-check.mjs
@@ -61,6 +61,7 @@ const ALLOWED_ACTIONS = [
 
 let report = `# Stabilization Sync Check Report\n\n**Date:** ${new Date().toUTCString()}\n\n`;
 let violations = [];
+const appLevelIssues = [];
 
 // 1. Governance Compliance Check
 report += `## 1. Governance Compliance Check\n\n`;
@@ -89,7 +90,7 @@ try {
 
   if (newScripts.length > 0) {
      const msg = `New scripts detected in root package.json: ${newScripts.join(', ')}`;
-     governanceViolations.push(msg);
+     violations.push(msg);
      report += `### ❌ Build Script Violation:\n- ${msg}\n\n`;
   } else {
     report += `✅ Root build scripts compliant.\n\n`;
@@ -249,7 +250,7 @@ if (appLevelIssues.length > 0) {
 // 5. Recommendations & Stop Condition
 report += `## 5. Recommendations\n\n`;
 
-if (governanceViolations.length === 0 && appLevelIssues.length === 0) {
+if (violations.length === 0 && appLevelIssues.length === 0) {
   report += `### ✅ Clean State\n\n`;
   report += `**Stop Condition Status:**\n`;
   report += `If CI is green across all required checks for 48 consecutive hours and no branch divergence >5 commits exists, recommend terminating recurring stabilization sync.\n`;


### PR DESCRIPTION
### Motivation
- Prevent runtime `ReferenceError` and ensure governance violations are recorded correctly when the stabilization script detects root `package.json` script drift.

### Description
- Declare `const appLevelIssues = []` to track app build failures used later in reporting and exit logic.
- Replace the undeclared `governanceViolations.push(...)` call with `violations.push(...)` in the root `package.json` script-drift check so violations are recorded in the existing list.
- Update the clean-state check to use `violations.length` so the stop-condition logic evaluates the actual governance list.

### Testing
- Ran `node --check scripts/stabilization-check.mjs` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4393fb3788331b7f66d9919fc976b)