### PR TITLE
Align gs-api wrangler-config test with canonical prod env

### DIFF
--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -6,7 +6,7 @@ import { resolve } from 'node:path';
 const wranglerToml = readFileSync(resolve(import.meta.dirname, '../../wrangler.toml'), 'utf8');
 
 describe('gs-api wrangler env bindings', () => {
-  for (const envName of ['prod', 'production', 'preview']) {
+  for (const envName of ['prod', 'preview']) {
     it(`keeps the KV binding required by runtime handlers in ${envName}`, () => {
       assert.match(
         wranglerToml,


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Ensure the gs-api test suite matches the current `wrangler.toml` layout after `env.production` was removed so tests don't falsely fail on CI.

### Description
- Updated `apps/gs-api/src/routes/wrangler-config.test.ts` to iterate over `['prod', 'preview']` instead of `['prod', 'production', 'preview']` to match `apps/gs-api/wrangler.toml` where the canonical production env is `env.prod`.

### Testing
- Attempted to run `pnpm --filter ./apps/gs-api... test`, but the command could not run in this environment because dependencies are not installed (`tsx: not found`, missing `node_modules`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9e1889608331a7846d0852d50ceb)