### PR TITLE
[Follow-up] Prevent admin accent MutationObserver feedback loop in PR #4520

### DIFF
--- a/apps/admin/src/layouts/AdminLayout.astro
+++ b/apps/admin/src/layouts/AdminLayout.astro
@@ -43,21 +43,29 @@ const favicon = '/logo.png';
           root.style.removeProperty('--gs-accent-contrast');
         }
 
+        function setDataAccent(root, accent) {
+          if (root.getAttribute('data-accent') !== accent) root.setAttribute('data-accent', accent);
+        }
+
+        function clearDataAccent(root) {
+          if (root.hasAttribute('data-accent')) root.removeAttribute('data-accent');
+        }
+
         function applyAccent(root, accent) {
           if (accent === 'gold') {
-            root.setAttribute('data-accent', 'gold');
+            setDataAccent(root, 'gold');
             removeAccentOverrides(root);
           } else if (accent === 'cyan') {
-            root.setAttribute('data-accent', 'cyan');
+            setDataAccent(root, 'cyan');
             removeAccentOverrides(root);
           } else if (accent === 'violet') {
-            root.removeAttribute('data-accent');
+            clearDataAccent(root);
             root.style.setProperty('--gs-accent', '#a855f7');
             root.style.setProperty('--gs-accent-strong', '#9333ea');
             root.style.setProperty('--gs-accent-soft', 'rgba(168,85,247,0.18)');
             root.style.setProperty('--gs-accent-contrast', '#0f172a');
           } else {
-            root.removeAttribute('data-accent');
+            clearDataAccent(root);
             removeAccentOverrides(root);
           }
         }
@@ -72,7 +80,11 @@ const favicon = '/logo.png';
         new MutationObserver(function (mutations) {
           for (var i = 0; i < mutations.length; i++) {
             if (mutations[i].attributeName === 'data-accent') {
-              applyAccent(root, readSettings().accent);
+              var accent = readSettings().accent;
+              var currentAccent = root.getAttribute('data-accent');
+              if ((accent === 'gold' || accent === 'cyan') && currentAccent === accent) break;
+              if (accent !== 'gold' && accent !== 'cyan' && currentAccent === null) break;
+              applyAccent(root, accent);
               break;
             }
           }


### PR DESCRIPTION
### Motivation
- Prevent a self-triggering `MutationObserver` loop in the admin layout that can cause high CPU and UI lockups when `data-accent` is repeatedly written for `gold`/`cyan` accents.
- Ensure the layout script only mutates `data-accent` when the attribute value actually changes to avoid unnecessary DOM mutations.

### Description
- Added guarded helper functions `setDataAccent(root, accent)` and `clearDataAccent(root)` and updated `applyAccent` to use them in `apps/admin/src/layouts/AdminLayout.astro` so the attribute is only changed when needed.
- Hardened the `MutationObserver` callback to read the persisted accent and skip calling `applyAccent` when the DOM already matches the stored setting (handles `gold`/`cyan` and non-attribute accents).
- The change is limited to the inline admin layout script and avoids disconnecting the observer while still preventing feedback loops.

### Testing
- Ran the admin build with `pnpm -C apps/admin build`, which exercised the code path but the build failed due to an unrelated Astro/@astrojs-cloudflare package export mismatch (`Package subpath './app/manifest' is not defined by "exports"`), so full build verification in this environment could not complete.
- No unit tests were added or run as part of this follow-up; the change is a small, targeted runtime fix in the admin inline script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26e2a22dc833181caa71d97477aba)