### PR TITLE
Refine Cloudflare policy report templates with declared/live evidence split

### DIFF
--- a/docs/domains-and-auth.md
+++ b/docs/domains-and-auth.md
@@ -6,10 +6,10 @@ This document captures the Cloudflare Access applications and policies that prot
 
 ## Access applications and policies
 
-| Access application | Policy name | Domain coverage | Notes |
-| --- | --- | --- | --- |
-| GoldShore Admin | GoldShore-Admin-ZT | `admin.goldshore.ai`, `admin-preview.goldshore.ai`, `*-preview.goldshore.ai` (admin preview branches), `{branch}.goldshore-pages.dev` (admin preview pages) | Admin cockpit is protected by Access with an email allowlist + identity provider requirement. Preview domains should be attached to the same application to match production enforcement. |
-| GoldShore Web (Preview) | GoldShore-Web-Preview | `preview.goldshore.ai`, `*-preview.goldshore.ai` (web preview branches), `{branch}.goldshore-pages.dev` (web preview pages) | Web production (`goldshore.ai`, `www.goldshore.ai`) is public, but preview domains must be gated behind Access. |
+| Access application      | Policy name           | Domain coverage                                                                                                                                             | Notes                                                                                                                                                                                     |
+| ----------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GoldShore Admin         | GoldShore-Admin-ZT    | `admin.goldshore.ai`, `admin-preview.goldshore.ai`, `*-preview.goldshore.ai` (admin preview branches), `{branch}.goldshore-pages.dev` (admin preview pages) | Admin cockpit is protected by Access with an email allowlist + identity provider requirement. Preview domains should be attached to the same application to match production enforcement. |
+| GoldShore Web (Preview) | GoldShore-Web-Preview | `preview.goldshore.ai`, `*-preview.goldshore.ai` (web preview branches), `{branch}.goldshore-pages.dev` (web preview pages)                                 | Web production (`goldshore.ai`, `www.goldshore.ai`) is public, but preview domains must be gated behind Access.                                                                           |
 
 ## Identity providers and session policy alignment
 
@@ -22,6 +22,7 @@ Preview applications should mirror production configuration wherever Access is e
 
 - Cloudflare desired state for Access policy naming and domain ownership lives in `infra/cloudflare/desired-state.yaml`.
 - Pages custom domains for admin and web are documented in `infra/cloudflare/BINDINGS_MAP.md`.
+
 # Domains & Auth (Single Source of Truth)
 
 This document is the canonical reference for GoldShore domains, preview URLs, Cloudflare Access policy coverage, and GitHub App callback endpoints.
@@ -42,15 +43,28 @@ This document is the canonical reference for GoldShore domains, preview URLs, Cl
 
 Cloudflare Access is enforced on internal tooling and protected previews. The table below captures the Access policy names and the domains they protect.
 
-| Access application | Policy name | Domains protected | Notes |
-| --- | --- | --- | --- |
-| Public web | `goldshore.ai`, `www.goldshore.ai` | No | Public marketing site. |
-| Web previews | `preview.goldshore.ai`, `*-preview.goldshore.ai`, `{branch}.goldshore-pages.dev` | Yes (GoldShore-Web-Preview) | Preview builds for the marketing site should remain Access gated. |
-| Admin cockpit | `admin.goldshore.ai`, `admin-preview.goldshore.ai`, `*-preview.goldshore.ai`, `{branch}.goldshore-pages.dev` | Yes (GoldShore-Admin-ZT) | Internal admin dashboard, email allowlist + IdP/OTP. |
-| Control worker | `ops.goldshore.ai` | Yes | Internal ops workflows and automation. |
-| API worker | `api.goldshore.ai` | Optional | Enable for private endpoints only. |
-| Gateway worker | `gw.goldshore.ai` | Optional | Depends on routing/auth design. |
-| Mail handler | `mail.goldshore.ai` | No | Cloudflare mail routing cannot authenticate. |
+### Evidence legend
+
+- **Declared (repo/docs):** what repository configuration/docs assert about policy intent.
+- **Verified live (Cloudflare Access API evidence):** what Cloudflare Access API artifacts prove in the live account.
+- **Confidence level:**
+  - `High` when declared and live evidence agree.
+  - `Medium` when only declared evidence is present, or live evidence is partial.
+  - `Low` when evidence conflicts or is missing.
+
+`Strictly enforced` should be used only when declared and verified-live evidence agree.
+
+| Surface                                                                                                                      | Declared (repo/docs)                     | Verified live (Cloudflare Access API evidence) | Enforcement classification                  | Confidence level  | Notes                                                |
+| ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------- | ------------------------------------------- | ----------------- | ---------------------------------------------------- |
+| Public web (`goldshore.ai`, `www.goldshore.ai`)                                                                              | Public web                               | [artifact reference or `not collected`]        | Public                                      | [High/Medium/Low] | Public marketing site.                               |
+| Web previews (`preview.goldshore.ai`, `*-preview.goldshore.ai`, `{branch}.goldshore-pages.dev`)                              | Access protected (GoldShore-Web-Preview) | [artifact reference or `not collected`]        | [Strictly enforced / Configurable/Optional] | [High/Medium/Low] | Preview builds should remain Access gated.           |
+| Admin cockpit (`admin.goldshore.ai`, `admin-preview.goldshore.ai`, `*-preview.goldshore.ai`, `{branch}.goldshore-pages.dev`) | Access protected (GoldShore-Admin-ZT)    | [artifact reference or `not collected`]        | [Strictly enforced / Configurable/Optional] | [High/Medium/Low] | Internal admin dashboard, email allowlist + IdP/OTP. |
+| Control worker (`ops.goldshore.ai`)                                                                                          | Access protected                         | [artifact reference or `not collected`]        | [Strictly enforced / Configurable/Optional] | [High/Medium/Low] | Internal ops workflows and automation.               |
+| API worker (`api.goldshore.ai`)                                                                                              | Optional/private endpoints               | [artifact reference or `not collected`]        | Configurable/Optional\*                     | [High/Medium/Low] | Enable for private endpoints only.                   |
+| Gateway worker (`gw.goldshore.ai`)                                                                                           | Optional/depends on routing design       | [artifact reference or `not collected`]        | Configurable/Optional\*                     | [High/Medium/Low] | Depends on routing/auth design.                      |
+| Mail handler (`mail.goldshore.ai`)                                                                                           | No Access                                | [artifact reference or `not collected`]        | Public                                      | [High/Medium/Low] | Cloudflare mail routing cannot authenticate.         |
+
+\* Keep `api.goldshore.ai` and `gw.goldshore.ai` as `Configurable/Optional` unless a live Access application binding is explicitly proven.
 
 ## GitHub App callback URLs
 

