### PR TITLE
Add About sections and convert Services to packaged offerings

### DIFF
--- a/apps/gs-web/src/pages/about.astro
+++ b/apps/gs-web/src/pages/about.astro
@@ -5,16 +5,20 @@ export const prerender = true;
 
 const sections = [
   {
-    title: 'What we do',
-    body: 'We design high-trust systems across decision support, workflow orchestration, and applied AI.',
+    title: 'Mission',
+    body: 'Build dependable AI-enabled systems that improve decision quality, reduce operational drag, and hold up under real production pressure.',
   },
   {
-    title: 'How we work',
-    body: 'Signal over spectacle. Systems that explain themselves.',
+    title: 'Operating principles',
+    body: 'We optimize for clarity, measurable outcomes, and maintainability: explicit ownership, observable workflows, and controls that operators can trust.',
   },
   {
-    title: 'Why GoldShore',
-    body: 'Most software is optimized for demos. GoldShore is optimized for use.',
+    title: 'Delivery model',
+    body: 'Every engagement starts with scoped discovery, moves into a tightly defined build sprint, and ends with hardening, handoff, and an adoption runway.',
+  },
+  {
+    title: 'Trust & security stance',
+    body: 'Security is part of system design—not a final checklist. Least-privilege access, auditable automation, and policy-aware defaults are built in from day one.',
   },
 ];
 ---
