### PR TITLE
Add gs-web style guardrails and align page-level styles to shared tokens

### DIFF
--- a/apps/gs-web/STYLE_GUARDRAILS.md
+++ b/apps/gs-web/STYLE_GUARDRAILS.md
@@ -1,0 +1,157 @@
+# STYLE_GUARDRAILS
+
+This document defines the approved design guardrails for `apps/gs-web`, based on existing shared theme tokens from `packages/theme` and shared component APIs from `@goldshore/ui`.
+
+## Source of truth
+
+- Theme tokens and scales: `packages/theme/src/styles/tokens.css`
+- Shared structural/component classes: `packages/theme/src/styles/components.css`
+- Shared layout classes: `packages/theme/src/styles/layout.css`
+- UI button API: `packages/ui/GSButton.astro` and `packages/ui/components/Button.astro`
+- App-level token aliases/overrides: `apps/gs-web/src/styles/global.css`
+
+## 1) Approved color tokens
+
+Use CSS variables only (no hardcoded hex/RGBA in page-level styles unless no token exists).
+
+### Background / surface
+
+- `--gs-bg`, `--gs-color-bg`
+- `--gs-surface`, `--gs-surface-strong`
+- `--gs-color-surface`, `--gs-color-muted-surface`
+- `--gs-bg-primary`, `--gs-bg-secondary`, `--gs-bg-surface`
+
+### Text
+
+- `--gs-text`, `--gs-color-text`, `--gs-text-primary`
+- `--gs-text-dim`, `--gs-color-subtle`, `--gs-text-muted`
+- `--gs-color-faint`
+
+### Accent / interactive
+
+- `--gs-primary`, `--gs-color-primary`
+- `--gs-primary-soft`, `--gs-accent-soft`
+- `--gs-accent`, `--gs-accent-strong`
+- `--gs-accent-blue`, `--gs-accent-cyan`, `--gs-accent-gold`
+
+### Status
+
+- `--gs-success`
+- `--gs-warning`
+- `--gs-danger`
+- `--gs-info`
+
+### Borders / effects
+
+- `--gs-border`, `--gs-color-border`, `--gs-color-border-strong`
+- `--gs-border-subtle`, `--gs-panel-border-subtle`
+- `--gs-shadow`, `--gs-shadow-soft`, `--gs-shadow-hard`
+
+---
+
+## 2) Approved spacing scale
+
+Prefer theme spacing tokens over literal `rem/px` values:
+
+- `--gs-space-0`: 0
+- `--gs-space-1`: 4px
+- `--gs-space-2`: 8px
+- `--gs-space-3`: 12px
+- `--gs-space-4`: 16px
+- `--gs-space-5`: 20px
+- `--gs-space-6`: 24px
+- `--gs-space-7`: 32px
+- `--gs-space-8`: 40px
+- `--gs-space-9`: 48px
+- `--gs-space-10`: 64px
+
+### Practical guidance
+
+- Section vertical rhythm: `--gs-space-8` to `--gs-space-10`
+- Card padding: `--gs-space-6`
+- Grid gaps: `--gs-space-4` to `--gs-space-6`
+- Small control spacing: `--gs-space-1` to `--gs-space-3`
+
+---
+
+## 3) Approved typography scale
+
+Use shared typography tokens and `clamp()` values already established in theme:
+
+- Body
+  - `--gs-font-body`
+  - `--gs-font-size-body` (1rem)
+  - `--gs-line-height` (1.6)
+- Display / heading
+  - `--gs-font-display`
+  - `--gs-font-heading`
+  - `--gs-font-size-h1`: `clamp(2rem, 3.6vw, 3.6rem)`
+  - `--gs-font-size-h2`: `clamp(1.5rem, 2.5vw, 2.25rem)`
+  - `--gs-font-size-h3`: 1.5rem
+  - `--gs-font-size-h4`: 1.25rem
+  - `--gs-font-size-h5`: 1rem
+  - `--gs-font-size-h6`: 0.875rem
+
+### Practical guidance
+
+- Page hero `h1` can use stronger local `clamp()` sizing, but color and spacing should still align with shared tokens.
+- Supporting paragraph copy should use text tokens (`--gs-text-dim`, `--gs-color-subtle`) and line-height ~1.6–1.75.
+
+---
+
+## 4) Approved component variants
+
+## Hero
+
+- Preferred container: `FlowSection variant="hero"` (uses `.gs-hero`).
+- For custom hero implementations, keep visual language aligned to:
+  - shared accent tokens (`--gs-primary`, `--gs-accent-*`)
+  - shared surface/border tokens
+  - shared spacing scale
+
+## Section card
+
+- Preferred class: `.gs-card` (from theme components).
+- Card visuals should use shared tokens:
+  - background: surface tokens
+  - border: border tokens
+  - radius: `--gs-radius-md` / `--gs-radius-lg`
+  - shadow: shared shadow tokens
+
+## CTA button
+
+Use `GSButton` / `Button` from `@goldshore/ui`.
+
+Approved variants:
+
+- `primary` (default)
+- `secondary`
+- `destructive`
+- `ghost`
+
+Approved size modifiers:
+
+- default
+- `.gs-button--small`
+- `.gs-button--large`
+
+## Form controls
+
+- Group controls with `.gs-input-group`.
+- Inputs/selects/textarea should inherit theme `field.css` styles and use tokenized text/surface/border colors.
+- Validation/progress messaging should use status tokens (`--gs-success`, `--gs-danger`, `--gs-info`) rather than hardcoded colors.
+
+---
+
+## 5) Enforcement rules for page-level styles
+
+When writing `<style>` blocks in pages:
+
+1. Prefer shared class utilities (`.gs-card`, `.gs-grid`, `.gs-hero`, `.gs-section`) before creating one-off styling.
+2. Prefer token variables for:
+   - color
+   - spacing
+   - radius
+   - shadows
+3. Avoid introducing raw color literals for new styles.
+4. If a new semantic style is needed repeatedly, promote it into shared theme styles instead of duplicating page-level CSS.

