### PR TITLE
chore(infra): validate Worker routes and Pages domains separately

### DIFF
--- a/.github/workflows/cloudflare-infra-guard.yml
+++ b/.github/workflows/cloudflare-infra-guard.yml
@@ -18,35 +18,99 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: test -n "$CLOUDFLARE_API_TOKEN" || (echo "Missing CLOUDFLARE_API_TOKEN" && exit 1)
-      - name: Validate routes and DNS
+      - name: Validate routes, Pages domains, and DNS
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           python - <<'PY'
-          import json, os, urllib.parse, urllib.request
-          def cf_get(url):
-              req = urllib.request.Request(url, headers={'Authorization': f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}", 'Content-Type': 'application/json'})
+          import json
+          import os
+          import urllib.parse
+          import urllib.request
+
+          API_BASE = "https://api.cloudflare.com/client/v4"
+
+
+          def cf_get(path):
+              req = urllib.request.Request(
+                  f"{API_BASE}{path}",
+                  headers={
+                      'Authorization': f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}",
+                      'Content-Type': 'application/json',
+                  },
+              )
               with urllib.request.urlopen(req) as resp:
                   data = json.loads(resp.read().decode())
               if not data.get('success'):
-                  raise SystemExit(f"Cloudflare API error for {url}: {data}")
-              return data['result']
+                  raise SystemExit(f"Cloudflare API error for {path}: {data}")
+              return data.get('result')
+
+
           cfg = json.load(open('ops/cloudflare-required.json', 'r', encoding='utf-8'))
+
           zone_name = urllib.parse.quote(cfg['zone_name'])
-          zones = cf_get(f"https://api.cloudflare.com/client/v4/zones?name={zone_name}")
+          zones = cf_get(f"/zones?name={zone_name}")
           if not zones:
               raise SystemExit(f"Zone not found: {cfg['zone_name']}")
-          zone_id = zones[0]['id']
-          route_patterns = [r.get('pattern') for r in cf_get(f"https://api.cloudflare.com/client/v4/zones/{zone_id}/workers/routes")]
-          for pattern in cfg.get('required_routes', []):
+          zone = zones[0]
+          zone_id = zone['id']
+
+          route_patterns = [
+              r.get('pattern')
+              for r in cf_get(f"/zones/{zone_id}/workers/routes")
+              if r.get('pattern')
+          ]
+
+          for pattern in cfg.get('required_worker_routes', []):
               if pattern not in route_patterns:
                   raise SystemExit(f"Missing required worker route: {pattern}")
-          for pattern in cfg.get('forbidden_routes', []):
+
+          for pattern in cfg.get('forbidden_worker_routes', []):
               if pattern in route_patterns:
                   raise SystemExit(f"Forbidden worker route still present: {pattern}")
+
+          account_id = (
+              cfg.get('account_id')
+              or ((zone.get('account') or {}).get('id'))
+          )
+          if not account_id and cfg.get('required_pages_domains'):
+              raise SystemExit(
+                  'Unable to determine Cloudflare account_id for Pages validation. '
+                  'Add account_id to ops/cloudflare-required.json.'
+              )
+
+          for entry in cfg.get('required_pages_domains', []):
+              project = entry.get('project')
+              domain = entry.get('domain')
+              if not project or not domain:
+                  raise SystemExit(
+                      f"Each required_pages_domains item must include project and domain: {entry}"
+                  )
+
+              domains = cf_get(
+                  f"/accounts/{account_id}/pages/projects/{urllib.parse.quote(project)}/domains"
+              )
+
+              # Cloudflare's Pages domains API can return either a flat list of domains
+              # or objects containing a nested 'name'. Support both shapes.
+              configured_domains = set()
+              for item in domains or []:
+                  if isinstance(item, str):
+                      configured_domains.add(item)
+                  elif isinstance(item, dict):
+                      if item.get('name'):
+                          configured_domains.add(item['name'])
+
+              if domain not in configured_domains:
+                  raise SystemExit(
+                      f"Missing required Pages custom domain: {domain} (project: {project})"
+                  )
+
           for hostname in cfg.get('required_dns', []):
               encoded = urllib.parse.quote(hostname)
-              if not cf_get(f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records?name={encoded}"):
+              records = cf_get(f"/zones/{zone_id}/dns_records?name={encoded}")
+              if not records:
                   raise SystemExit(f"Missing required DNS record: {hostname}")
+
           print('Cloudflare infra guard passed.')
           PY

--- a/ops/cloudflare-required.json
+++ b/ops/cloudflare-required.json
@@ -5,12 +5,20 @@
     "admin.goldshore.ai",
     "preview.goldshore.ai"
   ],
-  "required_routes": [
-    "api.goldshore.ai/*",
-    "admin.goldshore.ai/*",
-    "preview.goldshore.ai/*"
+  "required_worker_routes": [
+    "api.goldshore.ai/*"
   ],
-  "forbidden_routes": [
+  "required_pages_domains": [
+    {
+      "project": "gs-admin",
+      "domain": "admin.goldshore.ai"
+    },
+    {
+      "project": "preview-web",
+      "domain": "preview.goldshore.ai"
+    }
+  ],
+  "forbidden_worker_routes": [
     "goldshore.ai/*",
     "www.goldshore.ai/*"
   ],


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Prevent false failures when hostnames are intentionally served by Cloudflare Pages instead of Workers by validating Pages custom domains separately. 
- Make Worker-route expectations explicit so only intentionally Worker-routed hosts are checked against `workers/routes`.
- Keep DNS checks in place while supporting the Pages deployment model for `admin.goldshore.ai` and `preview.goldshore.ai`.

### Description
- Replace the single `required_routes` array in `ops/cloudflare-required.json` with `required_worker_routes`, `required_pages_domains` (items with `project` and `domain`), and `forbidden_worker_routes`, and move `admin.goldshore.ai` and `preview.goldshore.ai` into `required_pages_domains`.
- Update `.github/workflows/cloudflare-infra-guard.yml` Python validation to use a configurable `API_BASE`, call Cloudflare endpoints by path (e.g. `/zones`, `/zones/{id}/workers/routes`), and only check `workers/routes` against `required_worker_routes` and `forbidden_worker_routes`.
- Add explicit Pages validation using the Pages API endpoint `/accounts/{account_id}/pages/projects/{project}/domains`, derive `account_id` from the config or the zone payload as a fallback, and normalize supported response shapes for domain entries.
- Continue validating required DNS records via `/zones/{zone_id}/dns_records`.

### Testing
- Ran `python -m json.tool ops/cloudflare-required.json` to validate the JSON schema, which succeeded. 
- Loaded the workflow YAML via `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cloudflare-infra-guard.yml')"` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e293de2483319aa62fccf70eb2f3)