### PR TITLE
Normalize workflow pipeline job IDs after rebasing stabilization audit branch

### DIFF
--- a/.github/workflows/deploy-gs-api.yml
+++ b/.github/workflows/deploy-gs-api.yml
@@ -14,7 +14,7 @@ on:
       - "pnpm-lock.yaml"
 
 jobs:
-  deploy:
+  deploy-api:
     runs-on: ubuntu-latest
     name: Deploy
     steps:

--- a/.github/workflows/deploy-gs-mail.yml
+++ b/.github/workflows/deploy-gs-mail.yml
@@ -15,7 +15,7 @@ on:
       - "pnpm-lock.yaml"
 
 jobs:
-  deploy:
+  deploy-mail:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/preview-gs-agent.yml
+++ b/.github/workflows/preview-gs-agent.yml
@@ -20,7 +20,7 @@ on:
       - "pnpm-lock.yaml"
 
 jobs:
-  deploy-preview-agent:
+  preview-agent:
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'preview') ||

--- a/.github/workflows/preview-gs-api.yml
+++ b/.github/workflows/preview-gs-api.yml
@@ -19,7 +19,7 @@ on:
       - "pnpm-lock.yaml"
 
 jobs:
-  deploy-preview-api:
+  preview-api:
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'preview') ||

--- a/.github/workflows/preview-gs-gateway.yml
+++ b/.github/workflows/preview-gs-gateway.yml
@@ -19,7 +19,7 @@ on:
       - "pnpm-lock.yaml"
 
 jobs:
-  deploy-preview-gateway:
+  preview-gateway:
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'preview') ||


### PR DESCRIPTION
### Motivation

- Ensure a single canonical naming scheme for preview and deploy workflow job IDs to avoid duplicate/rename conflicts and make pipeline purposes consistent. 
- Normalize conflicted workflows in `.github/workflows/` so there is exactly one active workflow per pipeline purpose (preview/deploy/guard) and intentionally disabled pipelines remain as `.disabled` files. 

### Description

- Renamed preview job IDs to the canonical `preview-*` names in `.github/workflows/preview-gs-api.yml`, `.github/workflows/preview-gs-agent.yml`, and `.github/workflows/preview-gs-gateway.yml`. 
- Renamed deploy job IDs to the canonical `deploy-*` names in `.github/workflows/deploy-gs-api.yml` and `.github/workflows/deploy-gs-mail.yml`. 
- Verified there are no active/disabled duplicate filename pairs in `.github/workflows/` so disabled pipelines remain single-source-of-truth. 

### Testing

- Ran `git rebase main` which reported the branch was up to date. 
- Ran `git diff --check` which passed with no whitespace/errors. 
- Enumerated workflow job IDs with an `awk`/`find` listing and an ad-hoc Python check to confirm job-name normalization and absence of active/disabled duplicates, both of which succeeded. 
- Attempted `git push` from this environment but it failed because no `origin` remote is configured here, so remote push and CI reopening must be performed from a network-enabled environment with remotes configured. 
- Requesting review: @Jules-Bot [review-request]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63a07bfac833180d425d62b09efdd)