### PR TITLE
Update metadata + conversion-focused OG copy for core marketing routes

### DIFF
--- a/apps/gs-web/src/layouts/BaseLayout.astro
+++ b/apps/gs-web/src/layouts/BaseLayout.astro
@@ -1,8 +1,14 @@
 ---
 import WebLayout from './WebLayout.astro';
 
-const { title, description } = Astro.props;
+const { title, description, canonicalPath, ogTitle, ogDescription } = Astro.props;
 ---
-<WebLayout title={title} description={description}>
+<WebLayout
+  title={title}
+  description={description}
+  canonicalPath={canonicalPath}
+  ogTitle={ogTitle}
+  ogDescription={ogDescription}
+>
   <slot />
 </WebLayout>

--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -25,10 +25,13 @@ const {
   title = 'GoldShore',
   description = 'GoldShore AI',
   currentPath = Astro.url.pathname,
+  canonicalPath = Astro.url.pathname,
+  ogTitle = title,
+  ogDescription = description,
 } = Astro.props;
 
 const logoAssetPath = '/logo.svg';
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url);
+const canonicalUrl = new URL(canonicalPath, Astro.site ?? Astro.url);
 const socialImage = new URL(logoAssetPath, Astro.site ?? Astro.url);
 const mobileNavId = 'mobile-navigation';
 ---
@@ -42,13 +45,13 @@ const mobileNavId = 'mobile-navigation';
     <meta name="description" content={description} />
     <meta name="theme-color" content="#0b0f18" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
+    <meta property="og:title" content={ogTitle} />
+    <meta property="og:description" content={ogDescription} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:image" content={socialImage} />
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:title" content={title} />
-    <meta property="twitter:description" content={description} />
+    <meta property="twitter:title" content={ogTitle} />
+    <meta property="twitter:description" content={ogDescription} />
     <meta property="twitter:image" content={socialImage} />
     <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />

--- a/apps/gs-web/src/pages/about.astro
+++ b/apps/gs-web/src/pages/about.astro
@@ -19,7 +19,13 @@ const sections = [
 ];
 ---
 
-<BaseLayout title="About | GoldShore" description="What GoldShore builds and how the team works.">
+<BaseLayout
+  title="About | GoldShore"
+  description="How GoldShore designs and delivers operational AI systems."
+  canonicalPath="/about"
+  ogTitle="About GoldShore | Operators Behind Mission-Critical AI"
+  ogDescription="Learn how GoldShore works, what we build, and why high-trust teams use our systems-first delivery model."
+>
   <section class="page-shell gs-shell-section info-page">
     <p class="gs-eyebrow">About</p>
     <h1>High-trust systems built for use, not theater.</h1>

--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -8,7 +8,10 @@ export const prerender = true;
 
 <BaseLayout
   title="Contact | Gold Shore"
-  description="Contact the Gold Shore team."
+  description="Start a conversation with GoldShore about your AI infrastructure and delivery goals."
+  canonicalPath="/contact"
+  ogTitle="Contact GoldShore | Start Your Operational AI Engagement"
+  ogDescription="Share your timeline and constraints to get a focused plan for resilient infrastructure, observability, and AI execution."
 >
   <FlowSection variant="hero">
     <div>

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -69,6 +69,9 @@ const proofPoints = [
 <WebLayout
   title="GoldShore | Infrastructure for High-Trust AI"
   description="GoldShore builds resilient decision systems, risk tooling, and operator infrastructure."
+  canonicalPath="/"
+  ogTitle="GoldShore.ai | Resilient AI Infrastructure for High-Trust Teams"
+  ogDescription="Turn volatile AI operations into auditable, operator-ready systems. Request a briefing to accelerate reliable deployment."
 >
   <main class="home-page">
     <ParallaxHero

--- a/apps/gs-web/src/pages/services.astro
+++ b/apps/gs-web/src/pages/services.astro
@@ -34,7 +34,13 @@ const services = [
   }
 ];
 ---
