### PR TITLE
Instrument debounced analytics for CTAs and contact funnel

### DIFF
--- a/apps/gs-web/docs/analytics-events.md
+++ b/apps/gs-web/docs/analytics-events.md
@@ -1,0 +1,95 @@
+# Analytics Events
+
+The web app emits analytics events via `src/scripts/analytics.ts`.
+
+## Event transport
+
+Each tracked event sends:
+
+- `window.dataLayer.push({ event, ...payload })` when `dataLayer` is present.
+- `window.gtag('event', eventName, payload)` when `gtag` is present.
+- `window.dispatchEvent(new CustomEvent('gs:analytics', { detail }))` for local listeners.
+
+All event triggers are debounced. The contact form submit flow is also guarded to prevent duplicate submissions while a request is in-flight.
+
+## Event catalog
+
+### `homepage_cta_click`
+
+Triggered when a homepage CTA is clicked (hero or contact CTA).
+
+Payload:
+
+```ts
+{
+  cta_id: string;      // e.g. "homepage-hero-primary-cta"
+  page_path: string;   // e.g. "/"
+}
+```
+
+### `services_cta_click`
+
+Triggered when a services page CTA is clicked.
+
+Payload:
+
+```ts
+{
+  cta_id: string;      // e.g. "services-hero-cta"
+  page_path: string;   // e.g. "/services"
+}
+```
+
+### `contact_form_start`
+
+Triggered once per page view on the first form interaction (`focusin` or `input`) on the contact form.
+
+Payload:
+
+```ts
+{
+  form_id: 'contact-form';
+  page_path: string;   // e.g. "/contact"
+}
+```
+
+### `contact_submit_success`
+
+Triggered after a successful contact form submit response.
+
+Payload:
+
+```ts
+{
+  form_id: 'contact-form';
+  page_path: string;        // e.g. "/contact"
+  submission_id: string;    // UUID (or timestamp fallback)
+  response_status: number;  // HTTP status
+}
+```
+
+### `contact_submit_failure`
+
+Triggered when a contact form submit request fails.
+
+Payload:
+
+```ts
+{
+  form_id: 'contact-form';
+  page_path: string;      // e.g. "/contact"
+  submission_id: string;  // UUID (or timestamp fallback)
+}
+```
+
+### `thank_you_page_view`
+
+Triggered once when the thank-you page is viewed.
+
+Payload:
+
+```ts
+{
+  page_path: string;    // e.g. "/thank-you"
+}
+```

--- a/apps/gs-web/src/components/hero/ParallaxHero.astro
+++ b/apps/gs-web/src/components/hero/ParallaxHero.astro
@@ -46,14 +46,14 @@ const lines = headline.split('\n');
     <p class="gs-hero__sub">{sub}</p>
 
     <div class="gs-hero__actions">
-      <a class="gs-btn gs-btn--primary" href={ctaPrimary.href}>
+      <a class="gs-btn gs-btn--primary" href={ctaPrimary.href} data-analytics-id="homepage-hero-primary-cta">
         {ctaPrimary.label}
         <svg class="gs-btn__arrow" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M3 8h10M9 4l4 4-4 4" stroke="currentColor" stroke-width="1.5"
                 stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </a>
-      <a class="gs-btn gs-btn--ghost" href={ctaSecondary.href}>
+      <a class="gs-btn gs-btn--ghost" href={ctaSecondary.href} data-analytics-id="homepage-hero-secondary-cta">
         {ctaSecondary.label}
       </a>
     </div>

--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -150,6 +150,8 @@ export const prerender = true;
   </FlowSection>
 
   <script>
+    import { trackEvent, trackEventOnce } from '../scripts/analytics';
+
     const form = document.getElementById('contact-form');
     const button = form?.querySelector('button[type="submit"]');
     const submitText = form?.querySelector('#submit-text');
@@ -168,6 +170,7 @@ export const prerender = true;
       form instanceof HTMLFormElement &&
       button instanceof HTMLButtonElement
     ) {
+      let isSubmitting = false;
       const startedAtField = form.querySelector('[name="formStartedAt"]');
       if (startedAtField instanceof HTMLInputElement) {
         startedAtField.value = String(Date.now());
@@ -192,9 +195,20 @@ export const prerender = true;
         inquiryField.value = inquiryParam;
       }
 
+      const registerStart = () => {
+        trackEventOnce('contact_form_start', 'contact_form_start', {
+          page_path: window.location.pathname,
+          form_id: 'contact-form',
+        });
+      };
+
+      form.addEventListener('focusin', registerStart, { once: true });
+      form.addEventListener('input', registerStart, { once: true });
+
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
-        if (button.disabled) return;
+        if (button.disabled || isSubmitting) return;
+        isSubmitting = true;
 
         if (!form.checkValidity()) {
           form.reportValidity();
@@ -202,6 +216,7 @@ export const prerender = true;
             'Please complete all required fields before submitting.',
             'error',
           );
+          isSubmitting = false;
           return;
         }
 
