### PR TITLE
Resolve merge conflicts in gs-agent and gs-mail configs

### DIFF
--- a/apps/gs-agent/package.json
+++ b/apps/gs-agent/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "deploy": "wrangler deploy --minify src/index.ts --config ../../infra/cloudflare/gs-agent.wrangler.toml",
+    "dev": "wrangler dev src/index.ts --config ../../infra/cloudflare/gs-agent.wrangler.toml --env dev",
+    "deploy": "wrangler deploy --minify src/index.ts --config ../../infra/cloudflare/gs-agent.wrangler.toml --env prod",
     "build": "npx wrangler deploy src/index.ts --dry-run --outdir=dist --config ../../infra/cloudflare/gs-agent.wrangler.toml --env prod --tsconfig ../../apps/gs-agent/tsconfig.json"
   },
   "dependencies": {

--- a/apps/gs-mail/tsconfig.json
+++ b/apps/gs-mail/tsconfig.json
@@ -2,13 +2,19 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["@cloudflare/workers-types"],
+    "types": [
+      "@cloudflare/workers-types"
+    ],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
### Motivation

- Reconcile merge conflicts reported for the agent and mail app configuration files to restore a buildable workspace state.
- Ensure `wrangler` commands reference a stable tsconfig path so builds do not fail due to relative resolution differences.
- Normalize `tsconfig.json` include scope for `apps/gs-mail` to avoid upstream merge churn.

### Description

- Updated `apps/gs-agent/package.json` scripts to keep the shared Wrangler config path and add explicit runtime targets by adding `--env dev` to the `dev` script and `--env prod` to the `deploy` script while preserving the working `build` script with an explicit `--tsconfig ../../apps/gs-agent/tsconfig.json` flag.
- Normalized `apps/gs-mail/tsconfig.json` formatting and changed `include` from `"src/**/*.ts"` to `"src"` while preserving compiler options and Cloudflare types.
- Reviewed `infra/cloudflare/gs-agent.wrangler.toml` as part of the conflict set and did not commit additional content changes after reconciliation.
- Requesting review of these conflict resolutions via `@Jules-Bot [review-request]`.

### Testing

- Ran `pnpm -C apps/gs-agent run build` and the wrangler dry-run completed successfully (build step passes).
- Ran `pnpm -C apps/gs-mail exec tsc --noEmit` and TypeScript reported pre-existing type errors in `apps/gs-mail/src/index.ts`, so the failure is unrelated to the config merge changes.
- Verified repository status with `git status` which is clean after committing the merge-resolution changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a79171e5988331acbffacfb157db8f)