### PR TITLE
docs(migration): add integrity checks and exact scan targets

### DIFF
--- a/docs/migration/integrity-checks.md
+++ b/docs/migration/integrity-checks.md
@@ -1,0 +1,27 @@
+# Migration Integrity Checks
+
+## Required Scan Targets and Checks
+
+### Exact scan targets
+
+- Source globs:
+  - `apps/**`
+  - `packages/**`
+  - `infra/**`
+  - `.github/workflows/**`
+  - `docs/**`
+- Exclusions:
+  - `legacy/**`
+  - `node_modules/**`
+  - build outputs
+
+### Required string checks
+
+- Forbid `astro-goldshore/` outside `legacy/`.
+- Forbid import specifiers resolving into `legacy/astro-goldshore`.
+
+### Required path checks
+
+- Validate asset references under `public/assets/**`.
+- Ensure no duplicate workflow filenames exist in `.github/workflows/`.
+- Verify relative imports for moved files using static path existence checks.


### PR DESCRIPTION
### Motivation

- Ensure the migration tooling enforces a precise set of scan targets, prevents accidental `astro-goldshore/` leakage, and validates moved file references to avoid broken imports or duplicated workflows.

### Description

- Add `docs/migration/integrity-checks.md` that lists exact source globs (`apps/**`, `packages/**`, `infra/**`, `.github/workflows/**`, `docs/**`), exclusions (`legacy/**`, `node_modules/**`, build outputs), required string checks (forbid `astro-goldshore/` outside `legacy/` and forbid import specifiers resolving into `legacy/astro-goldshore`), and required path checks (asset references under `public/assets/**`, no duplicate workflow filenames in `.github/workflows/`, and static relative import path existence checks for moved files).

### Testing

- Documentation-only change; verified `docs/migration/integrity-checks.md` presence and contents with automated file checks, and request review via `@Jules-Bot [review-request]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46bcf35d883319869210a4889d467)