### PR TITLE
[Follow-up] Fix Codex review blockers in repo doc config (#4568)

### DIFF
--- a/apps/gs-control/wrangler.toml
+++ b/apps/gs-control/wrangler.toml
@@ -14,6 +14,14 @@ routes = [
 ENV = "production"
 CONTROL_SERVICE = "true"
 
+[[env.prod.kv_namespaces]]
+binding = "GS_CONFIG"
+id = "gs_config_001"
+
+[[env.prod.kv_namespaces]]
+binding = "CONTROL_LOGS"
+id = "gs_control_logs_001"
+
 [env.preview]
 routes = [
   { pattern = "ops-preview.goldshore.ai/*", zone_name = "goldshore.ai" }
@@ -21,3 +29,11 @@ routes = [
 
 [env.preview.vars]
 ENV = "preview"
+
+[[env.preview.kv_namespaces]]
+binding = "GS_CONFIG"
+id = "gs_config_preview"
+
+[[env.preview.kv_namespaces]]
+binding = "CONTROL_LOGS"
+id = "gs_control_logs_preview"

--- a/apps/gs-gateway/package.json
+++ b/apps/gs-gateway/package.json
@@ -13,9 +13,6 @@
     "@goldshore/auth": "workspace:*",
     "hono": "^4.12.4",
     "zod": "^4.3.6"
-    "dev": "wrangler dev src/index.ts",
-    "deploy": "wrangler deploy --env prod",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260329.1",

--- a/apps/gs-web/src/pages/status.astro
+++ b/apps/gs-web/src/pages/status.astro
@@ -6,11 +6,6 @@ import {
   statusSnapshot,
 } from '../data/status';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import {
-  getStatusLabel,
-  getStatusSummary,
-  statusSnapshot,
-} from '../data/status';
 
 const snapshot = statusSnapshot;
 const summary = getStatusSummary(snapshot.components);


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Prevent a workspace-wide install/build failure by fixing invalid JSON in `apps/gs-gateway/package.json` that caused `ERR_PNPM_JSON_PARSE`. 
- Prevent a compile-time duplicate-declaration error by removing the duplicate imports in `apps/gs-web/src/pages/status.astro`. 
- Ensure the control worker can persist sync state by binding the required KV namespaces used by `apps/gs-control/src/index.ts` in `apps/gs-control/wrangler.toml` for both `env.prod` and `env.preview`.

### Description
- Repaired `apps/gs-gateway/package.json` so `dependencies` is valid JSON and all runtime packages remain under `dependencies` while script entries remain under `scripts`.
- Removed the duplicated `getStatusLabel`, `getStatusSummary`, and `statusSnapshot` import block from `apps/gs-web/src/pages/status.astro` so the page no longer redeclares module-scope bindings.
- Added `[[env.prod.kv_namespaces]]` and `[[env.preview.kv_namespaces]]` entries in `apps/gs-control/wrangler.toml` for `GS_CONFIG` and `CONTROL_LOGS` with preview and prod placeholder IDs to match runtime bindings.

### Testing
- Validated `apps/gs-gateway/package.json` parses with Node using `JSON.parse(...)` which succeeded. 
- Ran `pnpm -C apps/gs-web run build` which failed in this environment because workspace dependencies and the `astro` binary are not installed, so the local build could not complete. 
- Ran a dry-run `pnpm -C apps/gs-control exec wrangler deploy --env preview --dry-run` which could not complete bundling in this environment due to missing installed dependencies and unresolved module aliases, so the deploy dry-run reported unresolved imports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8fbb2374833184d8eef7eb986eed)