### PR TITLE
Add gs-web launch checklist and release quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
 
       - name: Build all
         run: pnpm -r build
+
+      - name: gs-web release quality gate
+        working-directory: apps/gs-web
+        run: pnpm check:release
+
       - name: Verify internal links (Developer Hub, Risk Radar, Workflows)
         run: node scripts/check-internal-links.mjs
-

--- a/.github/workflows/deploy-gs-web.yml
+++ b/.github/workflows/deploy-gs-web.yml
@@ -118,6 +118,10 @@ jobs:
           PUBLIC_RELEASE_LABEL: ${{ steps.metadata.outputs.release_label }}
         run: pnpm build
 
+      - name: Run gs-web release quality gate
+        working-directory: apps/gs-web
+        run: pnpm check:release
+
       - name: Validate build artifacts
         working-directory: apps/gs-web
         run: |

--- a/.github/workflows/required-merge-checks.yml
+++ b/.github/workflows/required-merge-checks.yml
@@ -55,6 +55,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build gs-web
         run: pnpm --dir apps/gs-web build
+      - name: Run gs-web release quality gate
+        run: pnpm --dir apps/gs-web check:release
 
   gs-admin-build:
     runs-on: ubuntu-latest

--- a/apps/gs-web/docs/launch-checklist.md
+++ b/apps/gs-web/docs/launch-checklist.md
@@ -1,0 +1,32 @@
+# gs-web Launch Checklist
+
+Use this checklist before promoting `apps/gs-web` to production.
+
+## Release Readiness
+
+- [ ] Confirm release scope, owner, and rollback contact are documented in the PR.
+- [ ] Confirm runtime metadata is set for the build (`PUBLIC_BUILD_TIMESTAMP`, `PUBLIC_COMMIT_HASH`, optional `PUBLIC_RELEASE_LABEL`).
+- [ ] Verify no unresolved critical defects are open for the release branch.
+
+## Automated CI Quality Gates (Required)
+
+- [ ] **Page metadata completeness** passes for all built HTML pages:
+  - `<title>` present and non-empty
+  - `<meta name="description">` present
+  - Open Graph tags present (`og:title`, `og:description`, `og:type`, `og:url`)
+- [ ] **Broken links + route coverage** passes:
+  - every static page under `src/pages` is represented in `dist`
+  - internal links and hash anchors resolve
+- [ ] **Lighthouse budgets** pass for representative routes (`/`, `/about`, `/contact`, `/developer`):
+  - Performance ≥ 0.80
+  - Accessibility ≥ 0.90
+  - SEO ≥ 0.90
+- [ ] **Keyboard navigation + form label compliance** passes:
+  - keyboard tab flow reaches multiple interactive targets per route
+  - every rendered form control has an associated label (explicit label, wrapping label, or aria label)
+
+## Deployment Safety
+
+- [ ] Production deploy workflow is blocked on required gs-web quality checks.
+- [ ] Deploy is not executed if any required gate fails.
+- [ ] Post-deploy smoke test completed on homepage, contact form, and developer docs.

--- a/apps/gs-web/package.json
+++ b/apps/gs-web/package.json
@@ -14,7 +14,8 @@
     "test": "playwright test",
     "test:unit": "node --experimental-strip-types --test tests/unit/**/*.test.ts",
     "test:e2e": "playwright test",
-    "verify:dist": "node ../../scripts/verify-web-dist.mjs"
+    "verify:dist": "node ../../scripts/verify-web-dist.mjs",
+    "check:release": "node scripts/release-quality-gate.mjs"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.2",