@@ -216,6 +231,10 @@ export const prerender = true;
         }
         setStatus('Sending your message...', 'progress');
 
+        const submissionId =
+          (window.crypto?.randomUUID && window.crypto.randomUUID()) ||
+          `${Date.now()}`;
+
         try {
           const response = await fetch(
             form.getAttribute('action') || '/api/contact',
@@ -229,6 +248,20 @@ export const prerender = true;
             throw new Error(`Submission failed: ${response.status}`);
           }
 
+          trackEvent(
+            'contact_submit_success',
+            {
+              page_path: window.location.pathname,
+              form_id: 'contact-form',
+              submission_id: submissionId,
+              response_status: response.status,
+            },
+            {
+              debounceKey: `contact_submit_success:${submissionId}`,
+              debounceMs: 5000,
+            },
+          );
+
           const redirectToField = form.querySelector('[name="redirectTo"]');
           const redirectTarget =
             response.redirected && response.url
@@ -241,7 +274,20 @@ export const prerender = true;
           window.location.href = redirectTarget;
         } catch (error) {
           console.error(error);
+          trackEvent(
+            'contact_submit_failure',
+            {
+              page_path: window.location.pathname,
+              form_id: 'contact-form',
+              submission_id: submissionId,
+            },
+            {
+              debounceKey: `contact_submit_failure:${submissionId}`,
+              debounceMs: 5000,
+            },
+          );
           button.disabled = false;
+          isSubmitting = false;
           button.removeAttribute('aria-busy');
           if (submitText instanceof HTMLElement) {
             submitText.textContent = originalText || 'Send message';

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -220,13 +220,18 @@ const proofPoints = [
           Ready to operationalize AI with trust, control, and signal clarity?
         </h2>
       </div>
-      <a href="/contact" class="hero-button hero-button--primary">
+      <a
+        href="/contact"
+        class="hero-button hero-button--primary"
+        data-analytics-id="homepage-contact-cta"
+      >
         Start a conversation
       </a>
     </section>
   </main>
 
   <script>
+    import { trackEvent } from '../scripts/analytics';
     import { initWave } from '../scripts/init-wave';
     import { initLogo } from '../scripts/init-logo-reactive';
 
@@ -275,6 +280,25 @@ const proofPoints = [
       root.dataset.gsHomeHeroBound = 'true';
       document.addEventListener('astro:before-swap', cleanup);
       document.addEventListener('astro:page-load', boot);
+      document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+
+        const cta = target.closest('[data-analytics-id]');
+        if (!(cta instanceof HTMLElement)) return;
+
+        const ctaId = cta.dataset.analyticsId;
+        if (!ctaId || !ctaId.startsWith('homepage-')) return;
+
+        trackEvent(
+          'homepage_cta_click',
+          {
+            cta_id: ctaId,
+            page_path: window.location.pathname,
+          },
+          { debounceKey: `homepage_cta_click:${ctaId}`, debounceMs: 1200 },
+        );
+      });
     }
 
     boot();

--- a/apps/gs-web/src/pages/services.astro
+++ b/apps/gs-web/src/pages/services.astro
@@ -39,7 +39,7 @@ const services = [
     <div>
       <h1>Services</h1>
       <p>Crafted delivery engagements that combine platform engineering, AI execution, and operational rigor.</p>
-      <GSButton href="/contact">Request a scoping call</GSButton>
+      <GSButton href="/contact" data-analytics-id="services-hero-cta">Request a scoping call</GSButton>
     </div>
     <div class="gs-card">
       <h3 class="section-title"><span>☍</span>Engagement highlights</h3>
@@ -64,7 +64,14 @@ const services = [
               ))}
             </ul>
           ) : null}
-          <GSButton href={service.cta} variant="secondary" class="gs-button--small">Talk to us</GSButton>
+          <GSButton
+            href={service.cta}
+            variant="secondary"
+            class="gs-button--small"
+            data-analytics-id={`services-card-cta-${service.name.toLowerCase().replaceAll(' ', '-')}`}
+          >
+            Talk to us
+          </GSButton>
         </article>
       ))}
     </div>
@@ -75,7 +82,9 @@ const services = [
       <div>
         <h2>Snapshot</h2>
         <p class="gs-text-lg">Focused delivery for teams that need reliable systems and clear momentum.</p>
-        <GSButton href="/contact" variant="secondary">Plan the engagement</GSButton>
+        <GSButton href="/contact" variant="secondary" data-analytics-id="services-plan-cta">
+          Plan the engagement
+        </GSButton>
       </div>
       <div class="gs-card">
         <h3 class="section-title"><span>◆</span>Snapshot</h3>
@@ -89,4 +98,32 @@ const services = [
       </div>
     </div>
   </FlowSection>
+
+  <script>
+    import { trackEvent } from '../scripts/analytics';
+
+    const root = document.documentElement;
+    if (root.dataset.gsServicesAnalyticsBound !== 'true') {
+      root.dataset.gsServicesAnalyticsBound = 'true';
+      document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) return;
+
+        const cta = target.closest('[data-analytics-id]');
+        if (!(cta instanceof HTMLElement)) return;
+
+        const ctaId = cta.dataset.analyticsId;
+        if (!ctaId || !ctaId.startsWith('services-')) return;
+
+        trackEvent(
+          'services_cta_click',
+          {
+            cta_id: ctaId,
+            page_path: window.location.pathname,
+          },
+          { debounceKey: `services_cta_click:${ctaId}`, debounceMs: 1200 },
+        );
+      });
+    }
+  </script>
 </BaseLayout>

