### PR TITLE
fix(gs-api): align wrangler env test with canonical prod env

### DIFF
--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -6,7 +6,9 @@ import { resolve } from 'node:path';
 const wranglerToml = readFileSync(resolve(import.meta.dirname, '../../wrangler.toml'), 'utf8');
 
 describe('gs-api wrangler env bindings', () => {
-  for (const envName of ['prod', 'production', 'preview']) {
+  // Canonical environments are [env.prod] and [env.preview].
+  // Legacy [env.production] has been intentionally removed.
+  for (const envName of ['prod', 'preview']) {
     it(`keeps the KV binding required by runtime handlers in ${envName}`, () => {
       assert.match(
         wranglerToml,


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- `apps/gs-api/wrangler.toml` removed the legacy `[env.production]` alias in favor of `[env.prod]`, which caused the existing test to assert on a non-existent environment and produce a regression.

### Description
- Updated `apps/gs-api/src/routes/wrangler-config.test.ts` to iterate over the canonical environments `['prod', 'preview']` and added a comment clarifying that `[env.production]` was intentionally removed.

### Testing
- Ran `pnpm --filter ./apps/gs-api... test -- src/routes/wrangler-config.test.ts` and the test suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00af6e4608331a11d7fbd2e2c54e4)