### PR TITLE
[Follow-up] Restore /apps/risk-radar page content (fix dead-end route…

### DIFF
--- a/apps/web/src/pages/apps/risk-radar.astro
+++ b/apps/web/src/pages/apps/risk-radar.astro
@@ -1,0 +1,666 @@
+---
+import '@goldshore/theme/tokens';
+import MarketingLayout from '../../layouts/MarketingLayout.astro';
+
+export const prerender = true;
+
+const samples = [
+  {
+    label: 'Aurora Sigma',
+    ticker: 'AXP',
+    iv: '38.6%',
+    openVol: '1.42M',
+    openPositions: '8,240',
+    gForce: 'NW 18.2',
+    drift: '145°',
+    pressure: '+0.86',
+    momentum: 'Up-slope'
+  },
+  {
+    label: 'Titan Harbor',
+    ticker: 'NVDA',
+    iv: '52.1%',
+    openVol: '2.08M',
+    openPositions: '11,904',
+    gForce: 'E 22.7',
+    drift: '80°',
+    pressure: '+1.34',
+    momentum: 'Accel'
+  },
+  {
+    label: 'Mariner Ghost',
+    ticker: 'TSLA',
+    iv: '64.9%',
+    openVol: '1.77M',
+    openPositions: '9,332',
+    gForce: 'SE 12.3',
+    drift: '205°',
+    pressure: '-0.62',
+    momentum: 'Slip'
+  }
+];
+---
+
+<MarketingLayout title="Risk Radar | GoldShore" description="Blueprint-grade risk radar visual with live sample metrics.">
+  <section class="risk-hero">
+    <div class="risk-hero__content">
+      <p class="risk-badge">Risk Radar Suite</p>
+      <h1>Luxury-grade surveillance for volatility pressure</h1>
+      <p class="risk-subtitle">
+        A blueprint-inspired command surface that blends market telemetry, exposure drift, and watchmaking precision.
+        Designed for desks that live on the edge of momentum.
+      </p>
+      <div class="risk-hero__stats">
+        <div>
+          <span>Signal latency</span>
+          <strong>&lt; 28ms</strong>
+        </div>
+        <div>
+          <span>Volatility sweep</span>
+          <strong>96 bands</strong>
+        </div>
+        <div>
+          <span>Directional bias</span>
+          <strong>Adaptive</strong>
+        </div>
+      </div>
+    </div>
+    <div class="risk-hero__visual">
+      <svg class="risk-sketch" viewBox="0 0 520 360" role="img" aria-label="3D sketch of the risk radar device">
+        <defs>
+          <linearGradient id="metal" x1="0" x2="1">
+            <stop offset="0%" stop-color="#d8d4c3" stop-opacity="0.85" />
+            <stop offset="100%" stop-color="#6f6a59" stop-opacity="0.9" />
+          </linearGradient>
+          <linearGradient id="glass" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0%" stop-color="#0b1d2b" stop-opacity="0.15" />
+            <stop offset="100%" stop-color="#6ea4c5" stop-opacity="0.35" />
+          </linearGradient>
+        </defs>
+        <rect x="38" y="70" width="300" height="200" rx="32" fill="url(#metal)" stroke="#a9a48f" stroke-width="2" />
+        <rect x="58" y="94" width="260" height="152" rx="20" fill="url(#glass)" stroke="#6788a1" stroke-width="1.4" />
+        <ellipse cx="360" cy="190" rx="120" ry="80" fill="none" stroke="#b4b09a" stroke-width="2" />
+        <ellipse cx="360" cy="190" rx="80" ry="55" fill="none" stroke="#556b7a" stroke-dasharray="6 10" stroke-width="1.5" />
+        <path d="M360 110 L360 270" stroke="#7f8890" stroke-width="1.5" />
+        <path d="M300 190 L420 190" stroke="#7f8890" stroke-width="1.5" />
+        <path d="M360 190 L420 150" stroke="#96b0c4" stroke-width="2" />
+        <path d="M86 238 L152 278" stroke="#aeb3b0" stroke-width="2" />
+        <path d="M112 84 L206 48" stroke="#aeb3b0" stroke-width="1.5" />
+        <circle cx="270" cy="170" r="22" fill="none" stroke="#c7c2ad" stroke-width="2" />
+        <circle cx="270" cy="170" r="6" fill="#c7c2ad" />
+        <path d="M402 78 L456 32" stroke="#8c8a78" stroke-width="1.5" />
+        <path d="M408 76 L468 90" stroke="#8c8a78" stroke-width="1.5" />
+      </svg>
+      <div class="risk-hero__caption">3D sketch motif · layered sapphire glass · brushed titanium case</div>
+    </div>
+  </section>
+
+  <section class="risk-demo" aria-label="Interactive radar demo">
+    <header class="risk-demo__header">
+      <div>
+        <p class="risk-badge">Radar demo</p>
+        <h2>Interactive threat &amp; opportunity sweep</h2>
+        <p class="risk-subtitle">Select a working sample to preview how the radar translates flow into directional G-force.</p>
+      </div>
+      <div class="risk-demo__controls">
+        <label class="risk-select">
+          <span>Sample set</span>
+          <select name="sample" id="risk-sample-select">
+            {samples.map((sample, index) => (
+              <option value={index}>{sample.label}</option>
+            ))}
+          </select>
+        </label>
+        <label class="risk-range">
+          <span>Direction drift</span>
+          <input type="range" id="risk-direction-range" min="0" max="360" value="145" />
+        </label>
+      </div>
+    </header>
+
+    <div class="risk-demo__grid">
+      <div class="risk-panel">
+        <div class="risk-panel__head">
+          <h3>Working sample</h3>
+          <span class="risk-chip" data-field="ticker">AXP</span>
+        </div>
+        <div class="risk-panel__body">
+          <div class="risk-indicator" data-direction="145">
+            <div class="risk-indicator__arrow"></div>
+            <div class="risk-indicator__rings"></div>
+            <div class="risk-indicator__label" data-field="gForce">NW 18.2</div>
+            <div class="risk-indicator__hint">G-force vector</div>
+            <div class="risk-indicator__drift" data-field="drift">145°</div>
+          </div>
+          <dl class="risk-metrics">
+            <div>
+              <dt>Implied vol</dt>
+              <dd data-field="iv">38.6%</dd>
+            </div>
+            <div>
+              <dt>Open vol</dt>
+              <dd data-field="openVol">1.42M</dd>
+            </div>
+            <div>
+              <dt>Open positions</dt>
+              <dd data-field="openPositions">8,240</dd>
+            </div>
+            <div>
+              <dt>Pressure</dt>
+              <dd data-field="pressure">+0.86</dd>
+            </div>
+            <div>
+              <dt>Momentum</dt>
+              <dd data-field="momentum">Up-slope</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+
+      <div class="risk-panel risk-panel--radar">
+        <div class="risk-panel__head">
+          <h3>Radar sweep</h3>
+          <span class="risk-chip">Live simulation</span>
+        </div>
+        <div class="risk-radar">
+          <div class="risk-radar__grid"></div>
+          <div class="risk-radar__pulse"></div>
+          <div class="risk-radar__blip"></div>
+          <div class="risk-radar__legend">
+            <div>
+              <strong data-field="ticker">AXP</strong>
+              <span>Tracker lock</span>
+            </div>
+            <div>
+              <strong data-field="momentum">Up-slope</strong>
+              <span>Directional bias</span>
+            </div>
+          </div>
+        </div>
+        <p class="risk-helper">Rotating sweep translated into directional G-force bias for position mapping.</p>
+      </div>
+    </div>
+  </section>
+</MarketingLayout>
+
+<style>
+  :global(body) {
+    background:
+      radial-gradient(circle at 15% 10%, rgba(29, 126, 252, 0.18), transparent 40%),
+      radial-gradient(circle at 85% 90%, rgba(130, 71, 255, 0.16), transparent 45%),
+      #04070d;
+  }
+  :global(main) {
+    position: relative;
+    isolation: isolate;
+  }
+  .risk-hero {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: clamp(2rem, 4vw, 4rem);
+    padding: clamp(3rem, 6vw, 6rem) clamp(1.5rem, 5vw, 5rem);
+    max-width: 1300px;
+    margin: 0 auto;
+    color: #d9e5fb;
+    border-bottom: 1px solid rgba(24, 161, 255, 0.28);
+  }
+  .risk-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(rgba(70, 97, 131, 0.2) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(70, 97, 131, 0.2) 1px, transparent 1px),
+      linear-gradient(transparent 40%, rgba(24, 161, 255, 0.12) 60%, transparent 80%);
+    background-size: 48px 48px, 48px 48px, 100% 100%;
+    pointer-events: none;
+    opacity: 0.6;
+  }
+  .risk-hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(24, 161, 255, 0.24), transparent 55%);
+    pointer-events: none;
+  }
+  .risk-hero__content,
+  .risk-hero__visual {
+    position: relative;
+    z-index: 1;
+  }
+  .risk-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    font-size: 0.75rem;
+    color: #83cbff;
+    border: 1px solid rgba(24, 161, 255, 0.45);
+    box-shadow: 0 0 18px rgba(24, 161, 255, 0.14);
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    margin-bottom: 1.5rem;
+  }
+  .risk-hero h1 {
+    font-size: clamp(2.5rem, 4vw, 3.5rem);
+    line-height: 1.1;
+    margin: 0 0 1.5rem;
+    color: #f6fbff;
+    text-shadow: 0 8px 26px rgba(31, 130, 255, 0.28);
+  }
+  .risk-subtitle {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    color: #afc7e7;
+    margin-bottom: 2rem;
+  }
+  .risk-hero__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1.25rem;
+  }
+  .risk-hero__stats div {
+    background: linear-gradient(155deg, rgba(10, 20, 36, 0.9), rgba(8, 13, 24, 0.95));
+    border: 1px solid rgba(51, 136, 237, 0.28);
+    box-shadow: inset 0 0 26px rgba(20, 80, 151, 0.25);
+    padding: 1rem 1.25rem;
+    border-radius: 0.75rem;
+  }
+  .risk-hero__stats span {
+    display: block;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.2em;
+    color: #7eb2e0;
+  }
+  .risk-hero__stats strong {
+    font-size: 1.2rem;
+    color: #f3f9ff;
+  }
+  .risk-hero__visual {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+  }
+  .risk-sketch {
+    width: min(520px, 100%);
+    height: auto;
+    filter: drop-shadow(0 30px 40px rgba(0, 0, 0, 0.45));
+  }
+  .risk-hero__caption {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: #91b0d2;
+  }
+  .risk-demo {
+    max-width: 1300px;
+    margin: 0 auto;
+    padding: clamp(3rem, 6vw, 5.5rem) clamp(1.5rem, 5vw, 5rem);
+    color: #d9e5fb;
+  }
+  .risk-demo__header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 2.5rem;
+  }
+  .risk-demo__header h2 {
+    font-size: clamp(2rem, 3vw, 2.6rem);
+    margin: 0.5rem 0 1rem;
+    color: #f6fbff;
+  }
+  .risk-demo__controls {
+    display: grid;
+    gap: 1.5rem;
+    min-width: 240px;
+  }
+  .risk-select,
+  .risk-range {
+    display: grid;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: #7eb2e0;
+  }
+  .risk-select select,
+  .risk-range input {
+    background: rgba(4, 12, 22, 0.9);
+    border: 1px solid rgba(54, 146, 255, 0.34);
+    color: #f6fbff;
+    border-radius: 0.75rem;
+    padding: 0.65rem 0.75rem;
+    font-size: 0.9rem;
+  }
+  .risk-range input { accent-color: #18a1ff; }
+  .risk-demo__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+  }
+  .risk-panel {
+    background: linear-gradient(160deg, rgba(8, 14, 26, 0.95), rgba(4, 10, 18, 0.98));
+    border: 1px solid rgba(38, 123, 229, 0.34);
+    border-radius: 1.5rem;
+    padding: 2rem;
+    box-shadow: inset 0 0 60px rgba(10, 20, 38, 0.65), 0 20px 40px rgba(0, 0, 0, 0.35);
+  }
+  .risk-panel__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+  }
+  .risk-panel__head h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: #f6fbff;
+  }
+  .risk-chip {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid rgba(56, 140, 242, 0.4);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: #9cd7ff;
+  }
+  .risk-panel__body {
+    display: grid;
+    gap: 1.5rem;
+  }
+  .risk-indicator {
+    position: relative;
+    width: 180px;
+    height: 180px;
+    margin: 0 auto;
+  }
+  .risk-indicator__rings {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 1px solid rgba(24, 161, 255, 0.45);
+    box-shadow: inset 0 0 30px rgba(25, 108, 200, 0.42);
+  }
+  .risk-indicator__rings::before,
+  .risk-indicator__rings::after {
+    content: '';
+    position: absolute;
+    inset: 18px;
+    border-radius: 50%;
+    border: 1px dashed rgba(24, 161, 255, 0.45);
+  }
+  .risk-indicator__rings::after { inset: 42px; }
+  .risk-indicator__arrow {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 6px;
+    height: 70px;
+    background: linear-gradient(to bottom, #39b5ff, #18a1ff 40%, #8e5bff);
+    transform-origin: 50% 100%;
+    transform: translate(-50%, -100%) rotate(var(--direction, 145deg));
+    border-radius: 4px;
+    box-shadow: 0 0 16px rgba(24, 161, 255, 0.55);
+  }
+  .risk-indicator__arrow::after {
+    content: '';
+    position: absolute;
+    top: -14px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 16px solid #39b5ff;
+  }
+  .risk-indicator__label {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 1rem;
+    color: #f3f9ff;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+  }
+  .risk-indicator__hint {
+    position: absolute;
+    bottom: 52px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: #91b0d2;
+  }
+  .risk-indicator__drift {
+    position: absolute;
+    bottom: -6px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    color: #9cd7ff;
+    letter-spacing: 0.2em;
+  }
+  .risk-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+    margin: 0;
+  }
+  .risk-metrics div {
+    background: rgba(8, 16, 30, 0.9);
+    border: 1px solid rgba(47, 131, 231, 0.28);
+    padding: 0.8rem;
+    border-radius: 0.75rem;
+  }
+  .risk-metrics dt {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.25em;
+    color: #88acd2;
+  }
+  .risk-metrics dd {
+    margin: 0.5rem 0 0;
+    font-size: 1rem;
+    color: #f6fbff;
+  }
+  .risk-metrics [data-field="pressure"][data-trend='up'],
+  .risk-metrics [data-field="momentum"][data-trend='up'] {
+    color: #44dd90;
+    text-shadow: 0 0 10px rgba(68, 221, 144, 0.32);
+  }
+  .risk-metrics [data-field="pressure"][data-trend='down'],
+  .risk-metrics [data-field="momentum"][data-trend='down'] {
+    color: #ff5d75;
+    text-shadow: 0 0 10px rgba(255, 93, 117, 0.32);
+  }
+  .risk-chip[data-tone='neutral'] {
+    border-color: rgba(142, 91, 255, 0.5);
+    color: #c8a9ff;
+  }
+  .risk-chip[data-tone='up'] {
+    border-color: rgba(68, 221, 144, 0.5);
+    color: #91f0bd;
+  }
+  .risk-chip[data-tone='down'] {
+    border-color: rgba(255, 93, 117, 0.5);
+    color: #ff97a6;
+  }
+  .risk-panel--radar {
+    position: relative;
+    overflow: hidden;
+  }
+  .risk-radar {
+    position: relative;
+    height: 280px;
+    border-radius: 1.5rem;
+    background: radial-gradient(circle at center, rgba(19, 85, 157, 0.35), rgba(5, 13, 24, 0.95) 60%);
+    border: 1px solid rgba(50, 132, 232, 0.35);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .risk-radar__grid {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(circle, rgba(24, 161, 255, 0.34) 1px, transparent 1px);
+    background-size: 36px 36px;
+    opacity: 0.6;
+  }
+  .risk-radar__pulse {
+    position: absolute;
+    width: 240px;
+    height: 240px;
+    border-radius: 50%;
+    border: 1px solid rgba(24, 161, 255, 0.5);
+    animation: radar-pulse 4s infinite ease-in-out;
+  }
+  .risk-radar__blip {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #44dd90;
+    box-shadow: 0 0 20px rgba(68, 221, 144, 0.8);
+    transform: translate(60px, -40px);
+  }
+  .risk-radar__legend {
+    position: absolute;
+    bottom: 1rem;
+    left: 1rem;
+    display: grid;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    color: #b4cff0;
+  }
+  .risk-radar__legend strong {
+    display: block;
+    color: #f6fbff;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+  }
+  .risk-helper {
+    margin-top: 1.5rem;
+    font-size: 0.9rem;
+    color: #88acd2;
+  }
+  @keyframes radar-pulse {
+    0% { transform: scale(0.8); opacity: 0.2; }
+    50% { transform: scale(1); opacity: 0.6; }
+    100% { transform: scale(1.15); opacity: 0.1; }
+  }
+  @media (max-width: 900px) {
+    .risk-demo__controls { width: 100%; }
+    .risk-indicator { width: 160px; height: 160px; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .risk-radar__pulse {
+      animation: none;
+    }
+  }
+</style>
+
+<script>
+  const sampleData = [
+    {
+      label: 'Aurora Sigma',
+      ticker: 'AXP',
+      iv: '38.6%',
+      openVol: '1.42M',
+      openPositions: '8,240',
+      gForce: 'NW 18.2',
+      drift: '145°',
+      pressure: '+0.86',
+      momentum: 'Up-slope'
+    },
+    {
+      label: 'Titan Harbor',
+      ticker: 'NVDA',
+      iv: '52.1%',
+      openVol: '2.08M',
+      openPositions: '11,904',
+      gForce: 'E 22.7',
+      drift: '80°',
+      pressure: '+1.34',
+      momentum: 'Accel'
+    },
+    {
+      label: 'Mariner Ghost',
+      ticker: 'TSLA',
+      iv: '64.9%',
+      openVol: '1.77M',
+      openPositions: '9,332',
+      gForce: 'SE 12.3',
+      drift: '205°',
+      pressure: '-0.62',
+      momentum: 'Slip'
+    }
+  ];
+
+  const fieldTargets = document.querySelectorAll('[data-field]');
+  const select = document.getElementById('risk-sample-select');
+  const range = document.getElementById('risk-direction-range');
+  const indicator = document.querySelector('.risk-indicator');
+
+  const updateFields = (sample) => {
+    fieldTargets.forEach((node) => {
+      const key = node.dataset.field;
+      if (sample[key]) {
+        node.textContent = sample[key];
+      }
+    });
+
+    const pressureNode = document.querySelector('[data-field="pressure"]');
+    const momentumNode = document.querySelector('[data-field="momentum"]');
+    const tickerNode = document.querySelector('.risk-chip[data-field="ticker"]');
+
+    const pressureTrend = sample.pressure.trim().startsWith('-') ? 'down' : 'up';
+    const momentumTrend = /slip|down|drop|fade/i.test(sample.momentum) ? 'down' : 'up';
+    const tone = Number.parseFloat(sample.iv) > 50 ? 'neutral' : pressureTrend;
+
+    pressureNode?.setAttribute('data-trend', pressureTrend);
+    momentumNode?.setAttribute('data-trend', momentumTrend);
+    tickerNode?.setAttribute('data-tone', tone);
+
+    indicator?.style.setProperty('--direction', sample.drift.replace('°', '') + 'deg');
+    indicator?.setAttribute('data-direction', sample.drift.replace('°', ''));
+    if (range) {
+      range.value = sample.drift.replace('°', '');
+    }
+  };
+
+  const updateDirection = (value) => {
+    const numeric = `${value}`.padStart(3, '0');
+    const drift = `${numeric}°`;
+    indicator?.style.setProperty('--direction', `${value}deg`);
+    const driftField = document.querySelector('[data-field="drift"]');
+    if (driftField) {
+      driftField.textContent = drift;
+    }
+  };
+
+  if (select) {
+    select.addEventListener('change', (event) => {
+      const sample = sampleData[Number(event.target.value)];
+      if (sample) {
+        updateFields(sample);
+      }
+    });
+  }
+
+  if (range) {
+    range.addEventListener('input', (event) => {
+      updateDirection(event.target.value);
+    });
+  }
+
+  updateFields(sampleData[0]);
+</script>


### PR DESCRIPTION
…) (#4588)

### Motivation
- Restore the Risk Radar marketing/demo page because `apps/web/src/pages/apps/risk-radar.astro` was truncated/removed, leaving the `/apps/risk-radar` route rendering a blank page while the navigation still linked to it.
- Prevent a user-facing dead-end route in production by returning the original interactive page instead of silently removing the content without removing the nav entry.

### Description
- Restored the full `apps/web/src/pages/apps/risk-radar.astro` file including `export const prerender = true;`, the hero section, interactive radar demo, sample data, inline styles, and client-side demo script so the route renders as originally intended.
- Preserved the existing navigation and layout integration so the `/apps/risk-radar` link in `WebLayout.astro` resolves to a working page again.
- Added a concise follow-up PR description requesting a code review using the repository tagging convention: `@Jules-Bot [review-request]`.

### Testing
- Built the web app with `pnpm build:web` and the build completed successfully.
- Confirmed Astro prerender output included `/apps/risk-radar/index.html` during the build logs, indicating the restored page is being generated.

------
[Codex
Task](https://chatgpt.com/codex/tasks/task_e_69d26e31f97083318cbe7fddc935549b)