### PR TITLE
Add ./styles/global.css export in theme package

### DIFF
--- a/goldshore-ai/packages/theme/package.json
+++ b/goldshore-ai/packages/theme/package.json
@@ -17,6 +17,7 @@
     "./styles/base": "./src/styles/base.css",
     "./styles/components": "./src/styles/components.css",
     "./styles/layout": "./src/styles/layout.css",
+    "./styles/global.css": "./index.css",
     "./manager": "./src/theme-manager.ts",
     "./assets/logo.svg": "./assets/logo.svg"
   }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,6 +17,7 @@
     "./styles/base": "./src/styles/base.css",
     "./styles/components": "./src/styles/components.css",
     "./styles/layout": "./src/styles/layout.css",
+    "./styles/global.css": "./index.css",
     "./manager": "./src/theme-manager.ts",
     "./assets/logo.svg": "./assets/logo.svg"
   }


### PR DESCRIPTION
### Motivation
- Provide a stable import path for the package's global stylesheet by aliasing a `./styles/global.css` export to the existing `index.css` entry in the theme package.

### Description
- Added an `"./styles/global.css": "./index.css"` export mapping to `package.json` in both `packages/theme` and `goldshore-ai/packages/theme` so consumers can import the global stylesheet via `@goldshore/theme/styles/global.css`.

### Testing
- No automated tests were run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7905300e88331af943f1bf6676d91)