@@ -56,7 +60,7 @@ const sections = [
 
     .info-grid {
       display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 1rem;
       margin-top: 2rem;
     }

--- a/apps/gs-web/src/pages/services.astro
+++ b/apps/gs-web/src/pages/services.astro
@@ -7,30 +7,48 @@ export const prerender = true;
 
 const services = [
   {
-    name: 'Operations Control',
-    detail: 'Observability dashboards, incident automation, and policy-driven safeguards.',
-    cta: '/contact'
-  },
-  {
-    name: 'AI Execution',
-    detail: 'Signal ingestion, strategy deployment, and guardrailed automation for trading.',
-    cta: '/contact'
-  },
-  {
-    name: 'Edge Intelligence',
-    detail: 'Low-latency inference and routing tuned for reliability across regions.',
-    cta: '/contact'
-  },
-  {
-    name: 'Client Intake',
-    detail: 'Capture and qualify inbound opportunities with automation-ready workflows.',
-    bullets: [
-      'Lead capture form',
-      'CRM integration (HubSpot/Salesforce)',
-      'Billing integration (Stripe/PayPal)',
-      'Opportunity ranking pipeline surfaced in admin dashboards with KPIs'
+    name: 'AI Readiness Sprint',
+    scope: 'Baseline architecture, data pathways, and delivery constraints to establish a high-confidence AI roadmap.',
+    deliverables: [
+      'Current-state systems and risk assessment',
+      'Prioritized opportunity map with implementation sequencing',
+      '90-day execution plan with ownership model'
     ],
-    cta: '/contact'
+    timeline: '2–3 weeks',
+    inquiry: 'AI Readiness Sprint'
+  },
+  {
+    name: 'Operational Control Plane',
+    scope: 'Design and implement operator-facing control surfaces for observability, incident response, and policy enforcement.',
+    deliverables: [
+      'Unified dashboard and alerting model',
+      'Incident automation runbooks',
+      'Access policy and audit trail integration'
+    ],
+    timeline: '4–8 weeks',
+    inquiry: 'Operational Control Plane'
+  },
+  {
+    name: 'Workflow Automation Build',
+    scope: 'Automate high-friction workflows across intake, triage, and execution with guardrails for reliability and compliance.',
+    deliverables: [
+      'Workflow orchestration with fallback handling',
+      'Systems integrations (CRM, billing, support, or internal tooling)',
+      'KPI instrumentation and performance reporting'
+    ],
+    timeline: '3–6 weeks',
+    inquiry: 'Workflow Automation Build'
+  },
+  {
+    name: 'Trust & Security Hardening',
+    scope: 'Embed practical security controls into delivery pipelines, runtime operations, and agentic automation.',
+    deliverables: [
+      'Least-privilege role and access model',
+      'Policy checks for deployments and automations',
+      'Security posture memo with prioritized remediation plan'
+    ],
+    timeline: '2–4 weeks',
+    inquiry: 'Trust & Security Hardening'
   }
 ];
 ---
@@ -38,55 +56,51 @@ const services = [
   <FlowSection variant="hero">
     <div>
       <h1>Services</h1>
-      <p>Crafted delivery engagements that combine platform engineering, AI execution, and operational rigor.</p>
-      <GSButton href="/contact">Request a scoping call</GSButton>
+      <p>Packaged engagements that combine platform engineering, AI execution, and operational rigor.</p>
+      <GSButton href="/contact?inquiry=General%20Services%20Inquiry">Request a scoping call</GSButton>
     </div>
     <div class="gs-card">
       <h3 class="section-title"><span>☍</span>Engagement highlights</h3>
       <ul>
-        <li>Architecture assessments with action plans</li>
-        <li>Deployment of shared observability foundations</li>
-        <li>Security reviews with access and automation policy updates</li>
+        <li>Defined scope with practical rollout plans</li>
+        <li>Concrete deliverables mapped to measurable outcomes</li>
+        <li>Timeline bands designed for fast execution and clear checkpoints</li>
       </ul>
     </div>
   </FlowSection>
 
   <FlowSection>
-    <div class="gs-grid columns-3">
+    <div class="gs-grid columns-2 service-grid">
       {services.map((service) => (
-        <article class="gs-card">
+        <article class="gs-card service-card">
           <h3>{service.name}</h3>
-          <p>{service.detail}</p>
-          {service.bullets ? (
-            <ul class="gs-text-sm">
-              {service.bullets.map((item) => (
-                <li>{item}</li>
-              ))}
-            </ul>
-          ) : null}
-          <GSButton href={service.cta} variant="secondary" class="gs-button--small">Talk to us</GSButton>
+          <p><strong>Scope:</strong> {service.scope}</p>
+          <p><strong>Timeline:</strong> {service.timeline}</p>
+          <h4>Deliverables</h4>
+          <ul class="gs-text-sm">
+            {service.deliverables.map((item) => (
+              <li>{item}</li>
+            ))}
+          </ul>
+          <GSButton href={`/contact?inquiry=${encodeURIComponent(service.inquiry)}`} variant="secondary" class="gs-button--small">
+            Start this engagement
+          </GSButton>
         </article>
       ))}
     </div>
   </FlowSection>
 
-  <FlowSection>
-    <div class="gs-grid columns-2">
-      <div>
-        <h2>Snapshot</h2>
-        <p class="gs-text-lg">Focused delivery for teams that need reliable systems and clear momentum.</p>
-        <GSButton href="/contact" variant="secondary">Plan the engagement</GSButton>
-      </div>
-      <div class="gs-card">
-        <h3 class="section-title"><span>◆</span>Snapshot</h3>
-        <ul>
-          <li><strong>Current Focus:</strong> High-availability automation, observability, and AI execution.</li>
-          <li><strong>What I build:</strong> Control planes, incident workflows, and operator-grade interfaces.</li>
-          <li><strong>How I work:</strong> Scoped pilots, rapid delivery, and hardening with shared KPIs.</li>
-          <li><strong>Availability:</strong> Full-time or contract, tailored to your delivery window.</li>
-        </ul>
-        <p class="gs-text-sm">If you’re ready to move fast, let’s define a delivery plan.</p>
-      </div>
-    </div>
-  </FlowSection>
+  <style>
+    .service-grid {
+      gap: 1rem;
+    }
+
+    .service-card h4 {
+      margin: 1rem 0 0.5rem;
+      font-size: 0.95rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--gs-text-dim);
+    }
+  </style>
 </BaseLayout>


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Provide clearer messaging about GoldShore's mission, operating principles, delivery model, and trust/security stance to surface buyer expectations and risk posture. 
- Present services as opinionated, packaged engagements with predictable scope and timelines to simplify discovery and conversion. 
- Prefill contact context so inquiries carry the intended service intent to improve qualification.

### Description
- Updated `apps/gs-web/src/pages/about.astro` to add four sections: `Mission`, `Operating principles`, `Delivery model`, and `Trust & security stance`, and adjusted the info grid to a two-column layout. 
- Reworked `apps/gs-web/src/pages/services.astro` to define four packaged services (`AI Readiness Sprint`, `Operational Control Plane`, `Workflow Automation Build`, `Trust & Security Hardening`) each with `scope`, `deliverables`, and `timeline` fields. 
- Replaced generic CTAs so the hero CTA and each service card link to `/contact` with a prefilled `inquiry` query string (using `encodeURIComponent` for each service), and removed the old snapshot block in favor of the packaged layout. 
- Added minimal CSS for the `.service-grid` and `.service-card h4` styles to match the new card structure.

### Testing
- Ran `pnpm exec prettier --check apps/gs-web/src/pages/about.astro apps/gs-web/src/pages/services.astro` which failed due to a missing `prettier-plugin-astro` dependency in the environment, so formatting could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1921e41c88331aae4b2123f3561bb)