### PR TITLE
Make reveal animations progressive with gs-motion-ready gating

### DIFF
--- a/packages/theme/index.ts
+++ b/packages/theme/index.ts
@@ -2,6 +2,7 @@ export function initGoldShoreUI() {
   initNav();
   initModal();
   initParallax();
+  document.documentElement.classList.add("gs-motion-ready");
   initReveal();
 }
 

--- a/packages/theme/styles/motion.css
+++ b/packages/theme/styles/motion.css
@@ -7,9 +7,14 @@
 }
 
 [data-gs-reveal] {
+  opacity: 1;
+  transform: none;
+  transition: opacity var(--gs-slow) var(--gs-ease), transform var(--gs-slow) var(--gs-ease);
+}
+
+html.gs-motion-ready [data-gs-reveal] {
   opacity: 0;
   transform: translateY(18px);
-  transition: opacity var(--gs-slow) var(--gs-ease), transform var(--gs-slow) var(--gs-ease);
 }
 
 [data-gs-reveal].is-in {


### PR DESCRIPTION
### Motivation
- Ensure content using `[data-gs-reveal]` remains readable if runtime JS fails by making the visible state the default instead of hidden.
- Only apply the pre-reveal hidden/animated state after the UI runtime has successfully initialized to avoid a fail-closed experience.

### Description
- Changed CSS so ` [data-gs-reveal]` defaults to visible (`opacity: 1; transform: none;`) and preserved the transition rule as `transition: opacity var(--gs-slow) var(--gs-ease), transform var(--gs-slow) var(--gs-ease);` in `packages/theme/styles/motion.css`.
- Added a gated hidden state under `html.gs-motion-ready [data-gs-reveal] { opacity: 0; transform: translateY(18px); }` so the hidden pre-reveal appearance is only applied after JS sets the ready flag.
- Updated `initGoldShoreUI()` in `packages/theme/index.ts` to call `document.documentElement.classList.add("gs-motion-ready")` before invoking `initReveal()` so the reveal observers and animation gating are coordinated.
- Kept the `prefers-reduced-motion` guard and existing `IntersectionObserver` logic in `initReveal()` unchanged.

### Testing
- Ran `pnpm turbo run lint --filter=@goldshore/theme` which completed successfully (no lint tasks were executed for this package).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a461ba7d7083318552e00a6b737e02)