--- a/apps/gs-web/scripts/release-quality-gate.mjs
+++ b/apps/gs-web/scripts/release-quality-gate.mjs
@@ -1,0 +1,273 @@
+import { createServer } from 'node:http';
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { chromium } from '@playwright/test';
+
+const execFileAsync = promisify(execFile);
+
+const DIST_DIR = path.resolve(process.cwd(), 'dist');
+const PAGES_DIR = path.resolve(process.cwd(), 'src/pages');
+const HOST = '127.0.0.1';
+const PORT = Number(process.env.RELEASE_CHECK_PORT ?? 4173);
+
+const LIGHTHOUSE_BUDGETS = {
+  performance: Number(process.env.LH_MIN_PERFORMANCE ?? 0.8),
+  accessibility: Number(process.env.LH_MIN_ACCESSIBILITY ?? 0.9),
+  seo: Number(process.env.LH_MIN_SEO ?? 0.9),
+};
+
+const failures = [];
+
+const exists = async (filePath) => {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const walk = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const fullPath = path.join(dir, entry.name);
+    return entry.isDirectory() ? walk(fullPath) : [fullPath];
+  }));
+  return files.flat();
+};
+
+const toRoute = (relativeHtmlPath) => {
+  const normalized = relativeHtmlPath.replace(/\\/g, '/');
+  if (normalized === 'index.html') return '/';
+  if (normalized.endsWith('/index.html')) return `/${normalized.slice(0, -11)}`;
+  return `/${normalized.replace(/\.html$/, '')}`;
+};
+
+const toDistHtmlPath = (route) => (route === '/' ? 'index.html' : `${route.replace(/^\//, '')}/index.html`);
+
+const getDocuments = async () => {
+  const files = await walk(DIST_DIR);
+  const htmlFiles = files.filter((file) => file.endsWith('.html'));
+  return Promise.all(htmlFiles.map(async (absolutePath) => {
+    const relativePath = path.relative(DIST_DIR, absolutePath).replace(/\\/g, '/');
+    return {
+      route: toRoute(relativePath),
+      relativePath,
+      html: await readFile(absolutePath, 'utf8'),
+    };
+  }));
+};
+
+const getExpectedRoutes = async () => {
+  const files = await walk(PAGES_DIR);
+  return files
+    .filter((file) => /\.(astro|md|mdx)$/.test(file))
+    .map((file) => path.relative(PAGES_DIR, file).replace(/\\/g, '/'))
+    .filter((file) => !file.includes('/api/'))
+    .filter((file) => !file.includes('['))
+    .map((file) => {
+      if (/^index\.(astro|md|mdx)$/.test(file)) return '/';
+      return `/${file.replace(/\.(astro|md|mdx)$/, '').replace(/\/index$/, '')}`;
+    })
+    .sort();
+};
+
+const getMetaContent = (html, pattern) => {
+  const match = html.match(pattern);
+  return match?.[1]?.trim() || '';
+};
+
+const checkMetadata = (documents) => {
+  for (const doc of documents) {
+    const title = getMetaContent(doc.html, /<title>([\s\S]*?)<\/title>/i);
+    const description = getMetaContent(doc.html, /<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i);
+    const ogTitle = getMetaContent(doc.html, /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']+)["']/i);
+    const ogDescription = getMetaContent(doc.html, /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"']+)["']/i);
+    const ogType = getMetaContent(doc.html, /<meta[^>]+property=["']og:type["'][^>]+content=["']([^"']+)["']/i);
+    const ogUrl = getMetaContent(doc.html, /<meta[^>]+property=["']og:url["'][^>]+content=["']([^"']+)["']/i);
+
+    if (!title) failures.push(`[metadata] ${doc.route}: missing <title>`);
+    if (!description) failures.push(`[metadata] ${doc.route}: missing meta description`);
+    if (!ogTitle) failures.push(`[metadata] ${doc.route}: missing og:title`);
+    if (!ogDescription) failures.push(`[metadata] ${doc.route}: missing og:description`);
+    if (!ogType) failures.push(`[metadata] ${doc.route}: missing og:type`);
+    if (!ogUrl) failures.push(`[metadata] ${doc.route}: missing og:url`);
+  }
+};
+
+const getIds = (html) => new Set(Array.from(html.matchAll(/\sid=["']([^"']+)["']/gi)).map((m) => m[1]));
+const getLinks = (html) => Array.from(html.matchAll(/<a[^>]+href=["']([^"']+)["'][^>]*>/gi)).map((m) => m[1]);
+
+const hasLabelFor = (html, id) => new RegExp(`<label[^>]+for=["']${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']`, 'i').test(html);
+
+const checkRoutesAndLinks = (documents, expectedRoutes) => {
+  const byRoute = new Map(documents.map((doc) => [doc.route, doc]));
+
+  for (const route of expectedRoutes) {
+    if (!byRoute.has(route)) {
+      failures.push(`[routes] missing built route: ${route} (${toDistHtmlPath(route)})`);
+    }
+  }
+
+  for (const doc of documents) {
+    const ids = getIds(doc.html);
+    const links = getLinks(doc.html);
+
+    for (const href of links) {
+      if (!href || /^(mailto:|tel:|javascript:|data:)/i.test(href) || /^(https?:)?\/\//i.test(href)) continue;
+
+      const resolved = new URL(href, `https://goldshore.local${doc.route.endsWith('/') ? doc.route : `${doc.route}/`}`);
+      const target = byRoute.get(resolved.pathname);
+      if (!target) {
+        failures.push(`[links] ${doc.route}: ${href} -> missing route ${resolved.pathname}`);
+        continue;
+      }
+      if (resolved.hash) {
+        const targetIds = resolved.pathname === doc.route ? ids : getIds(target.html);
+        const anchor = resolved.hash.slice(1);
+        if (anchor && !targetIds.has(anchor)) {
+          failures.push(`[links] ${doc.route}: ${href} -> missing anchor #${anchor}`);
+        }
+      }
+    }
+  }
+};
+
+const checkFormLabels = (documents) => {
+  const controlRegex = /<(input|select|textarea)\b([^>]*)>/gi;
+
+  for (const doc of documents) {
+    let match;
+    while ((match = controlRegex.exec(doc.html)) !== null) {
+      const [fullTag, tag, attrs] = match;
+      const type = (attrs.match(/\stype=["']([^"']+)["']/i)?.[1] || '').toLowerCase();
+      if (tag === 'input' && ['hidden', 'submit', 'button', 'reset', 'image'].includes(type)) continue;
+
+      const id = attrs.match(/\sid=["']([^"']+)["']/i)?.[1];
+      const hasAriaLabel = /\saria-label=["'][^"']+["']/i.test(attrs) || /\saria-labelledby=["'][^"']+["']/i.test(attrs);
+      const wrappedByLabel = /<label[\s\S]*$/.test(doc.html.slice(0, match.index)) && /<\/label>/.test(doc.html.slice(match.index));
+      const hasLinkedLabel = id ? hasLabelFor(doc.html, id) : false;
+
+      if (!hasAriaLabel && !hasLinkedLabel && !wrappedByLabel) {
+        failures.push(`[forms] ${doc.route}: unlabeled ${tag} control (${fullTag.slice(0, 80)}...)`);
+      }
+    }
+  }
+};
+
+const createStaticServer = (documents) => {
+  const byPath = new Map(documents.map((doc) => [doc.relativePath, doc.html]));
+  return createServer((req, res) => {
+    const pathname = (req.url || '/').split('?')[0];
+    const key = pathname === '/' ? 'index.html' : `${pathname.replace(/^\//, '').replace(/\/$/, '')}/index.html`;
+    const html = byPath.get(key);
+    if (!html) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    res.statusCode = 200;
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.end(html);
+  });
+};
+
+const checkKeyboardNavigation = async (routes) => {
+  const browser = await chromium.launch({
+    executablePath: process.env.PLAYWRIGHT_CHROMIUM_PATH || '/usr/bin/chromium',
+    args: ['--disable-gpu', '--use-angle=swiftshader', '--use-gl=swiftshader'],
+  });
+
+  try {
+    for (const route of routes) {
+      const page = await browser.newPage();
+      await page.goto(`http://${HOST}:${PORT}${route}`, { waitUntil: 'networkidle' });
+
+      const focused = new Set();
+      for (let i = 0; i < 10; i += 1) {
+        await page.keyboard.press('Tab');
+        const locator = await page.evaluate(() => {
+          const el = document.activeElement;
+          if (!el) return '';
+          const tag = el.tagName.toLowerCase();
+          const id = el.id ? `#${el.id}` : '';
+          return `${tag}${id}`;
+        });
+        if (locator) focused.add(locator);
+      }
+
+      if (focused.size < 3) {
+        failures.push(`[keyboard] ${route}: expected at least 3 focusable elements, got ${focused.size}`);
+      }
+
+      await page.close();
+    }
+  } finally {
+    await browser.close();
+  }
+};
+
+const checkLighthouse = async (routes) => {
+  for (const route of routes) {
+    const { stdout } = await execFileAsync('npx', [
+      '--yes',
+      'lighthouse',
+      `http://${HOST}:${PORT}${route}`,
+      '--quiet',
+      '--output=json',
+      '--output-path=stdout',
+      '--chrome-flags=--headless --no-sandbox',
+      '--only-categories=performance,accessibility,seo',
+    ], { maxBuffer: 8 * 1024 * 1024 });
+
+    const report = JSON.parse(stdout);
+    for (const [category, minScore] of Object.entries(LIGHTHOUSE_BUDGETS)) {
+      const score = report?.categories?.[category]?.score;
+      if (typeof score !== 'number' || score < minScore) {
+        failures.push(`[lighthouse] ${route}: ${category} ${score ?? 'n/a'} below ${minScore}`);
+      }
+    }
+  }
+};
+
+const main = async () => {
+  if (!(await exists(DIST_DIR))) {
+    console.error('dist/ not found. Run `pnpm build` first.');
+    process.exit(1);
+  }
+
+  const documents = await getDocuments();
+  const expectedRoutes = await getExpectedRoutes();
+
+  checkMetadata(documents);
+  checkRoutesAndLinks(documents, expectedRoutes);
+  checkFormLabels(documents);
+
+  const server = createStaticServer(documents);
+  await new Promise((resolve) => server.listen(PORT, HOST, resolve));
+
+  const checksRoutes = ['/', '/about', '/contact', '/developer'].filter((route) =>
+    documents.some((doc) => doc.route === route),
+  );
+
+  try {
+    await checkKeyboardNavigation(checksRoutes);
+    await checkLighthouse(checksRoutes);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
+
+  if (failures.length > 0) {
+    console.error('❌ gs-web release quality gate failed');
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exit(1);
+  }
+
+  console.log('✅ gs-web release quality gate passed');
+};
+
+await main();


### PR DESCRIPTION
Merge strategy: squash

### Motivation

- Ensure gs-web releases meet content, accessibility, and performance standards before production deploy.  
- Prevent regressions by validating page metadata, internal links, route coverage, Lighthouse budgets, and basic keyboard/form accessibility as part of CI.  
- Block production deploys when required quality gates fail to reduce customer-facing failures and SEO/UX regressions.

### Description

- Add `apps/gs-web/docs/launch-checklist.md` documenting release readiness and the required CI quality gates.  
- Add `apps/gs-web/scripts/release-quality-gate.mjs` which validates built HTML for metadata completeness, route coverage and internal link/anchor integrity, Lighthouse category budgets (performance/accessibility/SEO), keyboard Tab navigation reachability, and form control label coverage.  
- Add `check:release` script to `apps/gs-web/package.json` to run the new quality gate.  
- Wire the release check into CI and deploy paths by running the gate in `.github/workflows/ci.yml`, `.github/workflows/required-merge-checks.yml`, and `.github/workflows/deploy-gs-web.yml` to block merges and production deploys when checks fail.

### Testing

- Ran `node --check apps/gs-web/scripts/release-quality-gate.mjs` to validate syntax of the gate script and it succeeded.  
- Ran `node --check apps/gs-web/scripts/generate-search-index.js` to validate supporting scripts and it succeeded.  
- Attempted `pnpm --dir apps/gs-web build` in the local sandbox but it failed due to missing local `node_modules` / `astro` binary in this environment, so full build+gate execution was not performed locally.  
- CI will execute the new `check:release` step during pull request and deploy workflows; please review runtime environment (Playwright/Chromium and Lighthouse availability) in CI to ensure the checks can run in your runners.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d192266ac483319ca0cd70731aeb3b)