### PR TITLE
Contact: strict validation, dedupe, delivery logging, and analytics

### DIFF
--- a/apps/gs-web/src/pages/api/contact.ts
+++ b/apps/gs-web/src/pages/api/contact.ts
@@ -25,6 +25,8 @@ type Submission = {
   receivedAt: string;
   ipAddress?: string;
   userAgent?: string;
+  inquiry?: string;
+  dedupeKey?: string;
 };
 
 type FormField = {
@@ -136,6 +138,55 @@ const storeInD1 = async (
 const extractString = (value: FormDataEntryValue | null) =>
   typeof value === 'string' ? value.trim() : '';
 
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+const normalizeMultiline = (value: string) =>
+  value
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+const allowedInquiryTypes = new Set([
+  'general',
+  'strategy-call',
+  'project-scope',
+  'support',
+]);
+
+const normalizeContactSubmission = (submission: Submission) => {
+  const normalizedEmail = submission.email.trim().toLowerCase();
+  const normalizedInquiry = submission.inquiry?.trim().toLowerCase() || 'general';
+  return {
+    ...submission,
+    name: normalizeWhitespace(submission.name),
+    email: normalizedEmail,
+    inquiry: allowedInquiryTypes.has(normalizedInquiry) ? normalizedInquiry : '',
+    message: normalizeMultiline(submission.message),
+    dedupeKey: submission.dedupeKey?.trim().toLowerCase() || '',
+  };
+};
+
+const validateContactSubmission = (submission: Submission): string[] => {
+  const errors: string[] = [];
+  if (!submission.name || submission.name.length < 2 || submission.name.length > 120) {
+    errors.push('name');
+  }
+  if (!submission.email || !isValidEmail(submission.email)) {
+    errors.push('email');
+  }
+  if (!submission.inquiry || !allowedInquiryTypes.has(submission.inquiry)) {
+    errors.push('inquiry');
+  }
+  if (!submission.message || submission.message.length < 20 || submission.message.length > 4000) {
+    errors.push('message');
+  }
+  if (!submission.dedupeKey || !/^[a-f0-9]{64}$/.test(submission.dedupeKey)) {
+    errors.push('dedupeKey');
+  }
+  return errors;
+};
+
 const isSpamSubmission = (formData: FormData) => {
   const honeypot = extractString(formData.get('companyWebsite'));
   if (honeypot) return true;
@@ -236,6 +287,23 @@ const validateRequiredFields = (submission: Submission, fields: FormField[]) => 
   return missing;
 };
 
+const checkRecentDuplicate = async (db: D1Database, submission: Submission): Promise<boolean> => {
+  const duplicateResult = await db
+    .prepare(
+      `SELECT id
+       FROM lead_submissions
+       WHERE form_type = ?
+         AND email = ?
+         AND message = ?
+         AND received_at >= datetime('now', '-15 minutes')
+       LIMIT 1`
+    )
+    .bind(submission.formType, submission.email, submission.message)
+    .first<{ id: string }>();
+
+  return Boolean(duplicateResult?.id);
+};
+
 const safeRedirect = (redirectTo: string | null, origin: string) => {
   if (!redirectTo) return new URL('/thank-you', origin);
   const trimmed = redirectTo.trim();
@@ -310,6 +378,9 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const formType = extractString(formData.get('formType')) || 'contact';
   const redirectTo = extractString(formData.get('redirectTo'));
   const isSpam = isSpamSubmission(formData);
+  const adminErrorView =
+    request.headers.get('x-gs-admin-error-view') === '1' ||
+    request.headers.get('x-gs-admin-error-view') === 'true';
 
   const submission: Submission = {
     id: crypto.randomUUID(),
@@ -329,15 +400,20 @@ export const POST: APIRoute = async ({ request, locals }) => {
     receivedAt: new Date().toISOString(),
     ipAddress: request.headers.get('CF-Connecting-IP') ?? undefined,
     userAgent: request.headers.get('User-Agent') ?? undefined,
+    inquiry: extractString(formData.get('inquiry')),
+    dedupeKey: extractString(formData.get('dedupeKey')),
   };
+
+  const normalizedSubmission = normalizeContactSubmission(submission);
 
   if (isSpam) {
     const redirectUrl = safeRedirect(redirectTo, new URL(request.url).origin);
     return Response.redirect(redirectUrl, 303);
   }
 
-  if (submission.email && !isValidEmail(submission.email)) {
-    return new Response('Invalid email address.', { status: 400 });
+  const validationErrors = validateContactSubmission(normalizedSubmission);
+  if (validationErrors.length > 0) {
+    return new Response('Invalid form fields.', { status: 400 });
   }
 
   const env = locals.runtime?.env as Env | undefined;
@@ -357,7 +433,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     return new Response('Form is not accepting submissions.', { status: 403 });
   }
 
-  const missingFields = validateRequiredFields(submission, formConfig.fields);
+  const missingFields = validateRequiredFields(normalizedSubmission, formConfig.fields);
   if (missingFields.length > 0) {
     if (env?.DB) {
       await logSubmissionStatus(env.DB, submission.id, formType, 'rejected', 'Missing required fields.', {
@@ -370,14 +446,30 @@ export const POST: APIRoute = async ({ request, locals }) => {
   const ttl = env?.CONTACT_TTL_SECONDS ? parseInt(env.CONTACT_TTL_SECONDS, 10) : DEFAULT_CONTACT_TTL_SECONDS;
 
   const autoResponder = buildLeadAutoResponder({
-    name: submission.name,
-    formType: submission.formType,
+    name: normalizedSubmission.name,
+    formType: normalizedSubmission.formType,
   });
+
+  if (env?.DB) {
+    const isDuplicate = await checkRecentDuplicate(env.DB, normalizedSubmission);
+    if (isDuplicate) {
+      await logSubmissionStatus(
+        env.DB,
+        normalizedSubmission.id,
+        formType,
+        'duplicate',
+        'Repeated submission detected within dedupe window.',
+        { dedupeKey: normalizedSubmission.dedupeKey }
+      );
+      const redirectUrl = safeRedirect(redirectTo, new URL(request.url).origin);
+      return Response.redirect(redirectUrl, 303);
+    }
+  }
 
   const storageTasks: Promise<unknown>[] = [];
   if (env?.KV)
-    storageTasks.push(storeInKv(env.KV, submission, autoResponder, ttl));
-  if (env?.DB) storageTasks.push(storeInD1(env.DB, submission, autoResponder));
+    storageTasks.push(storeInKv(env.KV, normalizedSubmission, autoResponder, ttl));
+  if (env?.DB) storageTasks.push(storeInD1(env.DB, normalizedSubmission, autoResponder));
 
   const storageResults = await Promise.allSettled(storageTasks);
   const storedSuccessfully = storageResults.some(
@@ -393,10 +485,74 @@ export const POST: APIRoute = async ({ request, locals }) => {
   }
 
   if (env?.DB) {
-    await logSubmissionStatus(env.DB, submission.id, formType, 'stored', 'Submission stored successfully.', {
+    await logSubmissionStatus(env.DB, normalizedSubmission.id, formType, 'stored', 'Submission stored successfully.', {
+      dedupeKey: normalizedSubmission.dedupeKey,
       recipients: formConfig.recipients,
       integrations: formConfig.integrations
     });
+  }
+
+  const notificationRecipients =
+    formConfig.recipients
+      ?.map((recipient) => ({
+        email: recipient.email?.trim().toLowerCase(),
+        name: recipient.name?.trim(),
+      }))
+      .filter((recipient): recipient is MailRecipient => Boolean(recipient.email && isValidEmail(recipient.email))) ?? [];
+
+  if (notificationRecipients.length > 0) {
+    if (env?.DB) {
+      await logSubmissionStatus(
+        env.DB,
+        normalizedSubmission.id,
+        formType,
+        'queued',
+        'Email delivery queued.',
+        { recipients: notificationRecipients.length }
+      );
+    }
+
+    const deliveryResult = await sendMail(
+      env,
+      notificationRecipients,
+      `[${normalizedSubmission.formType}] New contact inquiry from ${normalizedSubmission.name}`,
+      `${normalizedSubmission.name} (${normalizedSubmission.email}) submitted a new ${normalizedSubmission.inquiry} inquiry.\n\n${normalizedSubmission.message}`,
+      `<p><strong>Name:</strong> ${normalizedSubmission.name}</p><p><strong>Email:</strong> ${normalizedSubmission.email}</p><p><strong>Inquiry:</strong> ${normalizedSubmission.inquiry}</p><p><strong>Message:</strong></p><p>${normalizedSubmission.message.replace(/\n/g, '<br />')}</p>`,
+      { email: normalizedSubmission.email, name: normalizedSubmission.name }
+    );
+
+    if (env?.DB) {
+      await logSubmissionStatus(
+        env.DB,
+        normalizedSubmission.id,
+        formType,
+        deliveryResult.attempted && deliveryResult.ok ? 'sent' : 'failed',
+        deliveryResult.attempted && deliveryResult.ok
+          ? 'Email delivery sent successfully.'
+          : 'Email delivery failed.',
+        {
+          attempted: deliveryResult.attempted,
+          status: 'status' in deliveryResult ? deliveryResult.status : undefined,
+          reason: 'reason' in deliveryResult ? deliveryResult.reason : undefined,
+        }
+      );
+    }
+
+    if (adminErrorView && (!deliveryResult.attempted || !deliveryResult.ok)) {
+      return new Response(
+        JSON.stringify({
+          error: 'email_delivery_failed',
+          submissionId: normalizedSubmission.id,
+          details: deliveryResult,
+        }),
+        {
+          status: 502,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      );
+    }
   }
 
   const redirectUrl = safeRedirect(redirectTo, new URL(request.url).origin);

--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -28,6 +28,7 @@ export const prerender = true;
       <input type="hidden" name="formType" value="contact" />
       <input type="hidden" name="redirectTo" value="/thank-you" />
       <input type="hidden" name="formStartedAt" value="" />
+      <input type="hidden" name="dedupeKey" value="" />
 
       <div class="gs-honeypot" aria-hidden="true">
         <label for="companyWebsite">Company website</label>
@@ -74,15 +75,6 @@ export const prerender = true;
         </select>
       </div>
 
-      <div class="gs-input-group">
-        <label for="inquiry">Inquiry type</label>
-        <select id="inquiry" name="inquiry" autocomplete="off">
-          <option value="general">General inquiry</option>
-          <option value="strategy-call">Strategy call</option>
-          <option value="project-scope">Project scoping</option>
-          <option value="support">Support</option>
-        </select>
-      </div>
       <div class="gs-input-group">
         <label for="message">Project brief</label>
         <p id="message-help" class="field-help">
@@ -164,10 +156,65 @@ export const prerender = true;
       }
     };
 
+    const emitAnalytics = (eventName, payload = {}) => {
+      const eventPayload = {
+        event: eventName,
+        page: window.location.pathname,
+        ...payload,
+      };
+      window.dataLayer = window.dataLayer || [];
+      if (Array.isArray(window.dataLayer)) {
+        window.dataLayer.push(eventPayload);
+      }
+      window.dispatchEvent(
+        new CustomEvent('gs:analytics', {
+          detail: eventPayload,
+        }),
+      );
+    };
+
+    const toHex = (buffer) =>
+      Array.from(new Uint8Array(buffer))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+
+    const buildDedupeKey = async (currentForm) => {
+      const name = currentForm.querySelector('#name');
+      const email = currentForm.querySelector('#email');
+      const inquiry = currentForm.querySelector('#inquiry');
+      const message = currentForm.querySelector('#message');
+      const formTypeField = currentForm.querySelector('[name="formType"]');
+
+      const normalized = [
+        formTypeField instanceof HTMLInputElement
+          ? formTypeField.value.trim().toLowerCase()
+          : 'contact',
+        name instanceof HTMLInputElement
+          ? name.value.trim().toLowerCase().replace(/\s+/g, ' ')
+          : '',
+        email instanceof HTMLInputElement
+          ? email.value.trim().toLowerCase()
+          : '',
+        inquiry instanceof HTMLSelectElement
+          ? inquiry.value.trim().toLowerCase()
+          : '',
+        message instanceof HTMLTextAreaElement
+          ? message.value.trim().replace(/\s+/g, ' ')
+          : '',
+      ].join('|');
+
+      const hash = await crypto.subtle.digest(
+        'SHA-256',
+        new TextEncoder().encode(normalized),
+      );
+      return toHex(hash);
+    };
+
     if (
       form instanceof HTMLFormElement &&
       button instanceof HTMLButtonElement
     ) {
+      let formStartedTracked = false;
       const startedAtField = form.querySelector('[name="formStartedAt"]');
       if (startedAtField instanceof HTMLInputElement) {
         startedAtField.value = String(Date.now());
@@ -191,6 +238,15 @@ export const prerender = true;
       ) {
         inquiryField.value = inquiryParam;
       }
+
+      const markFormStart = () => {
+        if (formStartedTracked) return;
+        formStartedTracked = true;
+        emitAnalytics('form_start', { form_type: 'contact' });
+      };
+
+      form.addEventListener('focusin', markFormStart, { once: true });
+      form.addEventListener('input', markFormStart, { once: true });
 
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
@@ -217,6 +273,11 @@ export const prerender = true;
         setStatus('Sending your message...', 'progress');
 
         try {
+          const dedupeKeyField = form.querySelector('[name="dedupeKey"]');
+          if (dedupeKeyField instanceof HTMLInputElement) {
+            dedupeKeyField.value = await buildDedupeKey(form);
+          }
+
           const response = await fetch(
             form.getAttribute('action') || '/api/contact',
             {
@@ -238,6 +299,7 @@ export const prerender = true;
                 ? redirectToField.value
                 : '/thank-you';
 
+          emitAnalytics('form_submit_success', { form_type: 'contact' });
           window.location.href = redirectTarget;
         } catch (error) {
           console.error(error);
@@ -250,6 +312,7 @@ export const prerender = true;
             'Unable to send message right now. Please try again or email hello@goldshore.ai.',
             'error',
           );
+          emitAnalytics('form_submit_error', { form_type: 'contact' });
         }
       });
     }

--- a/apps/gs-web/src/pages/thank-you.astro
+++ b/apps/gs-web/src/pages/thank-you.astro
@@ -19,4 +19,19 @@ export const prerender = true;
       <GSButton href="/">Back to home</GSButton>
     </div>
   </section>
+  <script>
+    const payload = {
+      event: 'thank_you_view',
+      page: window.location.pathname,
+    };
+    window.dataLayer = window.dataLayer || [];
+    if (Array.isArray(window.dataLayer)) {
+      window.dataLayer.push(payload);
+    }
+    window.dispatchEvent(
+      new CustomEvent('gs:analytics', {
+        detail: payload,
+      }),
+    );
+  </script>
 </BaseLayout>


### PR DESCRIPTION
Merge strategy: squash

### Motivation

- Ensure contact UX remains client-side while strengthening server-side validation and normalization to reduce garbage and improve lead quality.  
- Prevent repeated submissions from creating duplicate alerts and give operators visibility into delivery status when outbound mail fails.  
- Capture simple analytics for form lifecycle events to measure form starts, successful submissions, errors, and thank-you views.

### Description

- Client: added a hidden `dedupeKey` and client-side SHA-256 generation of a normalized fingerprint before submit, removed the duplicate inquiry selector, and added analytics emission for `form_start`, `form_submit_success`, and `form_submit_error`.  
- API: added normalization helpers (`normalizeWhitespace`, `normalizeMultiline`) and `normalizeContactSubmission`, plus `validateContactSubmission` to enforce strict name/email/inquiry/message/dedupeKey rules and early-400 responses for invalid payloads.  
- Dedupe & storage: added a 15-minute duplicate check (`checkRecentDuplicate`) with explicit `duplicate` logging to `form_submission_logs`, and continued to persist submissions to KV/D1 even when email delivery is degraded.  
- Delivery & admin diagnostics: queued outbound delivery to configured recipients, logged `queued` → `sent`/`failed` statuses, and added an admin-visible diagnostic response when `x-gs-admin-error-view: 1|true` is present to surface provider failures as a structured `502` JSON payload.  
- Thank-you page: added a `thank_you_view` analytics event on page load.

### Testing

- Ran `pnpm --filter @goldshore/gs-web check` which failed due to an unrelated workspace `package.json` parse error in `apps/gs-gateway`, so workspace-level checks could not complete.  
- Ran `cd apps/gs-web && pnpm check` which failed because `node_modules` are not installed in the execution environment and `astro` was not available, so local project checks could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1922206548331ac29d5ddacc4ebc6)