### PR TITLE
[Follow-up] Fix frozen lockfile dependency snapshots for Auiltifix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8537,10 +8537,22 @@ snapshots:
       read-cache: 1.0.0
       resolve: 1.22.12
 
+  postcss-import@15.1.0(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
   postcss-js@4.1.0(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.5.10
+
+  postcss-js@4.1.0(postcss@8.5.8):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.8
 
   postcss-load-config@4.0.2(postcss@8.5.10):
     dependencies:


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Restore missing lockfile snapshot variants for `postcss@8.5.8` that are referenced by `tailwindcss@3.4.19` so frozen installs do not fail with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`.

### Description
- Re-added `postcss-import@15.1.0(postcss@8.5.8)` and `postcss-js@4.1.0(postcss@8.5.8)` snapshot entries to `pnpm-lock.yaml` to match the existing Tailwind snapshot peer set.

### Testing
- Ran `pnpm install --frozen-lockfile --ignore-scripts` at the repository root and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48b483f048331afe26c73beb93e05)