### PR TITLE
Add canonicalization migration policy and reference it in integration PR template

### DIFF
--- a/docs/migration/canonicalization-policy.md
+++ b/docs/migration/canonicalization-policy.md
@@ -1,0 +1,49 @@
+# Canonicalization Migration Policy
+
+This policy defines the deterministic, file-type-based canonicalization behavior for migration and integration work.
+
+## Global decision table
+
+| File type / pattern | Strategy | Deterministic rule |
+| --- | --- | --- |
+| `*.md` | structured merge strategy | Merge frontmatter keys by precedence (`target` keeps existing keys unless explicitly replaced; `source` adds missing keys). For body content, keep target body when both sides edited the same section and emit a conflict note for manual follow-up. |
+| `*.html` | skip-if-target-exists | Keep target file if it already exists; only copy from source when target is missing. |
+| `*.astro` | manual-review-required | Never auto-merge component/page templates. Stage both variants and require implementer review to resolve framework/runtime differences. |
+| `*.toml` | structured merge strategy | Perform key-level merge unless an explicit file override rule exists (see `wrangler.toml` below). |
+| `*.lock` and lockfiles | skip-if-target-exists | Do not line-merge lockfiles. Preserve canonical lockfile rule below. |
+| `*.svg` | copy-if-missing | Copy source SVG only when target file does not exist. Existing target SVGs are retained. |
+| Generated files (`dist/**`, `build/**`, `.astro/**`, coverage outputs, bundled assets) | manual-review-required | Do not canonicalize generated outputs by default. Regenerate from source after merge; commit only if repository policy requires checked-in artifacts. |
+
+## Explicit file rules
+
+### `wrangler.toml` (field-level merge behavior)
+
+Use structured merge with field-level precedence:
+
+1. Preserve target values for deployment identity and environment-bound fields (`name`, `account_id`, `main`, `compatibility_date`, `workers_dev`, and route bindings).
+2. Merge additive arrays/maps from source when missing in target (`kv_namespaces`, `r2_buckets`, `d1_databases`, `services`, `vars`).
+3. If the same field is modified on both sides with different values, keep target value and log conflict context in the PR under **Conflict resolutions** for manual review.
+
+### `pnpm-lock.yaml` (canonical source of truth)
+
+- `pnpm-lock.yaml` is the canonical lockfile source of truth.
+- No lockfile merge is allowed.
+- Always regenerate with workspace install after dependency-affecting merges and commit the regenerated file.
+
+### Markdown docs (`*.md`)
+
+Structured merge procedure:
+
+1. Parse and merge frontmatter keys first.
+   - Scalar key conflict: keep target value, record conflict note.
+   - List/map conflict: union by key/item when safe; otherwise keep target and record note.
+2. Merge body content by section heading.
+   - Non-overlapping section edits: include both.
+   - Overlapping/conflicting edits: keep target section and append a `TODO(migration): manual reconcile source section` marker.
+3. If frontmatter or body parse fails, fall back to `manual-review-required`.
+
+## Operational requirements
+
+- Implementers must follow this policy for every migration PR.
+- Any exception must be documented in the PR **Conflict resolutions** section with rationale.
+- PR templates and migration automation should link to this file to keep one deterministic path.

--- a/ops/integration-pr-template.md
+++ b/ops/integration-pr-template.md
@@ -13,6 +13,10 @@
 ## Conflict resolutions
 - `<file>`: `<decision and rationale>`
 
+## Canonicalization policy
+- Follow `docs/migration/canonicalization-policy.md` for deterministic file handling and conflict decisions.
+- Document any policy exception in **Conflict resolutions** with rationale.
+
 ## Regenerated artifacts
 - `pnpm-lock.yaml`: regenerated after merging `<branch list>`
 


### PR DESCRIPTION
### Motivation

- Provide a single, deterministic migration/canonicalization policy to remove ambiguity during integration and migration merges.
- Ensure specific file types (`.md`, `.html`, `.astro`, `.toml`, lockfiles, `.svg`, and generated outputs) each have a clear, actionable handling strategy.
- Make implementers follow the policy by referencing it from the integration PR template so exceptions are recorded and reproducible.

### Description

- Add `docs/migration/canonicalization-policy.md` containing a global decision table that maps file patterns to one of `copy-if-missing`, `skip-if-target-exists`, `structured merge strategy`, or `manual-review-required` and includes deterministic rules for each pattern.
- Add explicit rules for `wrangler.toml` (field-level structured merge with target-preserved identity fields and additive merges for resources), `pnpm-lock.yaml` (canonical lockfile, no merge, always regenerate), and markdown docs (`*.md`) (frontmatter-first merge and section-based body conflict handling with a `TODO(migration)` marker fallback).
- Update `ops/integration-pr-template.md` to reference `docs/migration/canonicalization-policy.md` and require documenting any exception in the PR **Conflict resolutions** section.

### Testing

- Ran `git diff --check -- docs/migration/canonicalization-policy.md ops/integration-pr-template.md`, which returned `OK` indicating no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46bc9d1d0833195adfb13c8c63a87)