--- a/apps/gs-web/src/pages/about.astro
+++ b/apps/gs-web/src/pages/about.astro
@@ -37,7 +37,7 @@ const sections = [
 
   <style>
     .info-page {
-      padding: 4.5rem 0 5rem;
+      padding: var(--gs-space-9) 0 calc(var(--gs-space-10) + var(--gs-space-1));
     }
 
     .info-page h1 {
@@ -57,15 +57,15 @@ const sections = [
     .info-grid {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 1rem;
-      margin-top: 2rem;
+      gap: var(--gs-space-4);
+      margin-top: var(--gs-space-7);
     }
 
     .info-card {
-      padding: 1.4rem;
-      border-radius: 20px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      background: rgba(10, 18, 36, 0.72);
+      padding: var(--gs-space-6);
+      border-radius: var(--gs-radius-lg);
+      border: 1px solid var(--gs-border);
+      background: var(--gs-surface);
       box-shadow: var(--gs-shadow);
     }
 

--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -266,35 +266,35 @@ export const prerender = true;
     }
 
     .field-help {
-      margin: 0.25rem 0 0.5rem;
-      color: var(--gs-color-text-muted, #94a3b8);
+      margin: var(--gs-space-1) 0 var(--gs-space-2);
+      color: var(--gs-text-dim);
       font-size: 0.95rem;
     }
 
     .form-status {
-      margin: 0.75rem 0;
-      padding: 0.75rem 1rem;
-      border-radius: 0.5rem;
+      margin: var(--gs-space-3) 0;
+      padding: var(--gs-space-3) var(--gs-space-4);
+      border-radius: var(--gs-radius-sm);
       border: 1px solid transparent;
       min-height: 1.25rem;
     }
 
     .form-status.progress {
-      background: rgba(37, 52, 138, 0.12);
-      border-color: rgba(96, 116, 211, 0.45);
-      color: #c7d2fe;
+      background: color-mix(in srgb, var(--gs-info) 14%, transparent);
+      border-color: color-mix(in srgb, var(--gs-info) 48%, transparent);
+      color: color-mix(in srgb, var(--gs-info) 65%, white);
     }
 
     .form-status.success {
-      background: rgba(10, 95, 37, 0.14);
-      border-color: rgba(110, 231, 183, 0.35);
-      color: #bbf7d0;
+      background: color-mix(in srgb, var(--gs-success) 14%, transparent);
+      border-color: color-mix(in srgb, var(--gs-success) 42%, transparent);
+      color: color-mix(in srgb, var(--gs-success) 60%, white);
     }
 
     .form-status.error {
-      background: rgba(143, 23, 23, 0.14);
-      border-color: rgba(248, 113, 113, 0.35);
-      color: #fecaca;
+      background: color-mix(in srgb, var(--gs-danger) 14%, transparent);
+      border-color: color-mix(in srgb, var(--gs-danger) 42%, transparent);
+      color: color-mix(in srgb, var(--gs-danger) 62%, white);
     }
 
     #contact-form button[disabled] {

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -282,7 +282,7 @@ const proofPoints = [
 
   <style>
     .home-page {
-      padding-bottom: 4rem;
+      padding-bottom: var(--gs-space-10);
     }
 
     .hero {
@@ -291,7 +291,7 @@ const proofPoints = [
       display: grid;
       align-items: end;
       overflow: hidden;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      border-bottom: 1px solid var(--gs-border);
     }
 
     #wave-bg,
@@ -333,7 +333,7 @@ const proofPoints = [
     .gs-logo-reactive {
       width: clamp(72px, 11vw, 120px);
       height: auto;
-      color: #8ec1ff;
+      color: var(--gs-primary);
       will-change: transform, filter;
     }
 
@@ -407,9 +407,9 @@ const proofPoints = [
 
     .hero-actions {
       display: flex;
-      gap: 0.9rem;
+      gap: var(--gs-space-4);
       flex-wrap: wrap;
-      margin-top: 1.5rem;
+      margin-top: var(--gs-space-6);
     }
 
     .hero-button {
@@ -418,9 +418,9 @@ const proofPoints = [
       justify-content: center;
       padding: 0.9rem 1.2rem;
       border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.04);
-      color: #fff;
+      border: 1px solid var(--gs-border);
+      background: var(--gs-primary-soft);
+      color: var(--gs-text);
       text-decoration: none;
       transition:
         transform 160ms ease,
@@ -431,13 +431,13 @@ const proofPoints = [
     .hero-button:hover,
     .hero-button:focus-visible {
       transform: translateY(-1px);
-      border-color: rgba(90, 162, 255, 0.36);
-      background: rgba(90, 162, 255, 0.14);
+      border-color: var(--gs-primary);
+      background: color-mix(in srgb, var(--gs-primary) 20%, transparent);
     }
 
     .hero-button--primary {
-      border-color: rgba(90, 162, 255, 0.28);
-      background: rgba(90, 162, 255, 0.18);
+      border-color: var(--gs-primary);
+      background: color-mix(in srgb, var(--gs-primary) 24%, transparent);
       box-shadow: 0 18px 42px rgba(9, 17, 33, 0.28);
     }
 
@@ -447,16 +447,16 @@ const proofPoints = [
     .proof-card,
     .team-card,
     .contact-cta {
-      padding: 1.25rem;
-      border-radius: 20px;
-      border: 1px solid rgba(255, 255, 255, 0.06);
-      background: rgba(10, 18, 36, 0.74);
+      padding: var(--gs-space-6);
+      border-radius: var(--gs-radius-lg);
+      border: 1px solid var(--gs-border);
+      background: var(--gs-surface);
       box-shadow: var(--gs-shadow);
     }
 
     .hero-panel {
       border-color: var(--gs-border);
-      background: rgba(10, 18, 36, 0.8);
+      background: var(--gs-surface-strong);
       backdrop-filter: blur(12px);
     }
 
@@ -474,8 +474,8 @@ const proofPoints = [
       padding: 0.95rem 1rem;
       margin-bottom: 1rem;
       border-radius: 18px;
-      border: 1px solid rgba(90, 162, 255, 0.18);
-      background: rgba(90, 162, 255, 0.08);
+      border: 1px solid var(--gs-border);
+      background: var(--gs-primary-soft);
     }
 
     .status-banner strong {
@@ -514,7 +514,7 @@ const proofPoints = [
     .proof-grid,
     .team-row {
       display: grid;
-      gap: 1rem;
+      gap: var(--gs-space-4);
     }
 
     .signal-strip {
@@ -577,7 +577,7 @@ const proofPoints = [
     .signal-link {
       display: inline-flex;
       margin-top: 0.85rem;
-      color: #b2d7ff;
+      color: var(--gs-primary);
       text-decoration: none;
       font-weight: 700;
     }


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Document and lock down which theme tokens and component APIs are approved for use in `apps/gs-web` to avoid ad-hoc page-level styles. 
- Ensure marketing pages use the shared design system (`packages/theme` + `@goldshore/ui`) tokens for colors, spacing, typography, and component visuals. 

### Description
- Added `apps/gs-web/STYLE_GUARDRAILS.md` that codifies approved color tokens, spacing scale, typography scale, and component variants (hero, section card, CTA button, form controls). 
- Refactored page-level inline styles to use shared tokens and utilities on prioritized pages: `apps/gs-web/src/pages/index.astro`, `about.astro`, and `contact.astro`. 
- Replaced hardcoded spacings, radii, borders, background and accent colors with theme CSS variables (e.g. `--gs-space-*`, `--gs-border`, `--gs-surface`, `--gs-primary`, and status tokens via `--gs-info`, `--gs-success`, `--gs-danger` / `color-mix`). 
- Kept changes scoped to page-level inline `<style>` blocks and documentation; did not alter shared theme or component code behavior. 

### Testing
- Ran `pnpm -C apps/gs-web check` to validate the app, which failed because the environment is missing installed dependencies (`astro` / `node_modules` not available). 
- No other automated unit or e2e tests were run in this environment due to missing app dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d19211be5c8331b07f9224d6be63d8)