### PR TITLE
ci: add independent Cloudflare infra sync workflow

### DIFF
--- a/.github/workflows/sync-infra.yml
+++ b/.github/workflows/sync-infra.yml
@@ -1,0 +1,46 @@
+name: Sync Infrastructure (Cloudflare)
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/Cloudflare/**"
+      - "infra/cron/**"
+      - "docs/ci/INFRA_SYNC_RUNBOOK.md"
+  workflow_dispatch:
+  schedule:
+    - cron: "30 3 * * 1"
+
+jobs:
+  sync-infra:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run infra sync utility
+        run: pnpm tsx infra/Cloudflare/deploy.ts
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_KV_NAMESPACE_API_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_API_ID }}
+          CF_KV_NAMESPACE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_GATEWAY_ID }}

--- a/docs/ci/INFRA_SYNC_RUNBOOK.md
+++ b/docs/ci/INFRA_SYNC_RUNBOOK.md
@@ -1,0 +1,35 @@
+# Infra Sync Runbook
+
+Use `.github/workflows/sync-infra.yml` to run Cloudflare infrastructure synchronization separately from app deploy pipelines.
+
+## Trigger model
+
+- **Automatic on `main` push (path-filtered):** runs when infra sources change (`infra/Cloudflare/**`, `infra/cron/**`).
+- **Scheduled (weekly):** catches drift even without recent infra commits.
+- **Manual (`workflow_dispatch`):** recommended for urgent reconciliation or post-incident verification.
+
+## When to run manually
+
+Run `Sync Infrastructure (Cloudflare)` manually when:
+
+- You rotate Cloudflare credentials or namespace bindings.
+- You changed Cloudflare resources via dashboard/API and need repo-defined state re-applied.
+- You need immediate drift correction before the next scheduled run.
+
+## When schedule is enough
+
+Rely on the weekly schedule when:
+
+- No urgent Cloudflare drift is observed.
+- Infra updates are already merged and path-filtered push runs succeeded.
+
+## Required GitHub Secrets
+
+Set these repository secrets before enabling the workflow:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_KV_NAMESPACE_API_ID`
+- `CLOUDFLARE_KV_NAMESPACE_GATEWAY_ID`
+
+Do not store Cloudflare credentials or namespace IDs in tracked workflow files or scripts.

--- a/infra/Cloudflare/deploy.ts
+++ b/infra/Cloudflare/deploy.ts
@@ -8,7 +8,7 @@ import { smoke, lighthouse } from "./tests";
 import { changedPaths, pathsMatchOnly, withinDailyCap } from "./guards";
 
 type Cfg = ReturnType<typeof loadCfg>;
-function loadCfg() { return YAML.parse(fs.readFileSync("infra/cf/config.yaml","utf8")); }
+function loadCfg() { return YAML.parse(fs.readFileSync("infra/Cloudflare/config.yaml","utf8")); }
 
 async function countTodayDeploys(deployments: any[]) {
   const today = new Date().toISOString().slice(0,10);


### PR DESCRIPTION
### Motivation

- Separate Cloudflare infra reconciliation from app deploys so infra syncs can be triggered and scheduled independently of admin/web Pages deploy pipelines.
- Avoid hardcoding credentials or namespace IDs in workflow files and scripts by relying on GitHub Secrets.
- Provide a short runbook to guide operators on when to run syncs manually versus relying on schedule.

### Description

- Added a new workflow at `.github/workflows/sync-infra.yml` that runs on `workflow_dispatch`, a weekly `schedule`, and `push` to `main` filtered to `infra/Cloudflare/**`, `infra/cron/**`, and the runbook file. 
- The workflow installs dependencies and runs the infra sync utility via `pnpm tsx infra/Cloudflare/deploy.ts` while sourcing Cloudflare credentials and namespace IDs from repository secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_KV_NAMESPACE_API_ID`, `CLOUDFLARE_KV_NAMESPACE_GATEWAY_ID`).
- Added `docs/ci/INFRA_SYNC_RUNBOOK.md` documenting trigger semantics, when to run manually, and required secrets.
- Fixed the config path in `infra/Cloudflare/deploy.ts` so the sync utility loads `infra/Cloudflare/config.yaml` correctly in CI.
- Left `.github/workflows/deploy-gs-admin.yml` unchanged because no inbox-specific build/deploy changes were required.

### Testing

- Verified the new workflow YAML parses successfully using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-infra.yml")'` which exited successfully. 
- Validated the runbook and workflow presence with `git diff` and file listings to confirm expected changes were written. 
- Confirmed the `infra/Cloudflare/deploy.ts` path change via a diff check to ensure the utility references `infra/Cloudflare/config.yaml`.
- All automated checks executed during the rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7504766d88331ba29e7906931f3a2)