### PR TITLE
docs(theme): declare canonical ownership and migration rules for --gs-* tokens

### DIFF
--- a/packages/theme/TOKENS_OWNERSHIP.md
+++ b/packages/theme/TOKENS_OWNERSHIP.md
@@ -1,0 +1,31 @@
+# Theme Token Ownership
+
+`packages/theme` is the only canonical owner of all CSS custom properties matching `--gs-*`.
+
+## Canonical ownership rule
+
+- Canonical token definitions must live in `packages/theme` token sources.
+- No other package or migrated stylesheet should keep source-of-truth declarations for `--gs-*` variables.
+
+## Migration handling rules
+
+When migrating incoming CSS:
+
+1. Detect all `--gs-*` declarations in the incoming file.
+2. For each detected token:
+   - If the token already exists canonically in `packages/theme`:
+     - Remove the legacy declaration from the migrated file.
+     - Update references only if the incoming declaration value differs from canonical value.
+   - If the token is new:
+     - Append it to the canonical token file in `packages/theme`.
+     - Remove the duplicate definition from the migrated file.
+3. Record every collision in the migration report under **“CSS token collisions”** with:
+   - file path
+   - token name
+
+## Search strings for implementers
+
+Use these searches when auditing or migrating CSS:
+
+- `--gs-`
+- `var(--gs-`


### PR DESCRIPTION
### Motivation

- Ensure `packages/theme` is the single source-of-truth for all `--gs-*` CSS tokens and to standardize migration behavior to avoid duplicated or conflicting declarations.

### Description

- Add `packages/theme/TOKENS_OWNERSHIP.md` documenting canonical ownership, migration handling (detect `--gs-*` declarations, remove legacy declarations when canonical exists, append new tokens to canonical file, remove duplicates from migrated files), collision reporting under **CSS token collisions** (file path and token name), and implementer search strings `--gs-` and `var(--gs-`; requesting review: @Jules-Bot [review-request].

### Testing

- Ran `git status --short`, `nl -ba packages/theme/TOKENS_OWNERSHIP.md`, and repository file listings (`rg --files`) to confirm the file was created and contents match, and all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a46bd1f7388331ac3db78dad719d96)