--- a/docs/infra/WEEKLY_INFRA_REPORT_TEMPLATE.md
+++ b/docs/infra/WEEKLY_INFRA_REPORT_TEMPLATE.md
@@ -5,61 +5,93 @@
 **Phase:** [Current Phase, e.g., Phase 4 - Frontend Stabilization]
 
 ## 1. Executive Summary
-*   **Overall Status:** [GREEN / YELLOW / RED]
-*   **Key Achievement:** [e.g., Frontend Integrity Verified]
-*   **Critical Blockers:** [List or None]
+
+- **Overall Status:** [GREEN / YELLOW / RED]
+- **Key Achievement:** [e.g., Frontend Integrity Verified]
+- **Critical Blockers:** [List or None]
 
 ## 2. Workflow Health
-*   **Total Workflows:** [Number]
-*   **Passing:** [Number]
-*   **Failing:** [Number]
-*   **Disabled:** [Number] (gs-agent, gs-control, etc.)
 
-| Workflow | Status | Failure Reason | Action |
-| :--- | :--- | :--- | :--- |
-| Deploy GS Web | ✅ / ❌ | | |
-| Deploy GS API | ✅ / ❌ | | |
-| Stabilization Task | ✅ / ❌ | | |
+- **Total Workflows:** [Number]
+- **Passing:** [Number]
+- **Failing:** [Number]
+- **Disabled:** [Number] (gs-agent, gs-control, etc.)
+
+| Workflow           | Status  | Failure Reason | Action |
+| :----------------- | :------ | :------------- | :----- |
+| Deploy GS Web      | ✅ / ❌ |                |        |
+| Deploy GS API      | ✅ / ❌ |                |        |
+| Stabilization Task | ✅ / ❌ |                |        |
 
 ## 3. Branch Hygiene
-*   **Total Branches:** [Number] (Target: < 15)
-*   **Stale Branches (> 14 days):** [Number]
-*   **Stabilization Branches:** [Number]
+
+- **Total Branches:** [Number] (Target: < 15)
+- **Stale Branches (> 14 days):** [Number]
+- **Stabilization Branches:** [Number]
 
 **Action Required:**
+
 - [ ] Delete branch `x`
 - [ ] Merge PR `y`
 
 ## 4. Production Render Status
+
 **Target:** goldshore.ai (gs-web)
 
-| Check | Status | Notes |
-| :--- | :--- | :--- |
-| HTTP 200 OK | ✅ / ❌ | |
-| CSS Loaded | ✅ / ❌ | |
-| JS Loaded | ✅ / ❌ | |
-| No WAF Challenge | ✅ / ❌ | |
-| Logo Rendered | ✅ / ❌ | |
-| Font Loaded | ✅ / ❌ | |
+| Check            | Status  | Notes |
+| :--------------- | :------ | :---- |
+| HTTP 200 OK      | ✅ / ❌ |       |
+| CSS Loaded       | ✅ / ❌ |       |
+| JS Loaded        | ✅ / ❌ |       |
+| No WAF Challenge | ✅ / ❌ |       |
+| Logo Rendered    | ✅ / ❌ |       |
+| Font Loaded      | ✅ / ❌ |       |
 
 **Target:** admin.goldshore.ai (gs-admin)
 
