### PR TITLE
fix: remove conflict markers from audit report

### DIFF
--- a/reports/AUDIT_2026-03-29.md
+++ b/reports/AUDIT_2026-03-29.md
@@ -13,10 +13,10 @@
 The deploy workflow for `gs-agent` contains a **live, unresolved Git merge conflict marker** at lines 20-23:
 
 ```
-<<<<<<< codex/review-and-update-workflow-models-2026-03-23
-=======
+[conflict-marker-start]
+[conflict-marker-separator]
     name: Deploy
->>>>>>> main
+[conflict-marker-end]
 ```
 
 **Impact:** This workflow is syntactically invalid YAML. Any push that triggers it will cause the **entire deploy job to fail immediately**. The `gs-agent` worker cannot be deployed from CI while this persists.


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Remove literal Git conflict markers from the audit report to avoid conflict-scan false positives and prevent referencing invalid workflow snippets.

### Description
- Replaced the `<<<<<<<`, `=======`, and `>>>>>>>` lines in `reports/AUDIT_2026-03-29.md` with neutral placeholders (`[conflict-marker-start]`, `[conflict-marker-separator]`, `[conflict-marker-end]`).

### Testing
- Ran `rg -n "^(<<<<<<<|=======|>>>>>>>)"` and confirmed no matches, indicating the conflict markers were removed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8ef30f48833196bcdecb46376916)