### PR TITLE
fix(ci follow-up): keep gs-agent deploy workflow disabled in Phase 0

### DIFF
--- a/.github/workflows/deploy-gs-agent.yml
+++ b/.github/workflows/deploy-gs-agent.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ false }} # Phase 0: keep gs-agent production deploy disabled
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation

- A merge resolution removed the disable guard from the active `gs-agent` deploy workflow, which could cause pushes to `main` that touch `apps/gs-agent/**` to trigger unintended production `wrangler deploy` runs.

### Description

- Added a job-level guard `if: ${{ false }} # Phase 0: keep gs-agent production deploy disabled` to `.github/workflows/deploy-gs-agent.yml` to preserve the Phase 0 behavior and prevent accidental production deployments.

### Testing

- Validated YAML parsing with Ruby via `YAML.load_file(".github/workflows/deploy-gs-agent.yml")`, ensured no merge conflict markers remain using `rg -n "^(<<<<<<<|=======|>>>>>>>)" .github/workflows`, and ran `git diff --check`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9e1ea9448331bb1824d41253dde6)