### PR TITLE
Canonicalize Cloudflare deploy/account manifests and guard checks

### DIFF
--- a/.github/workflows/cloudflare-account-guard.yml
+++ b/.github/workflows/cloudflare-account-guard.yml
@@ -1,0 +1,67 @@
+name: Cloudflare Account Guard
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "ops/cloudflare-account-required.json"
+      - "ops/cloudflare-deploy-targets.json"
+      - "ops/cloudflare-required.json"
+      - ".github/workflows/cloudflare-account-guard.yml"
+      - ".github/workflows/cloudflare-infra-guard.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate canonical Cloudflare manifests
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          account_path = Path('ops/cloudflare-account-required.json')
+          targets_path = Path('ops/cloudflare-deploy-targets.json')
+          legacy_path = Path('ops/cloudflare-required.json')
+
+          for path in (account_path, targets_path, legacy_path):
+              if not path.exists():
+                  raise SystemExit(f"Missing required manifest: {path}")
+
+          account = json.loads(account_path.read_text(encoding='utf-8'))
+          targets = json.loads(targets_path.read_text(encoding='utf-8'))
+          legacy = json.loads(legacy_path.read_text(encoding='utf-8'))
+
+          if account.get('build_token_service') != 'gs-control':
+              raise SystemExit('build_token_service must remain gs-control')
+
+          for key in ('worker_owned_targets', 'pages_owned_targets'):
+              if not targets.get(key):
+                  raise SystemExit(f'Manifest must include at least one {key} entry')
+
+          worker_services = {t['service'] for t in targets['worker_owned_targets']}
+          declared_services = set(account.get('required_worker_services', []))
+          if worker_services != declared_services:
+              raise SystemExit(
+                  f"Service mismatch between manifests. worker_owned_targets={sorted(worker_services)} "
+                  f"required_worker_services={sorted(declared_services)}"
+              )
+
+          pages_projects = {t['project'] for t in targets['pages_owned_targets']}
+          declared_projects = set(account.get('required_pages_projects', []))
+          if pages_projects != declared_projects:
+              raise SystemExit(
+                  f"Pages project mismatch. pages_owned_targets={sorted(pages_projects)} "
+                  f"required_pages_projects={sorted(declared_projects)}"
+              )
+
+          if not legacy.get('deprecated'):
+              raise SystemExit('Legacy manifest must be marked deprecated=true')
+
+          print('Cloudflare account/deploy manifests are structurally valid.')
+          PY

--- a/.github/workflows/cloudflare-infra-guard.yml
+++ b/.github/workflows/cloudflare-infra-guard.yml
@@ -13,14 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: test -f ops/cloudflare-account-required.json
+      - run: test -f ops/cloudflare-deploy-targets.json
       - run: test -f ops/cloudflare-required.json
       - name: Verify Cloudflare token is present
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: test -n "$CLOUDFLARE_API_TOKEN" || (echo "Missing CLOUDFLARE_API_TOKEN" && exit 1)
       - name: Validate routes and DNS
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           python - <<'PY'
           import json, os, urllib.parse, urllib.request
@@ -31,7 +35,25 @@ jobs:
               if not data.get('success'):
                   raise SystemExit(f"Cloudflare API error for {url}: {data}")
               return data['result']
-          cfg = json.load(open('ops/cloudflare-required.json', 'r', encoding='utf-8'))
+          account_cfg = json.load(open('ops/cloudflare-account-required.json', 'r', encoding='utf-8'))
+          deploy_cfg = json.load(open('ops/cloudflare-deploy-targets.json', 'r', encoding='utf-8'))
+          legacy_cfg = json.load(open('ops/cloudflare-required.json', 'r', encoding='utf-8'))
+
+          if deploy_cfg.get('canonical'):
+              required_routes = []
+              required_dns = []
+              for target in deploy_cfg.get('worker_owned_targets', []):
+                  required_routes.extend(target.get('required_routes', []))
+                  required_dns.extend(target.get('required_dns', []))
+              cfg = {
+                  'zone_name': deploy_cfg['zone_name'],
+                  'required_routes': sorted(set(required_routes)),
+                  'required_dns': sorted(set(required_dns)),
+                  'forbidden_routes': deploy_cfg.get('forbidden_worker_routes', [])
+              }
+          else:
+              cfg = legacy_cfg
+
           zone_name = urllib.parse.quote(cfg['zone_name'])
           zones = cf_get(f"https://api.cloudflare.com/client/v4/zones?name={zone_name}")
           if not zones:
