### PR TITLE
[PR #4613 follow-up] Fix merge artifacts, clean pnpm lockfile, and correct gs-agent Wrangler path

### DIFF
--- a/apps/gs-agent/package.json
+++ b/apps/gs-agent/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --env dev --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "deploy": "wrangler deploy src/index.ts --env prod --minify --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "deploy:preview": "wrangler deploy src/index.ts --env preview --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "build": "wrangler deploy src/index.ts --dry-run --outdir=dist --env prod --config ../../infra/cloudflare/gs-agent.wrangler.toml"
+    "dev": "wrangler dev src/index.ts --env dev --config ../../infra/Cloudflare/gs-agent.wrangler.toml",
+    "deploy": "wrangler deploy src/index.ts --env prod --minify --config ../../infra/Cloudflare/gs-agent.wrangler.toml",
+    "deploy:preview": "wrangler deploy src/index.ts --env preview --config ../../infra/Cloudflare/gs-agent.wrangler.toml",
+    "build": "wrangler deploy src/index.ts --dry-run --outdir=dist --env prod --config ../../infra/Cloudflare/gs-agent.wrangler.toml"
   },
   "dependencies": {
     "@goldshore/auth": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,21 +29,6 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.6.0
         version: 3.7.0
-<<<<<<< main-HEAD-2
-=======
-        specifier: ^2.8.9
-        version: 2.8.9
-    devDependencies:
-      '@astrojs/mdx':
-        specifier: ^4.0.8
-        version: 4.3.13(astro@5.18.0(@types/node@25.3.3)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
-      '@astrojs/sitemap':
-        specifier: ^3.6.0
-        version: 3.7.0
-<<<<<<< chore/working-copy-upstream
-=======
->>>>>>> chore/working-copy
->>>>>>> main-HEAD-2
       '@astrojs/tailwind':
         specifier: ^6.0.2
         version: 6.0.2(astro@5.18.0(@types/node@25.3.3)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -1211,17 +1196,9 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@types/sax@1.2.7':
-    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
-  '@types/unist@2.0.11':
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@types/sax@1.2.7':
-    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
-  '@types/unist@2.0.11':
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -2128,21 +2105,6 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
-<<<<<<< main-HEAD-2
-=======
-  iron-webcrypto@1.2.1:
-    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
-
-  is-alphabetical@2.0.1:
-    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
-
-  is-alphanumerical@2.0.1:
-    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
-
-<<<<<<< chore/working-copy-upstream
-=======
->>>>>>> chore/working-copy
->>>>>>> main-HEAD-2
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -4382,17 +4344,9 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@types/sax@1.2.7':
-    dependencies:
-      '@types/node': 25.3.3
 
-  '@types/unist@2.0.11': {}
 
-  '@types/sax@1.2.7':
-    dependencies:
-      '@types/node': 25.3.3
 
-  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -6712,16 +6666,6 @@ snapshots:
 
   stream-replace-string@2.0.0: {}
 
-<<<<<<< main-HEAD-2
-=======
-  space-separated-tokens@2.0.2: {}
-
-  stream-replace-string@2.0.0: {}
-
-<<<<<<< chore/working-copy-upstream
-=======
->>>>>>> chore/working-copy
->>>>>>> main-HEAD-2
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0

--- a/scripts/sync-gateway.ts
+++ b/scripts/sync-gateway.ts
@@ -1,17 +1,4 @@
-<<<<<<< HEAD
 import { MasterConfigSchema, type MasterConfig } from '../packages/schema/src/system.ts';
-=======
-<<<<<<< HEAD
-import {
-  AiOrchestrationSchema,
-  RoutingTableSchema,
-  ServiceStatusSchema,
-} from '../packages/schema/src/system.ts';
-import { z } from 'zod';
-=======
-import { MasterConfigSchema, type MasterConfig } from '../packages/schema/src/system.ts';
->>>>>>> 9a7cd1bf7c1ad35699a74d37fff8bae63408bf13
->>>>>>> 2513239f97c889fa6a258a9de2085481dc7def4c
 
 const DEFAULT_ACCOUNT_ID = 'f77de112d2019e5456a3198a8bb50bd2';
 const DEFAULT_NAMESPACE_ID = '9cc2209906a94851b704be57543987a9';
@@ -22,35 +9,24 @@ const NAMESPACE_ID = process.env.GS_KV_NAMESPACE_ID ?? DEFAULT_NAMESPACE_ID;
 
 const MASTER_CONFIG: MasterConfig = {
   ROUTING_TABLE: {
-    'gateway.goldshore.ai': { role: 'ingress', worker: 'gs-gateway' },
-    'agent.goldshore.ai': { role: 'alias', target: 'gateway.goldshore.ai' },
-    'api.goldshore.ai': { role: 'backend', worker: 'gs-api' },
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-    'agent.internal.goldshore.ai': { role: 'backend', worker: 'gs-agent' },
-=======
->>>>>>> 9a7cd1bf7c1ad35699a74d37fff8bae63408bf13
->>>>>>> 2513239f97c889fa6a258a9de2085481dc7def4c
-    'admin.goldshore.ai': { role: 'frontend', project: 'gs-admin-pages' },
-    'mail.goldshore.ai': { role: 'mx-only', provider: 'cloudflare-email' },
+    'gateway.goldshore.ai': { role: 'ingress', worker: 'gs-gateway', priority: 1 },
+    'agent.goldshore.ai': { role: 'alias', target: 'gateway.goldshore.ai', priority: 1 },
+    'api.goldshore.ai': { role: 'backend', worker: 'gs-api', priority: 1 },
+    'agent.internal.goldshore.ai': { role: 'backend', worker: 'gs-agent', priority: 1 },
+    'admin.goldshore.ai': { role: 'frontend', project: 'gs-admin-pages', priority: 1 },
+    'mail.goldshore.ai': { role: 'mx-only', provider: 'cloudflare-email', priority: 1 },
   },
   SERVICE_STATUS: {
     maintenance_mode: false,
-<<<<<<< HEAD
-    active_services: ['gateway', 'api', 'agent', 'admin'],
-=======
-<<<<<<< HEAD
     active_services: ['gs-gateway', 'gs-api', 'gs-agent', 'gs-admin'],
-=======
-    active_services: ['gateway', 'api', 'agent', 'admin'],
->>>>>>> 9a7cd1bf7c1ad35699a74d37fff8bae63408bf13
->>>>>>> 2513239f97c889fa6a258a9de2085481dc7def4c
+    version: '2026-04-15',
+    last_sync: new Date().toISOString(),
   },
   AI_ORCHESTRATION: {
-    preferred_model: 'gpt-4-turbo',
+    preferred_model: 'gpt-5-mini',
     agent_modules: ['operator-assist', 'market-intel'],
     queue_concurrency: 10,
+    retry_attempts: 2,
   },
 };
 
@@ -90,9 +66,10 @@ async function syncConfig(config: MasterConfig): Promise<void> {
 
 async function runFinalVerification(): Promise<void> {
   console.log('\n📬 Checking /internal/inbox-status...');
+
   try {
     const finalVerify = await fetch('https://api.goldshore.ai/internal/inbox-status');
-    const data = await finalVerify.json() as { success?: boolean; inbox?: { count?: number } };
+    const data = (await finalVerify.json()) as { success?: boolean; inbox?: { count?: number } };
 
     if (data.success) {
       console.log(`🎉 SYSTEM ONLINE: ${data.inbox?.count ?? 0} emails logged in KV.`);
@@ -101,288 +78,17 @@ async function runFinalVerification(): Promise<void> {
     }
   } catch (error) {
     console.error('⚠️ Final verification failed due to network/auth issue:', error);
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-import { z } from "zod";
-
-type ConfigKey = "ROUTING_TABLE" | "SERVICE_STATUS" | "AI_ORCHESTRATION";
-
-const RoutingTargetSchema = z
-  .object({
-    role: z.enum(["ingress", "alias", "backend", "frontend", "mx-only"]),
-    worker: z.string().min(1).optional(),
-    target: z.string().min(1).optional(),
-    project: z.string().min(1).optional(),
-    priority: z.number().int().min(1).default(1),
-  })
-  .strict();
-
-const RoutingTableSchema = z.record(z.string().min(1), RoutingTargetSchema);
-
-const ServiceStatusSchema = z
-  .object({
-    maintenance_mode: z.boolean().default(false),
-    active_services: z.array(z.string().min(1)).min(1),
-    version: z.string().min(1),
-    last_sync: z.string().datetime().optional(),
-  })
-  .strict();
-
-const AiProviderConfigSchema = z
-  .object({
-    provider: z.enum(["openai", "anthropic", "google", "cloudflare-ai"]),
-    model: z.string().min(1),
-    enabled: z.boolean().default(true),
-    priority: z.number().int().min(1),
-  })
-  .strict();
-
-const AiOrchestrationSchema = z
-  .object({
-    default_provider: z.string().min(1),
-    providers: z.array(AiProviderConfigSchema).min(1),
-    fallback_chain: z.array(z.string().min(1)).min(1),
-    max_retries: z.number().int().min(0).max(10).default(2),
-  })
-  .strict();
-
-const ConfigPayloadSchema = z
-  .object({
-    ROUTING_TABLE: RoutingTableSchema,
-    SERVICE_STATUS: ServiceStatusSchema,
-    AI_ORCHESTRATION: AiOrchestrationSchema,
-  })
-  .strict();
-
-type ConfigPayload = z.infer<typeof ConfigPayloadSchema>;
-
-const DEFAULT_ACCOUNT_ID = process.env.CF_ACCOUNT_ID;
-const DEFAULT_NAMESPACE_ID = "9cc2209906a94851b704be57543987a9";
-
-const payload: ConfigPayload = {
-  ROUTING_TABLE: {
-    api: { role: "backend", worker: "gs-api", priority: 1 },
-    gateway: { role: "ingress", worker: "gs-gateway", priority: 1 },
-const SyncLedgerSchema = z
-  .object({
-    last_sync: z.string().datetime(),
-    namespace_id: z.string().min(1),
-    account_id_masked: z.string().min(4),
-    hosts: z.array(z.string().min(1)).min(1),
-    keys_uploaded: z.array(z.string().min(1)).min(1),
-  })
-  .strict();
-
-type ConfigPayload = z.infer<typeof ConfigPayloadSchema>;
-type ConfigKey = keyof ConfigPayload;
-
-type SyncLedger = z.infer<typeof SyncLedgerSchema>;
-
-const MASTER_CONFIG: ConfigPayload = {
-  ROUTING_TABLE: {
-    api: { role: "backend", worker: "gs-api", priority: 1 },
-    gateway: { role: "ingress", worker: "gs-gateway", priority: 1 },
-    agent: { role: "backend", worker: "gs-agent", priority: 1 },
-    "agent.goldshore.ai": { role: "alias", target: "gateway", priority: 1 },
-    admin: { role: "frontend", project: "gs-admin", priority: 1 },
-    web: { role: "frontend", project: "gs-web", priority: 1 },
-    mail: { role: "mx-only", target: "gs-mail", priority: 1 },
-  },
-  SERVICE_STATUS: {
-    maintenance_mode: false,
-    active_services: ["gs-api", "gs-gateway", "gs-agent", "gs-mail", "gs-web", "gs-admin"],
-    version: "2026-03-03",
-    last_sync: new Date().toISOString(),
-  },
-  AI_ORCHESTRATION: {
-    default_provider: "openai",
-    providers: [
-      { provider: "openai", model: "gpt-5-mini", enabled: true, priority: 1 },
-      { provider: "anthropic", model: "claude-3-5-sonnet", enabled: true, priority: 2 },
-    ],
-    fallback_chain: ["openai", "anthropic"],
-    max_retries: 2,
-  },
-};
-
-function getRequiredEnv(name: "CLOUDFLARE_API_TOKEN"): string {
-    preferred_model: 'gpt-5-mini',
-    agent_modules: ['operator-assist', 'market-intel'],
-    queue_concurrency: 10,
-    retry_attempts: 2,
-  },
-};
-
-function getRequiredEnv(name: 'CLOUDFLARE_API_TOKEN'): string {
-  const value = process.env[name]?.trim();
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}.`);
-  }
-  return value;
-}
-
-function resolveEnvWithFallback(
-  primary: "CLOUDFLARE_ACCOUNT_ID" | "GS_KV_NAMESPACE_ID",
-  fallback: string | undefined,
-  hint: string,
-): string {
-  const value = process.env[primary]?.trim() ?? fallback?.trim();
-  if (!value) {
-    throw new Error(
-      `Unable to resolve ${primary}. Set ${primary}${hint ? ` (${hint})` : ""}.`,
-    );
-  }
-  return value;
-}
-
-function maskAccountId(accountId: string): string {
-  return accountId.length > 4 ? `${'*'.repeat(accountId.length - 4)}${accountId.slice(-4)}` : accountId;
-}
-
-async function putKvValue(args: {
-  accountId: string;
-  namespaceId: string;
-  token: string;
-  key: ConfigKey;
-  value: unknown;
-}): Promise<{ key: ConfigKey; ok: boolean; status: number; detail?: string }> {
-  const endpoint = `https://api.cloudflare.com/client/v4/accounts/${args.accountId}/storage/kv/namespaces/${args.namespaceId}/values/${encodeURIComponent(args.key)}`;
-  const response = await fetch(endpoint, {
-    method: "PUT",
-    headers: {
-      Authorization: `Bearer ${args.token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(args.value),
-  });
-
-  if (response.ok) {
-    return { key: args.key, ok: true, status: response.status };
-  }
-
-  const bodyText = await response.text();
-  return {
-    key: args.key,
-    ok: false,
-    status: response.status,
-    detail: bodyText.slice(0, 500),
-  };
-}
-
-async function verifyInboxStatus(): Promise<{ ok: boolean; status?: number; detail?: string }> {
-  const endpoint = "https://api.goldshore.ai/internal/inbox-status";
-  try {
-    const response = await fetch(endpoint, {
-      headers: { Accept: "application/json" },
-    });
-
-    if (!response.ok) {
-      return { ok: false, status: response.status, detail: `HTTP ${response.status}` };
-    }
-
-    return { ok: true, status: response.status };
-  } catch (error) {
-    return {
-      ok: false,
-      detail: error instanceof Error ? error.message : "Unknown verification error",
-    };
-=======
->>>>>>> 9a7cd1bf7c1ad35699a74d37fff8bae63408bf13
->>>>>>> 2513239f97c889fa6a258a9de2085481dc7def4c
   }
 }
 
 async function main(): Promise<void> {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-  const token = getRequiredEnv('CLOUDFLARE_API_TOKEN');
-  const accountId = resolveEnvWithFallback('CLOUDFLARE_ACCOUNT_ID', DEFAULT_ACCOUNT_ID);
-  const namespaceId = resolveEnvWithFallback('GS_KV_NAMESPACE_ID', DEFAULT_NAMESPACE_ID);
-
-  const validatedPayload = ConfigPayloadSchema.parse(MASTER_CONFIG);
-  const configKeys = Object.keys(validatedPayload) as ConfigKey[];
-
-  const syncLedger: SyncLedger = SyncLedgerSchema.parse({
-    last_sync: new Date().toISOString(),
-    namespace_id: namespaceId,
-    account_id_masked: maskAccountId(accountId),
-    hosts: Object.keys(validatedPayload.ROUTING_TABLE),
-    keys_uploaded: [...configKeys, 'INFRA_SYNC_LEDGER'],
-  });
-
-  console.log('Starting Cloudflare KV sync...');
-  console.log(`- Account: ${syncLedger.account_id_masked}`);
-  console.log(`- Namespace: ${namespaceId}`);
-
-  const results = await Promise.all([
-    ...configKeys.map((key) =>
-      putKvValue({
-        accountId,
-        namespaceId,
-        token,
-        key,
-        value: validatedPayload[key],
-      }),
-    ),
-    putKvValue({
-      accountId,
-      namespaceId,
-      token,
-      key: 'INFRA_SYNC_LEDGER',
-      value: syncLedger,
-    }),
-  ]);
-
-  for (const result of results) {
-    if (result.ok) {
-      console.log(`✅ ${result.key}: uploaded (HTTP ${result.status})`);
-    } else {
-      console.error(`❌ ${result.key}: failed (HTTP ${result.status}) ${result.detail ?? ''}`);
-    }
-  }
-
-  const verifyResult = await verifyInboxStatus();
-  if (verifyResult.ok) {
-    console.log(`✅ Verification: /internal/inbox-status passed (HTTP ${verifyResult.status})`);
-  } else {
-    console.error(`❌ Verification: /internal/inbox-status failed (${verifyResult.detail ?? 'unknown error'})`);
-  }
-
-  const uploadFailures = results.filter((result) => !result.ok).length;
-  const failures = uploadFailures + (verifyResult.ok ? 0 : 1);
-  console.log(`Summary: ${results.length - uploadFailures}/${results.length} KV uploads passed; verification ${verifyResult.ok ? 'passed' : 'failed'}.`);
-
-  if (failures > 0) {
-    process.exitCode = 1;
-  }
-}
-
-main().catch((error) => {
-  console.error(`❌ sync:infra failed: ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(1);
-=======
->>>>>>> 2513239f97c889fa6a258a9de2085481dc7def4c
   assertEnvironment();
-  const parseResult = MasterConfigSchema.safeParse(MASTER_CONFIG);
-
-  if (!parseResult.success) {
-    console.error('❌ Invalid MASTER_CONFIG.');
-    console.error(parseResult.error.format());
-    process.exitCode = 1;
-    return;
-  }
-
-  await syncConfig(parseResult.data);
+  const parsedConfig = MasterConfigSchema.parse(MASTER_CONFIG);
+  await syncConfig(parsedConfig);
   await runFinalVerification();
 }
 
 main().catch((error) => {
-  console.error('❌ System sync failed:', error);
+  console.error('❌ Sync failed:', error);
   process.exitCode = 1;
-<<<<<<< HEAD
-=======
->>>>>>> 9a7cd1bf7c1ad35699a74d37fff8bae63408bf13
->>>>>>> 2513239f97c889fa6a258a9de2085481dc7def4c
 });


### PR DESCRIPTION
### Motivation

- Resolve high-priority failures introduced by unresolved merge conflict markers and duplicated blocks that broke `scripts/sync-gateway.ts`, `pnpm-lock.yaml`, and CI/operator flows that depend on the gs-agent Wrangler config path.

### Description

- Cleaned `scripts/sync-gateway.ts` by removing all merge conflict markers and duplicate/incomplete code, restoring a single valid sync flow with `assertEnvironment`, `MasterConfigSchema` validation, `syncConfig`, `runFinalVerification`, and `main` execution.
- Updated routing entries and service metadata in `MASTER_CONFIG` to meet the `MasterConfigSchema` expectations (added `priority` on routing entries and added `version`/`last_sync` for service status), and adjusted small orchestration defaults (`preferred_model`, `retry_attempts`).
- Fixed case-sensitive Wrangler config paths in `apps/gs-agent/package.json` from `infra/cloudflare/...` to `infra/Cloudflare/...` so Linux CI/runner environments can locate the config file.
- Removed merge artifacts and duplicate mapping entries from `pnpm-lock.yaml` so the lockfile is valid YAML and no longer triggers `duplicated mapping key` parse errors.

### Testing

- Verified removal of conflict markers with `rg -n '<<<<<<<|>>>>>>>|======' scripts/sync-gateway.ts apps/gs-agent/package.json pnpm-lock.yaml`, which returned no matches after the fix.
- Ran `pnpm install --frozen-lockfile --ignore-scripts` to validate the cleaned lockfile; the lockfile parsing/frozen-lockfile validation completed but package fetch failed in this environment due to external npm registry `403` auth errors unrelated to lockfile syntax.
- Executed `pnpm exec tsc --noEmit scripts/sync-gateway.ts` to check TypeScript surface errors and observed failures stemming from workspace/TS configuration (lib/ambient types) outside the scope of these fixes and not caused by the resolved merge artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9e23d7708331b9e789669c0f1ed1)