### PR TITLE
Fix gs-gateway package.json JSON and delegate gs-control fetch to Hono

### DIFF
--- a/apps/gs-control/src/index.ts
+++ b/apps/gs-control/src/index.ts
@@ -91,7 +91,9 @@ export const createApp = () => {
 const app = createApp();
 
 export default {
-  fetch: app.fetch,
+  async fetch(request: Request, env: ControlEnv, ctx: ExecutionContext): Promise<Response> {
+    return app.fetch(request, env, ctx);
+  },
   async scheduled(
     _controller: ScheduledController,
     env: ControlEnv,

--- a/apps/gs-gateway/package.json
+++ b/apps/gs-gateway/package.json
@@ -13,9 +13,6 @@
     "@goldshore/auth": "workspace:*",
     "hono": "^4.12.4",
     "zod": "^4.3.6"
-    "dev": "wrangler dev src/index.ts",
-    "deploy": "wrangler deploy --env prod",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260329.1",


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Fix a malformed `apps/gs-gateway/package.json` that caused JSON parse errors and blocked `pnpm install` for the workspace.
- Ensure the gs-control Cloudflare Worker routes and middleware run by delegating the default fetch to the Hono `app.fetch` handler.
- Validate there are no unresolved local imports that would break bundling/type-checking for `gs-control`.

### Description
- Corrected `apps/gs-gateway/package.json` by restoring valid JSON in the `dependencies` block and removing accidental script-like keys so only real dependency entries remain (`@goldshore/auth`, `hono`, `zod`).
- Replaced the previous default export shape in `apps/gs-control/src/index.ts` with an explicit `async fetch(request, env, ctx)` implementation that returns `app.fetch(request, env, ctx)`, ensuring routes/middleware are executed.
- Verified `apps/gs-control/src/index.ts` does not reference `./libs/*`, `./tasks/*`, or `./routes/cloudflare` imports that were absent in the commit.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('apps/gs-gateway/package.json','utf8'))"` which succeeded and confirmed the manifest is valid JSON.
- Ran `rg "\./(libs|tasks)/|\./routes/cloudflare" apps/gs-control/src/index.ts` which returned no matches, confirming no unresolved local imports.
- Ran a node script checking for a hard-coded `Response` return in the default fetch path which passed and confirmed requests are not short-circuited.
- Attempted `pnpm install --frozen-lockfile` which failed due to pre-existing lockfile drift unrelated to these edits, and `pnpm install --no-frozen-lockfile` which failed in this environment due to npm registry `403` auth restrictions, so a full workspace install/build could not be completed here.
- Ran `pnpm --filter @goldshore/gs-control exec tsc --noEmit` previously which failed with a missing `@cloudflare/workers-types` type definition error, indicating type resolution still requires the workspace dependencies to be installed in CI/environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d276a230848331a7610358aaac783b)