### PR TITLE
Restore WebLayout symbols and align core-schema dependency

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -3,9 +3,9 @@ import '@goldshore/theme/styles/tokens';
 import '@goldshore/theme/styles/base';
 import '@goldshore/theme/styles/components';
 import '@goldshore/theme/styles/layout';
-import { GSButton } from '@goldshore/ui';
-import SiteFooter from '../components/SiteFooter.astro';
+import Logo from '../components/brand/Logo.astro';
 import { HTML_CSP_META_FALLBACK } from '../security/policy';
+import { WEB_META_CSP } from '../utils/csp';
 
 const navLinks = [
   { href: '/', label: 'Home' },
@@ -16,9 +16,13 @@ const navLinks = [
   { href: '/apps/risk-radar', label: 'Risk Radar' },
   { href: '/developer', label: 'Developer Hub' },
 ];
+const footerLinks = [
+  { href: '/legal/privacy', label: 'Privacy' },
+  { href: '/legal/terms', label: 'Terms' },
+];
+const mobileNavId = 'mobile-navigation';
 
 const { title = 'GoldShore', description = 'GoldShore AI', currentPath = Astro.url.pathname } = Astro.props;
-const logoSrc = '/logo.svg';
 const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
 ---
 

--- a/packages/core-schema/package.json
+++ b/packages/core-schema/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.30.0"
   },
   "devDependencies": {
     "drizzle-kit": "^0.20.0",


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Fix unresolved frontmatter symbols in `apps/gs-web/src/layouts/WebLayout.astro` that cause Astro compilation failures when the layout is rendered. 
- Reintroduce layout constants required by markup for mobile navigation and footer rendering. 
- Prevent CI `pnpm install --frozen-lockfile` failures by aligning `packages/core-schema` dependency with the committed lockfile.

### Description
- Restored the `Logo` import and `WEB_META_CSP` import in `apps/gs-web/src/layouts/WebLayout.astro` so template references resolve during build. 
- Reintroduced `footerLinks` and `mobileNavId` constants in `apps/gs-web/src/layouts/WebLayout.astro` to satisfy `footerLinks.map(...)` and `aria-controls`/`id` usages. 
- Updated `packages/core-schema/package.json` to set `drizzle-orm` back to `^0.30.0`, matching the current `pnpm-lock.yaml` to avoid lockfile/specifier mismatch in CI.

### Testing
- Ran `pnpm --filter @goldshore/gs-web check` which failed because `astro` is not available in this environment and `node_modules` are not installed. 
- Attempted `pnpm install --lockfile-only --filter @goldshore/core-schema` which failed due to registry authorization (`403`) when fetching `drizzle-orm` in this environment. 
- Attempted `pnpm install --frozen-lockfile --filter @goldshore/core-schema --offline` which failed because the workspace has unrelated lockfile specifier drift (e.g., `apps/gs-admin`) causing a frozen-lockfile mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9e1d201c8331a0b6d27c5733f710)