### PR TITLE
Enforce canonical Cloudflare deploy secret contract in worker workflows

### DIFF
--- a/.github/workflows/cloudflare-infra-guard.yml
+++ b/.github/workflows/cloudflare-infra-guard.yml
@@ -9,18 +9,53 @@ permissions:
   contents: read
 
 jobs:
+  validate-cloudflare-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required Cloudflare account and build token secrets
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+        run: |
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+
+  validate-worker-token-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce canonical build token usage in worker deploy workflows
+        run: |
+          worker_deploy_workflows=(
+            ".github/workflows/deploy-gs-api.yml"
+            ".github/workflows/deploy-gs-agent.yml"
+            ".github/workflows/deploy-gs-gateway.yml"
+            ".github/workflows/deploy-gs-control.yml"
+          )
+
+          for workflow in "${worker_deploy_workflows[@]}"; do
+            rg -q "CLOUDFLARE_API_TOKEN:\s+\$\{\{\s*secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\}\}" "$workflow" \
+              || (echo "Workflow must set CLOUDFLARE_API_TOKEN from secrets.CLOUDFLARE_BUILD_API_TOKEN: $workflow" && exit 1)
+            ! rg -q "secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\|\|" "$workflow" \
+              || (echo "Fallback token source is not allowed: $workflow" && exit 1)
+          done
+
   verify-cloudflare:
+    needs:
+      - validate-cloudflare-secrets
+      - validate-worker-token-policy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: test -f ops/cloudflare-required.json
-      - name: Verify Cloudflare token is present
+      - name: Verify Cloudflare deploy token is present
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: test -n "$CLOUDFLARE_API_TOKEN" || (echo "Missing CLOUDFLARE_API_TOKEN" && exit 1)
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+        run: |
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
       - name: Validate routes and DNS
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
         run: |
           python - <<'PY'
           import json, os, urllib.parse, urllib.request

--- a/.github/workflows/deploy-gs-agent.yml
+++ b/.github/workflows/deploy-gs-agent.yml
@@ -44,9 +44,17 @@ jobs:
       - name: Validate canonical worker names
         run: pnpm validate:names
 
+      - name: Validate required Cloudflare deploy secrets
+        env:
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+
       - name: Deploy GS Agent worker to Cloudflare
         working-directory: apps/gs-agent
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm exec wrangler deploy --env prod

--- a/.github/workflows/deploy-gs-api.yml
+++ b/.github/workflows/deploy-gs-api.yml
@@ -41,9 +41,17 @@ jobs:
       - name: Validate canonical worker names
         run: pnpm validate:names
 
+      - name: Validate required Cloudflare deploy secrets
+        env:
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+
       - name: Deploy GS API worker to Cloudflare
         working-directory: apps/gs-api
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm exec wrangler deploy --env prod

--- a/.github/workflows/deploy-gs-control.yml
+++ b/.github/workflows/deploy-gs-control.yml
@@ -44,9 +44,17 @@ jobs:
       - name: Validate canonical worker names
         run: pnpm validate:names
 
+      - name: Validate required Cloudflare deploy secrets
+        env:
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+
       - name: Deploy GS Control worker to Cloudflare
         working-directory: apps/gs-control
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm exec wrangler deploy --env prod

--- a/.github/workflows/deploy-gs-gateway.yml
+++ b/.github/workflows/deploy-gs-gateway.yml
@@ -44,9 +44,17 @@ jobs:
       - name: Validate canonical worker names
         run: pnpm validate:names
 
+      - name: Validate required Cloudflare deploy secrets
+        env:
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+
       - name: Deploy GS Gateway worker to Cloudflare
         working-directory: apps/gs-gateway
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm exec wrangler deploy --env prod

--- a/infra/Cloudflare/README.md
+++ b/infra/Cloudflare/README.md
@@ -28,3 +28,17 @@ The legacy `infra/Cloudflare/legacy/goldshore-api.wrangler.toml` file remains fo
 ## Selection policy
 
 Do **not** glob `infra/Cloudflare/*.wrangler.toml` in scripts/docs. Use the explicit canonical paths above.
