### PR TITLE
Refine contact form field set and submission status messaging

### DIFF
--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -42,7 +42,17 @@ export const prerender = true;
 
       <div class="gs-input-group">
         <label for="name">Name</label>
-        <input id="name" name="name" type="text" autocomplete="name" required />
+        <p id="name-help" class="field-help">
+          Share your full name so we can personalize the follow-up.
+        </p>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          autocomplete="name"
+          aria-describedby="name-help"
+          required
+        />
       </div>
 
       <div class="gs-input-group">
@@ -67,16 +77,6 @@ export const prerender = true;
           Choose the path that best matches the engagement you want to start.
         </p>
         <select id="inquiry" name="inquiry" aria-describedby="inquiry-help">
-          <option value="general">General inquiry</option>
-          <option value="strategy-call">Strategy call</option>
-          <option value="project-scope">Project scoping</option>
-          <option value="support">Support</option>
-        </select>
-      </div>
-
-      <div class="gs-input-group">
-        <label for="inquiry">Inquiry type</label>
-        <select id="inquiry" name="inquiry" autocomplete="off">
           <option value="general">General inquiry</option>
           <option value="strategy-call">Strategy call</option>
           <option value="project-scope">Project scoping</option>
@@ -154,6 +154,7 @@ export const prerender = true;
     const button = form?.querySelector('button[type="submit"]');
     const submitText = form?.querySelector('#submit-text');
     const formStatus = document.getElementById('form-status');
+    let hadSubmissionError = false;
 
     const setStatus = (message, type) => {
       if (!(formStatus instanceof HTMLElement)) return;
@@ -161,6 +162,11 @@ export const prerender = true;
       formStatus.classList.remove('success', 'error', 'progress');
       if (type) {
         formStatus.classList.add(type);
+      }
+      if (type === 'error') {
+        formStatus.setAttribute('aria-live', 'assertive');
+      } else {
+        formStatus.setAttribute('aria-live', 'polite');
       }
     };
 
@@ -205,16 +211,17 @@ export const prerender = true;
           return;
         }
 
-        const originalText =
-          submitText instanceof HTMLElement
-            ? submitText.textContent
-            : button.textContent;
         button.disabled = true;
         button.setAttribute('aria-busy', 'true');
         if (submitText instanceof HTMLElement) {
           submitText.textContent = 'Sending...';
         }
-        setStatus('Sending your message...', 'progress');
+        setStatus(
+          hadSubmissionError
+            ? 'Retrying your submission...'
+            : 'Sending your message...',
+          'progress',
+        );
 
         try {
           const response = await fetch(
@@ -238,16 +245,19 @@ export const prerender = true;
                 ? redirectToField.value
                 : '/thank-you';
 
+          hadSubmissionError = false;
+          setStatus('Message sent. Redirecting you now...', 'success');
           window.location.href = redirectTarget;
         } catch (error) {
           console.error(error);
+          hadSubmissionError = true;
           button.disabled = false;
           button.removeAttribute('aria-busy');
           if (submitText instanceof HTMLElement) {
-            submitText.textContent = originalText || 'Send message';
+            submitText.textContent = 'Retry sending';
           }
           setStatus(
-            'Unable to send message right now. Please try again or email hello@goldshore.ai.',
+            'We could not send your message. Please review your details and retry. If the issue persists, email hello@goldshore.ai.',
             'error',
           );
         }


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Remove duplicated UI and tidy the contact intake so there is a single canonical `Inquiry` selector in the form. 
- Improve form accessibility and client-side feedback so users receive clear messages for submitting, retrying, and error states. 
- Preserve existing anti-spam measures (`companyWebsite` honeypot and `formStartedAt` timing field) while making the visible controls consistent and accessible. 

### Description
- Removed the duplicate `Inquiry type` select block and kept one canonical `<select id="inquiry" name="inquiry">` with helper text wired via `aria-describedby`. 
- Added helper text for the `name` field and associated it with `aria-describedby`, and ensured visible inputs have unique `id` and `label` relationships (`name`, `email`, `inquiry`, `message`, `companyWebsite`). 
- Enhanced client-side status handling by introducing a `hadSubmissionError` flag, updating progress copy for initial send vs retry, setting errors to an assertive live-region, showing a success message before redirect, and updating the submit label to `Retry sending` after failures. 
- Left the honeypot and form timing anti-spam fields intact and preserved existing form `action`/`redirectTo` behavior. 

### Testing
- Ran `pnpm -C apps/gs-web check`, which failed in this environment due to missing dependencies and `astro: not found`. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d192878700833193193d54a0837664)