### PR TITLE
[Follow-up] Fix stabilization-check governance violations list initialization

### DIFF
--- a/scripts/stabilization-check.mjs
+++ b/scripts/stabilization-check.mjs
@@ -60,10 +60,8 @@ const ALLOWED_ACTIONS = [
 ];
 
 let report = `# Stabilization Sync Check Report\n\n**Date:** ${new Date().toUTCString()}\n\n`;
-let violations = [];
-// Keep app-level issues list in module scope so checks and final exit logic share it.
 const governanceViolations = [];
-const violations = governanceViolations;
+// Keep issue lists in module scope so checks and final exit logic share them.
 const appLevelIssues = [];
 
 // 1. Governance Compliance Check


### PR DESCRIPTION
### Motivation
- Prevent a `ReferenceError` in `scripts/stabilization-check.mjs` caused by duplicate/conflicting `violations` declarations so the stabilization report path can run when new scripts are detected.

### Description
- Removed the duplicate `violations` declarations, kept a single module-scoped `governanceViolations` array and `appLevelIssues`, and updated the nearby comment to accurately describe the module-level issue lists in `scripts/stabilization-check.mjs`.

### Testing
- Ran a syntax check with `node --check scripts/stabilization-check.mjs`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a63b43ad608331a67c3cab576efc98)