-<BaseLayout title="Services | GoldShore" description="Service catalog for GoldShore AI">
+<BaseLayout
+  title="Services | GoldShore"
+  description="Operational AI services for infrastructure, observability, and controlled execution."
+  canonicalPath="/services"
+  ogTitle="GoldShore Services | Reduce Risk, Increase AI Delivery Confidence"
+  ogDescription="Explore service offerings built for resilient AI operations, clearer ownership, and measurable production outcomes."
+>
   <FlowSection variant="hero">
     <div>
       <h1>Services</h1>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -7,11 +7,23 @@ interface Props {
 	title: string;
 	description: string;
 	image?: string;
+	canonical?: string | URL;
+	ogTitle?: string;
+	ogDescription?: string;
+	ogType?: 'website' | 'article';
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
+const {
+	title,
+	description,
+	image = '/blog-placeholder-1.jpg',
+	canonical = canonicalURL,
+	ogTitle = title,
+	ogDescription = description,
+	ogType = 'website',
+} = Astro.props;
 ---
 
 <!-- Global Metadata -->
@@ -30,7 +42,7 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
 
 <!-- Canonical URL -->
-<link rel="canonical" href={canonicalURL} />
+<link rel="canonical" href={canonical} />
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
@@ -38,15 +50,15 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta name="description" content={description} />
 
 <!-- Open Graph / Facebook -->
-<meta property="og:type" content="website" />
-<meta property="og:url" content={Astro.url} />
-<meta property="og:title" content={title} />
-<meta property="og:description" content={description} />
+<meta property="og:type" content={ogType} />
+<meta property="og:url" content={canonical} />
+<meta property="og:title" content={ogTitle} />
+<meta property="og:description" content={ogDescription} />
 <meta property="og:image" content={new URL(image, Astro.url)} />
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
-<meta property="twitter:title" content={title} />
-<meta property="twitter:description" content={description} />
+<meta property="twitter:url" content={canonical} />
+<meta property="twitter:title" content={ogTitle} />
+<meta property="twitter:description" content={ogDescription} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,7 +10,10 @@ import { team, credibility } from '../data/site-content';
   <head>
     <BaseHead
       title="About | GoldShore.ai"
-      description="Team and delivery posture."
+      description="Meet the operators and delivery posture behind GoldShore.ai."
+      canonical={new URL('/about', Astro.site)}
+      ogTitle="Why Teams Trust GoldShore.ai for Operational AI Delivery"
+      ogDescription="See the team, operating principles, and domain experience behind GoldShore.ai before you start your engagement."
     />
   </head>
   <body>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -9,7 +9,10 @@ import Footer from '../components/Footer.astro';
   <head>
     <BaseHead
       title="Contact | GoldShore.ai"
-      description="Start an engagement with GoldShore.ai."
+      description="Start your GoldShore.ai engagement and align next steps with your constraints."
+      canonical={new URL('/contact', Astro.site)}
+      ogTitle="Start Your AI Operations Engagement with GoldShore.ai"
+      ogDescription="Share your system goals and constraints to get a focused plan for resilient AI infrastructure, observability, and risk controls."
     />
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,13 @@ const proofPoints = [
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead
+      title={SITE_TITLE}
+      description={SITE_DESCRIPTION}
+      canonical={new URL('/', Astro.site)}
+      ogTitle="Operational AI Infrastructure for Mission-Critical Teams | GoldShore.ai"
+      ogDescription="Build resilient AI operations with observability, risk controls, and operator-ready workflows. Talk to GoldShore.ai to harden your production stack."
+    />
   </head>
   <body>
     <Header />

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -10,7 +10,10 @@ import { services, caseStudies } from '../data/site-content';
   <head>
     <BaseHead
       title="Services | GoldShore.ai"
-      description="Depth-first services for operational AI systems."
+      description="Services built to stabilize, observe, and scale live AI systems."
+      canonical={new URL('/services', Astro.site)}
+      ogTitle="Operational AI Services That Reduce Risk and Speed Delivery"
+      ogDescription="Explore GoldShore.ai services for infrastructure hardening, observability, and resilience engineering tailored to production AI teams."
     />
   </head>
   <body>


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Ensure marketing pages (`/`, `/about`, `/services`, `/contact`) have explicit, SEO-friendly `title`, `description`, `canonical`, and Open Graph metadata tailored for conversion intent. 
- Allow page-level overrides for canonical and OG fields instead of relying solely on defaults from the layout or current URL. 
- Validate that all indexable Astro pages are rendered through a metadata-providing layout/head so no pages are missing metadata.

### Description
- Extended the root `BaseHead` component to accept `canonical`, `ogTitle`, `ogDescription`, and `ogType` and use the provided `canonical` for OG/Twitter URL fields (`src/components/BaseHead.astro`).
- Added `canonicalPath`, `ogTitle`, and `ogDescription` support to `apps/gs-web` layout chain by plumbing props from `BaseLayout` into `WebLayout` and using them to construct `canonicalUrl` and OG/Twitter tags (`apps/gs-web/src/layouts/BaseLayout.astro`, `apps/gs-web/src/layouts/WebLayout.astro`).
- Updated page metadata for `/`, `/about`, `/services`, and `/contact` in both the root site (`src/pages/*`) and the marketing site (`apps/gs-web/src/pages/*`) to supply page-specific `title`, `description`, explicit `canonical`/`canonicalPath`, and conversion-focused `ogTitle`/`ogDescription` strings. 
- Verified indexable pages are wired through the shared metadata layers so metadata is present site-wide.

### Testing
- Ran a Python coverage check (`python` script) to assert metadata-providing layouts/head are present across `src/pages` and `apps/gs-web/src/pages`, which reported `missing 0` and succeeded. 
- Used `rg` to verify presence of `title`, `description`, canonical, and OG tags in the updated shared metadata files, which returned the expected tag lines. 
- Attempted to run `astro` checks with `pnpm -C apps/gs-web exec astro check`, but the command failed in this environment with `Command "astro" not found` (environmental limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d19291b0a48331803bb80060c28dd7)