+
+## CI Secret Contract (Canonical)
+
+Cloudflare worker deploy workflows and infra guard checks use the following canonical GitHub Actions secrets:
+
+| Secret name | Required for | Ownership |
+|---|---|---|
+| `CLOUDFLARE_ACCOUNT_ID` | All worker deploy jobs and Cloudflare infra guard checks | Cloudflare account owner / platform ops |
+| `CLOUDFLARE_BUILD_API_TOKEN` | All worker deploy jobs (`gs-api`, `gs-agent`, `gs-gateway`, `gs-control`) and Cloudflare infra guard API calls | `gs-control` service token owner (platform ops) |
+
+Policy:
+
+- `CLOUDFLARE_BUILD_API_TOKEN` is the single canonical deploy token secret for worker CI.
+- Do not add fallback expressions (for example `secretA || secretB`) in worker deploy workflows unless a documented exception is added to Cloudflare runbooks.

--- a/infra/Cloudflare/runbooks/CLOUDFLARE_APPS.md
+++ b/infra/Cloudflare/runbooks/CLOUDFLARE_APPS.md
@@ -45,6 +45,15 @@ Cloudflare applications (Pages / Workers / KV / R2 / D1 / AI / Queues).
 10. Worker Builds token policy:
 
 - For `gs-web`, `gs-admin`, and `gs-api`, use the `gs-control` build token in Cloudflare Worker Builds.
+- For GitHub Actions worker deploy jobs (`deploy-gs-api.yml`, `deploy-gs-agent.yml`, `deploy-gs-gateway.yml`, `deploy-gs-control.yml`), use only:
+  - `CLOUDFLARE_BUILD_API_TOKEN` (canonical build token secret)
+  - `CLOUDFLARE_ACCOUNT_ID` (Cloudflare account secret)
+- Secret ownership:
+  - `CLOUDFLARE_BUILD_API_TOKEN`: owned/rotated by the `gs-control` service owner (platform ops).
+  - `CLOUDFLARE_ACCOUNT_ID`: owned by Cloudflare account admins (platform ops).
+- Pre-deploy policy:
+  - Deploy jobs must fail fast when either required secret is unset.
+  - No fallback to ambiguous token sources (for example `CLOUDFLARE_BUILD_API_TOKEN || CLOUDFLARE_API_TOKEN`) is allowed unless explicitly documented as an exception in this runbook.
 - Current repo wrangler files live at:
   - `infra/Cloudflare/gs-web.wrangler.toml`
   - `infra/Cloudflare/gs-admin.wrangler.toml`


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Ensure worker deploy jobs fail fast when required Cloudflare secrets are missing to avoid accidental ambiguous token use at deploy time. 
- Standardize CI on a single canonical build token to simplify ownership and rotation (`CLOUDFLARE_BUILD_API_TOKEN`).
- Add guard checks to prevent accidental fallback expressions and bake the policy into infra validation and docs.

### Description
- Add a pre-deploy fail-fast secret validation step to `deploy-gs-api.yml`, `deploy-gs-agent.yml`, `deploy-gs-gateway.yml`, and `deploy-gs-control.yml` that requires `CLOUDFLARE_BUILD_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
- Wire deploy jobs to use the canonical secret only by setting `CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}` and remove fallback expressions.
- Extend `.github/workflows/cloudflare-infra-guard.yml` with two new jobs that verify required account/build secrets and enforce that worker deploy workflows reference the canonical token without fallbacks, and make the existing route/DNS checks depend on those validations.
- Document the canonical secret names, ownership, and the no-fallback policy in `infra/Cloudflare/README.md` and `infra/Cloudflare/runbooks/CLOUDFLARE_APPS.md`.

### Testing
- Ran an `rg` check to confirm the ambiguous fallback expression (`CLOUDFLARE_BUILD_API_TOKEN || CLOUDFLARE_API_TOKEN`) is no longer present in the updated workflows, which passed.
- Performed YAML parsing of the updated workflow files with Ruby's `YAML.load_file` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e2983adc8331a848e3024ed1e276)