### PR TITLE
Fix gs-web favicon declarations and CI favicon existence checks

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -36,7 +36,8 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
     <meta name="description" content={description} />
     <!-- Response headers from middleware/platform config are authoritative. Keep this meta CSP only as a fallback when headers are unavailable. -->
     {shouldRenderCspMeta && <meta http-equiv="Content-Security-Policy" content={HTML_CSP_META_FALLBACK} />}
-    <link rel="icon" href="/favicon.png" type="image/png" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.png" type="image/png" sizes="32x32" />
     <!-- Bolt: Preconnect to external origins to speed up resource loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/scripts/verify-web-dist.mjs
+++ b/scripts/verify-web-dist.mjs
@@ -5,6 +5,9 @@ import path from 'node:path';
 const distDir = path.resolve('dist');
 const astroDir = path.join(distDir, '_astro');
 const indexPath = path.join(distDir, 'index.html');
+const webAppRoot = path.resolve('.');
+const webLayoutPath = path.join(webAppRoot, 'src', 'layouts', 'WebLayout.astro');
+const publicDir = path.join(webAppRoot, 'public');
 
 const errors = [];
 
@@ -41,6 +44,36 @@ if (existsSync(indexPath)) {
 
   if (!indexHtml.includes('<script')) {
     errors.push('index.html does not include any <script tags.');
+  }
+}
+
+if (!existsSync(webLayoutPath)) {
+  errors.push(`Missing layout file: ${webLayoutPath}`);
+} else {
+  const layoutSource = readFileSync(webLayoutPath, 'utf8');
+  const iconLinkPattern = /<link\s+[^>]*rel=["']icon["'][^>]*>/gi;
+  const hrefPattern = /\shref=["']([^"']+)["']/i;
+  const declaredIconHrefs = [...layoutSource.matchAll(iconLinkPattern)]
+    .map((tagMatch) => {
+      const hrefMatch = tagMatch[0].match(hrefPattern);
+      return hrefMatch?.[1] ?? null;
+    })
+    .filter((href) => typeof href === 'string');
+
+  if (declaredIconHrefs.length === 0) {
+    errors.push(`No favicon <link rel="icon"> tags found in ${webLayoutPath}`);
+  }
+
+  for (const href of declaredIconHrefs) {
+    if (!href.startsWith('/')) {
+      errors.push(`Favicon path must be root-relative: "${href}"`);
+      continue;
+    }
+
+    const publicAssetPath = path.join(publicDir, href.slice(1));
+    if (!existsSync(publicAssetPath)) {
+      errors.push(`Missing favicon asset for "${href}" at ${publicAssetPath}`);
+    }
   }
 }
 


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Ensure layout references point to actual files shipped in `apps/gs-web/public` to avoid broken favicon links in production.
- Provide both SVG and PNG favicon entries when both assets are available so browsers can choose the best format.
- Make CI fail early when layout-declared favicon assets are missing so build artifacts are consistent and auditable.

### Description
- Updated `apps/gs-web/src/layouts/WebLayout.astro` to declare `/favicon.svg` and a PNG fallback `/favicon.png` in the head (`<link rel="icon" href="/favicon.svg" type="image/svg+xml" />` and `<link rel="icon" href="/favicon.png" type="image/png" sizes="32x32" />`).
- Extended `scripts/verify-web-dist.mjs` to load `src/layouts/WebLayout.astro`, extract all `<link rel="icon">` `href` values, enforce root-relative paths, and verify that each referenced file exists under `apps/gs-web/public`.
- The verification now emits clear error messages for missing layout files, missing favicon tags, non-root-relative paths, and missing public assets so CI can fail fast.

### Testing
- Ran a targeted Node check to parse `WebLayout.astro` and confirm declared hrefs resolve to files under `apps/gs-web/public`; this check passed (no missing favicon assets).
- Ran `pnpm -C apps/gs-web build`, which failed due to an existing Astro/Rollup source-phase import issue unrelated to the favicon changes (build did not complete).
- Ran `pnpm -C apps/gs-web verify:dist`, which fails when no `dist` is present and therefore reported missing `dist` artifacts as expected given the upstream build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d835dc883318ace381b39d55e34)