--- a/apps/gs-web/src/pages/thank-you.astro
+++ b/apps/gs-web/src/pages/thank-you.astro
@@ -19,4 +19,12 @@ export const prerender = true;
       <GSButton href="/">Back to home</GSButton>
     </div>
   </section>
+
+  <script>
+    import { trackEventOnce } from '../scripts/analytics';
+
+    trackEventOnce('thank_you_page_view', 'thank_you_page_view', {
+      page_path: window.location.pathname,
+    });
+  </script>
 </BaseLayout>

--- a/apps/gs-web/src/scripts/analytics.ts
+++ b/apps/gs-web/src/scripts/analytics.ts
@@ -1,0 +1,79 @@
+export type AnalyticsPayload = Record<string, string | number | boolean | null | undefined>;
+
+export type TrackOptions = {
+  debounceKey?: string;
+  debounceMs?: number;
+};
+
+type AnalyticsState = {
+  debounceMap: Map<string, number>;
+  firedOnce: Set<string>;
+};
+
+declare global {
+  interface Window {
+    __gsAnalyticsState?: AnalyticsState;
+    dataLayer?: Array<Record<string, unknown>>;
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+const getState = (): AnalyticsState => {
+  if (!window.__gsAnalyticsState) {
+    window.__gsAnalyticsState = {
+      debounceMap: new Map(),
+      firedOnce: new Set(),
+    };
+  }
+
+  return window.__gsAnalyticsState;
+};
+
+export const trackEvent = (
+  eventName: string,
+  payload: AnalyticsPayload = {},
+  options: TrackOptions = {},
+): boolean => {
+  const state = getState();
+  const debounceWindowMs = options.debounceMs ?? 1000;
+  const debounceKey = options.debounceKey ?? `${eventName}:${JSON.stringify(payload)}`;
+  const now = Date.now();
+  const lastFiredAt = state.debounceMap.get(debounceKey);
+
+  if (typeof lastFiredAt === 'number' && now - lastFiredAt < debounceWindowMs) {
+    return false;
+  }
+
+  state.debounceMap.set(debounceKey, now);
+
+  const eventPayload = {
+    event: eventName,
+    ...payload,
+  };
+
+  if (Array.isArray(window.dataLayer)) {
+    window.dataLayer.push(eventPayload);
+  }
+
+  if (typeof window.gtag === 'function') {
+    window.gtag('event', eventName, payload);
+  }
+
+  window.dispatchEvent(new CustomEvent('gs:analytics', { detail: eventPayload }));
+  return true;
+};
+
+export const trackEventOnce = (
+  onceKey: string,
+  eventName: string,
+  payload: AnalyticsPayload = {},
+): boolean => {
+  const state = getState();
+
+  if (state.firedOnce.has(onceKey)) {
+    return false;
+  }
+
+  state.firedOnce.add(onceKey);
+  return trackEvent(eventName, payload, { debounceKey: onceKey, debounceMs: Number.MAX_SAFE_INTEGER });
+};


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Add consistent, debounced analytics for marketing CTAs and the contact funnel to measure user engagement without duplicate events.  
- Ensure contact submissions cannot fire duplicate events by guarding in-flight submits and correlating outcomes with a per-submit id.  

### Description
- Add a shared analytics helper `apps/gs-web/src/scripts/analytics.ts` exposing `trackEvent` and `trackEventOnce` that emits to `dataLayer`, `gtag`, and a local `gs:analytics` event with debounce and once-per-key semantics.  
- Instrument homepage CTAs by adding `data-analytics-id` attributes to hero buttons and wiring a delegated, debounced `homepage_cta_click` handler in `apps/gs-web/src/pages/index.astro` and `apps/gs-web/src/components/hero/ParallaxHero.astro`.  
- Instrument services page CTAs by tagging buttons and adding a delegated, debounced `services_cta_click` handler in `apps/gs-web/src/pages/services.astro`.  
- Instrument contact funnel in `apps/gs-web/src/pages/contact.astro` including `contact_form_start` (fires once on first interaction), `contact_submit_success` and `contact_submit_failure` (include `submission_id`), and add an `isSubmitting` in-flight guard to prevent duplicate submissions.  
- Instrument thank-you page with a once-only `thank_you_page_view` event and add documentation of all event names and payload shapes in `apps/gs-web/docs/analytics-events.md`.  

### Testing
- Ran the repository check via `npm --prefix apps/gs-web run check`, which failed in this environment because `astro` is not installed or available in PATH.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1928dd7048331a6f4a063661837b9)