-| Check | Status | Notes |
-| :--- | :--- | :--- |
-| Access Login | ✅ / ❌ | |
-| Dashboard Load | ✅ / ❌ | |
+| Check          | Status  | Notes |
+| :------------- | :------ | :---- |
+| Access Login   | ✅ / ❌ |       |
+| Dashboard Load | ✅ / ❌ |       |
 
 ## 5. Governance Violations
-*   **New Violations:** [List or None]
-    *   e.g., Unapproved app folder created
-    *   e.g., Direct theme import in page
-*   **Resolved Violations:** [List]
+
+- **New Violations:** [List or None]
+  - e.g., Unapproved app folder created
+  - e.g., Direct theme import in page
+- **Resolved Violations:** [List]
 
 ## 6. Cloudflare Policy Alignment
-*   **Goldshore.ai Public:** [Yes/No]
-*   **WAF Rules Modified:** [Yes/No] (Should be No)
+
+### Evidence legend (required in generated reports)
+
+- **Declared (repo/docs):** policy claims from repository configuration and documentation artifacts.
+- **Verified live (Cloudflare Access API evidence):** policy state observed from live Cloudflare Access API output (application + policy bindings).
+- **Confidence level:**
+  - `High`: declared evidence and verified live evidence agree.
+  - `Medium`: only declared evidence is available, or live evidence is partial.
+  - `Low`: declared and live evidence disagree, or evidence is missing/ambiguous.
+
+> Static repository evidence must never be reported as live enforcement proof.
+
+| Domain                 | Declared (repo/docs)                     | Verified live (Cloudflare Access API evidence) | Enforcement classification                  | Confidence level  | Notes |
+| :--------------------- | :--------------------------------------- | :--------------------------------------------- | :------------------------------------------ | :---------------- | :---- |
+| `goldshore.ai`         | Public                                   | [Present/Absent + artifact ref]                | Public                                      | [High/Medium/Low] |       |
+| `www.goldshore.ai`     | Public                                   | [Present/Absent + artifact ref]                | Public                                      | [High/Medium/Low] |       |
+| `admin.goldshore.ai`   | Access protected                         | [Present/Absent + artifact ref]                | [Strictly enforced / Configurable/Optional] | [High/Medium/Low] |       |
+| `preview.goldshore.ai` | Access protected                         | [Present/Absent + artifact ref]                | [Strictly enforced / Configurable/Optional] | [High/Medium/Low] |       |
+| `ops.goldshore.ai`     | Access protected                         | [Present/Absent + artifact ref]                | [Strictly enforced / Configurable/Optional] | [High/Medium/Low] |       |
+| `api.goldshore.ai`     | Optional/depends on endpoint posture     | [Present/Absent + artifact ref]                | Configurable/Optional\*                     | [High/Medium/Low] |       |
+| `gw.goldshore.ai`      | Optional/depends on routing/auth posture | [Present/Absent + artifact ref]                | Configurable/Optional\*                     | [High/Medium/Low] |       |
+
+\* Keep `api.goldshore.ai` and `gw.goldshore.ai` as `Configurable/Optional` unless a live Access application binding is explicitly proven.
+
+`Strictly enforced` may only be used when declared evidence and verified live policy artifacts explicitly agree.
+
+- **WAF Rules Modified:** [Yes/No] (Should be No)
 
 ## 7. Next Week Goals
+
 1.  [Goal 1]
 2.  [Goal 2]
 3.  [Goal 3]


### PR DESCRIPTION
### Motivation
- Improve accuracy and auditability of Cloudflare Access reporting by separating static repository claims from live Cloudflare Access evidence.
- Avoid false assertions of enforcement by requiring a confidence model that reflects agreement or disagreement between declared and live artifacts.
- Treat `api.goldshore.ai` and `gw.goldshore.ai` conservatively as optional unless a live Access application binding is proven.

### Description
- Added an evidence legend and a domain-level table to `docs/infra/WEEKLY_INFRA_REPORT_TEMPLATE.md` that splits policy into `Declared (repo/docs)`, `Verified live (Cloudflare Access API evidence)`, and `Confidence level` with guidance for `High`/`Medium`/`Low` classifications.
- Added explicit enforcement classification rules in the report template that reserve `Strictly enforced` for cases where declared and verified-live artifacts agree and mark `api.goldshore.ai` and `gw.goldshore.ai` as `Configurable/Optional` by default.
- Aligned `docs/domains-and-auth.md` to the same declared/vetted/live evidence model and added the evidence legend and domain classification table to that document.
- Reformatted modified files with `prettier` to match project style.

### Testing
- Ran `pnpm exec prettier --check docs/domains-and-auth.md docs/infra/WEEKLY_INFRA_REPORT_TEMPLATE.md` to validate formatting and detected issues prior to fixing.
- Ran `pnpm exec prettier --write docs/domains-and-auth.md docs/infra/WEEKLY_INFRA_REPORT_TEMPLATE.md` and re-ran `pnpm exec prettier --check` which completed with no style errors.
- @Jules-Bot [review-request] Please review the updated reporting semantics and evidence classification guidance for Cloudflare Access policy documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a778f6449883318fb64b9055af9780)