@@ -48,5 +70,19 @@ jobs:
               encoded = urllib.parse.quote(hostname)
               if not cf_get(f"https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records?name={encoded}"):
                   raise SystemExit(f"Missing required DNS record: {hostname}")
-          print('Cloudflare infra guard passed.')
+          account_id = os.environ.get('CLOUDFLARE_ACCOUNT_ID', '').strip()
+          if account_id:
+              workers = cf_get(f"https://api.cloudflare.com/client/v4/accounts/{account_id}/workers/scripts")
+              worker_names = {w.get('id') for w in workers}
+              for svc in account_cfg.get('required_worker_services', []):
+                  if svc not in worker_names:
+                      raise SystemExit(f"Missing required worker service in account: {svc}")
+
+              pages = cf_get(f"https://api.cloudflare.com/client/v4/accounts/{account_id}/pages/projects")
+              page_names = {p.get('name') for p in pages}
+              for project in account_cfg.get('required_pages_projects', []):
+                  if project not in page_names:
+                      raise SystemExit(f"Missing required Pages project in account: {project}")
+
+          print('Cloudflare infra guard passed (canonical manifests).')
           PY

--- a/ops/cloudflare-account-required.json
+++ b/ops/cloudflare-account-required.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "2026-04-18",
+  "canonical": true,
+  "build_token_service": "gs-control",
+  "zone_name": "goldshore.ai",
+  "required_worker_services": [
+    "gs-api",
+    "gs-gateway",
+    "gs-mail",
+    "gs-control"
+  ],
+  "required_pages_projects": [
+    "gs-web",
+    "gs-admin"
+  ],
+  "required_secrets": [
+    "CLOUDFLARE_API_TOKEN",
+    "CLOUDFLARE_ACCOUNT_ID"
+  ],
+  "ownership_expectations": {
+    "worker_targets": "Worker-owned targets must be managed by Wrangler worker routes and zone DNS.",
+    "pages_targets": "Pages-owned targets must be managed by Cloudflare Pages custom domains and Pages preview subdomains."
+  },
+  "backward_compatibility": {
+    "legacy_manifest": "ops/cloudflare-required.json",
+    "mode": "bridge",
+    "notes": [
+      "Legacy route/DNS checks are synthesized from ops/cloudflare-deploy-targets.json at runtime.",
+      "Do not add new route or DNS policy entries to the legacy manifest."
+    ]
+  }
+}

--- a/ops/cloudflare-deploy-targets.json
+++ b/ops/cloudflare-deploy-targets.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "2026-04-18",
+  "canonical": true,
+  "zone_name": "goldshore.ai",
+  "worker_owned_targets": [
+    {
+      "id": "api",
+      "service": "gs-api",
+      "environment": "prod",
+      "production_url": "https://api.goldshore.ai",
+      "preview_url": "https://api-preview.goldshore.ai",
+      "ownership_expectation": "Worker owns route matching and DNS for this API host.",
+      "required_dns": [
+        "api.goldshore.ai",
+        "api-preview.goldshore.ai"
+      ],
+      "required_routes": [
+        "api.goldshore.ai/*",
+        "api-preview.goldshore.ai/*"
+      ]
+    },
+    {
+      "id": "gateway",
+      "service": "gs-gateway",
+      "environment": "prod",
+      "production_url": "https://gw.goldshore.ai",
+      "preview_url": "https://gw-preview.goldshore.ai",
+      "ownership_expectation": "Worker owns gateway ingress routing and DNS.",
+      "required_dns": [
+        "gw.goldshore.ai",
+        "gw-preview.goldshore.ai",
+        "agent.goldshore.ai"
+      ],
+      "required_routes": [
+        "gw.goldshore.ai/*",
+        "gw-preview.goldshore.ai/*",
+        "agent.goldshore.ai/*"
+      ]
+    },
+    {
+      "id": "mail",
+      "service": "gs-mail",
+      "environment": "prod",
+      "production_url": "https://mail.goldshore.ai",
+      "preview_url": "https://mail-preview.goldshore.ai",
+      "ownership_expectation": "Worker owns mail ingress routing and DNS.",
+      "required_dns": [
+        "mail.goldshore.ai",
+        "mail-preview.goldshore.ai"
+      ],
+      "required_routes": [
+        "mail.goldshore.ai/*",
+        "mail-preview.goldshore.ai/*"
+      ]
+    },
+    {
+      "id": "control",
+      "service": "gs-control",
+      "environment": "prod",
+      "production_url": "https://ops.goldshore.ai",
+      "preview_url": "https://ops-preview.goldshore.ai",
+      "ownership_expectation": "Worker owns control-plane routing and DNS.",
+      "required_dns": [
+        "ops.goldshore.ai",
+        "ops-preview.goldshore.ai"
+      ],
+      "required_routes": [
+        "ops.goldshore.ai/*",
+        "ops-preview.goldshore.ai/*"
+      ]
+    }
+  ],
+  "pages_owned_targets": [
+    {
+      "id": "marketing-web",
+      "project": "gs-web",
+      "production_url": "https://goldshore.ai",
+      "preview_url": "https://<branch>.gs-web.pages.dev",
+      "ownership_expectation": "Pages owns production custom domains and Pages preview domains.",
+      "required_custom_domains": [
+        "goldshore.ai",
+        "www.goldshore.ai"
+      ]
+    },
+    {
+      "id": "admin-web",
+      "project": "gs-admin",
+      "production_url": "https://admin.goldshore.ai",
+      "preview_url": "https://<branch>.gs-admin.pages.dev",
+      "ownership_expectation": "Pages owns admin custom domain and Pages preview domains.",
+      "required_custom_domains": [
+        "admin.goldshore.ai"
+      ]
+    }
+  ],
+  "forbidden_worker_routes": [
+    "goldshore.ai/*",
+    "www.goldshore.ai/*"
+  ]
+}

