### PR TITLE
docs(migration): add precedence order and normalization requirements

### DIFF
--- a/docs/migration/astro-goldshore-merge.md
+++ b/docs/migration/astro-goldshore-merge.md
@@ -33,3 +33,38 @@ python3 scripts/merge/merge_engine.py \
 
 Outputs:
 reports/merge/
+
+---
+
+## Precedence Rules
+
+When multiple migration rules could apply to the same file or path, implementation must resolve them in the following order:
+
+1. **Safety (no destructive deletion)**
+2. **Canonical destination structure**
+3. **Normalization edits (workflows/infra)**
+4. **Non-overwrite fallback**
+
+This order is mandatory. Lower-priority rules must not violate higher-priority guarantees.
+
+### Normalization edits to existing files
+
+If normalization requires editing files that already exist in the destination repository, the implementation must:
+
+* **Patch minimally** — change only the smallest required keys/paths/values.
+* **Preserve existing semantics** — keep the destination's current behavior unless a normalization rule explicitly requires a behavior-preserving transformation.
+* **Log every edit** in `docs/migration/migration-report.md` under the section heading **"normalized existing files"**.
+
+### Normalization examples
+
+* **`.github/workflows/*.yml` key-level merge**
+  * Merge specific keys (for example `on`, `permissions`, `jobs.<name>.steps`) instead of replacing whole workflow files.
+  * Keep repository-specific jobs/conditions already present in destination workflows.
+
+* **`infra/Cloudflare/**` path normalization**
+  * Normalize imported legacy Cloudflare files into the canonical `infra/Cloudflare/**` layout.
+  * Update only path references required by the move (e.g., include/import/module paths) without broad refactors.
+
+* **`pnpm-workspace.yaml` exclusion update for `legacy/**`**
+  * Add or merge an exclusion entry for `legacy/**` into existing workspace package globs.
+  * Do not remove existing include/exclude rules unless required to avoid conflicting duplicates.


### PR DESCRIPTION
### Motivation

- Define a clear conflict-resolution precedence for the migration engine to avoid destructive or ambiguous merges. 
- Specify required behavior when normalizing files that already exist in the destination so automated normalization is deterministic and low-risk. 
- Provide concrete examples (workflows, Cloudflare paths, `pnpm-workspace.yaml`) so implementers have actionable guidance.

### Description

- Add a `Precedence Rules` section that requires resolution order: 1) Safety (no destructive deletion), 2) Canonical destination structure, 3) Normalization edits (workflows/infra), 4) Non-overwrite fallback. 
- Require normalization edits to existing files to `patch minimally`, `preserve existing semantics`, and `log every edit` in `docs/migration/migration-report.md` under the section heading "normalized existing files". 
- Add examples showing `.github/workflows/*.yml` key-level merges, `infra/Cloudflare/**` path normalization, and updating `pnpm-workspace.yaml` to exclude `legacy/**`. 
- Request a review with `@Jules-Bot [review-request]`.

### Testing

- Verified the documentation change with `git diff -- docs/migration/astro-goldshore-merge.md` which showed the inserted sections and examples and succeeded. 
- Confirmed working-tree status with `git status --short` and inspected the updated file with `nl -ba docs/migration/astro-goldshore-merge.md | sed -n '1,220p'`, both of which succeeded. 
- This is a documentation-only change and no runtime migration code or automated unit tests were modified or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46bcdba0083319f3df054a58b1485)