--- a/ops/cloudflare-required.json
+++ b/ops/cloudflare-required.json
@@ -1,18 +1,14 @@
 {
-  "zone_name": "goldshore.ai",
-  "required_dns": [
-    "api.goldshore.ai",
-    "admin.goldshore.ai",
-    "preview.goldshore.ai"
-  ],
-  "required_routes": [
-    "api.goldshore.ai/*",
-    "admin.goldshore.ai/*",
-    "preview.goldshore.ai/*"
-  ],
-  "forbidden_routes": [
-    "goldshore.ai/*",
-    "www.goldshore.ai/*"
-  ],
-  "required_kv_namespaces": []
+  "schema_version": "2026-04-18",
+  "deprecated": true,
+  "migration_status": "bridged-to-canonical-manifests",
+  "canonical_manifests": {
+    "account_required": "ops/cloudflare-account-required.json",
+    "deploy_targets": "ops/cloudflare-deploy-targets.json"
+  },
+  "backward_compatibility_notes": [
+    "This file is retained as a compatibility shim for legacy tooling.",
+    "Route and DNS enforcement now comes from ops/cloudflare-deploy-targets.json.",
+    "Do not duplicate policy paths in this file."
+  ]
 }


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Centralize Cloudflare account and deploy-target policy into canonical manifests to avoid duplicated route/DNS policy across repo files.
- Distinguish Worker-owned vs Pages-owned surfaces and codify ownership expectations and required account resources (Workers/Pages projects and build token service).
- Provide a backward-compatible bridge for existing tooling that reads `ops/cloudflare-required.json` while migrating enforcement to the canonical manifests.

### Description
- Added `ops/cloudflare-account-required.json` as the canonical account-level manifest with `build_token_service: gs-control`, required worker services, required Pages projects, and backward-compatibility pointers to the legacy manifest.
- Added `ops/cloudflare-deploy-targets.json` as the canonical deploy-target manifest enumerating `worker_owned_targets` and `pages_owned_targets` with explicit production/preview URLs, required routes/DNS, and ownership expectations.
- Added `.github/workflows/cloudflare-account-guard.yml` to validate manifest structure and cross-manifest parity checks (services/projects and `gs-control` token service expectation).
- Migrated `.github/workflows/cloudflare-infra-guard.yml` to synthesize route/DNS assertions from `ops/cloudflare-deploy-targets.json`, to consult the account manifest for required Workers/Pages projects using `CLOUDFLARE_ACCOUNT_ID`, and to accept `CLOUDFLARE_BUILD_API_TOKEN` as a build-time token fallback.
- Converted `ops/cloudflare-required.json` into a deprecated compatibility shim that points to the canonical manifests and no longer duplicates route/DNS policy paths.

### Testing
- Ran JSON validity checks with `python -m json.tool` on `ops/cloudflare-account-required.json`, `ops/cloudflare-deploy-targets.json`, and `ops/cloudflare-required.json`, and they parsed successfully.
- Executed a parity assertion script that verifies `{t['service'] for t in deploy.targets['worker_owned_targets']}` equals `required_worker_services` and `{t['project'] for t in deploy.targets['pages_owned_targets']}` equals `required_pages_projects`, and the assertions passed after updating the account manifest.
- Performed repository modifications and workflow template updates locally and committed the changes without errors; CI guard workflows were updated to validate the canonical manifests at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e29a45448331bd289db09af590d6)