### PR TITLE
Add canonical URL and social metadata wiring in web layouts

### DIFF
--- a/apps/gs-web/src/layouts/DocsLayout.astro
+++ b/apps/gs-web/src/layouts/DocsLayout.astro
@@ -3,11 +3,17 @@ import WebLayout from './WebLayout.astro';
 import DocsSidebar from '../components/DocsSidebar.astro';
 import DocsSearch from '../components/DocsSearch.astro';
 
-const { title, page } = Astro.props;
+const { title, page, canonicalPath, ogTitle, ogDescription } = Astro.props;
 const currentSlug = page ? page.slug : undefined;
 ---
 
-<WebLayout title={`${title} | Docs`} description="GoldShore developer documentation">
+<WebLayout
+  title={`${title} | Docs`}
+  description="GoldShore developer documentation"
+  canonicalPath={canonicalPath}
+  ogTitle={ogTitle}
+  ogDescription={ogDescription}
+>
   <section class="gs-section docs-shell">
     <aside class="gs-card docs-sidebar" aria-label="Documentation navigation">
       <DocsSearch />

--- a/apps/gs-web/src/layouts/MarketingLayout.astro
+++ b/apps/gs-web/src/layouts/MarketingLayout.astro
@@ -1,8 +1,14 @@
 ---
 import WebLayout from './WebLayout.astro';
 
-const { title, description } = Astro.props;
+const { title, description, canonicalPath, ogTitle, ogDescription } = Astro.props;
 ---
-<WebLayout title={title} description={description}>
+<WebLayout
+  title={title}
+  description={description}
+  canonicalPath={canonicalPath}
+  ogTitle={ogTitle}
+  ogDescription={ogDescription}
+>
   <slot />
 </WebLayout>

--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -3,8 +3,7 @@ import '@goldshore/theme/styles/tokens.css';
 import '@goldshore/theme/styles/base.css';
 import '@goldshore/theme/styles/components.css';
 import '@goldshore/theme/styles/layout.css';
-import { GSButton } from '@goldshore/ui';
-import SiteFooter from '../components/SiteFooter.astro';
+import Logo from '../components/brand/Logo.astro';
 import { HTML_CSP_META_FALLBACK } from '../security/policy';
 import { WEB_META_CSP } from '../utils/csp';
 
@@ -23,7 +22,18 @@ const footerLinks = [
 ];
 const mobileNavId = 'mobile-navigation';
 
-const { title = 'GoldShore', description = 'GoldShore AI', currentPath = Astro.url.pathname } = Astro.props;
+const CANONICAL_ORIGIN = 'https://goldshore.org';
+
+const {
+  title = 'GoldShore',
+  description = 'GoldShore AI',
+  currentPath = Astro.url.pathname,
+  canonicalPath = Astro.url.pathname,
+  ogTitle = title,
+  ogDescription = description,
+} = Astro.props;
+
+const canonicalUrl = new URL(canonicalPath, CANONICAL_ORIGIN).toString();
 const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
 ---
 
@@ -34,6 +44,15 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
     <meta http-equiv="Content-Security-Policy" content={WEB_META_CSP} />
     <title>{title}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:title" content={ogTitle} />
+    <meta property="og:description" content={ogDescription} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content={canonicalUrl} />
+    <meta name="twitter:title" content={ogTitle} />
+    <meta name="twitter:description" content={ogDescription} />
     <!-- Response headers from middleware/platform config are authoritative. Keep this meta CSP only as a fallback when headers are unavailable. -->
     {shouldRenderCspMeta && <meta http-equiv="Content-Security-Policy" content={HTML_CSP_META_FALLBACK} />}
     <link rel="icon" href="/favicon.png" type="image/png" />


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Ensure pages emit an authoritative canonical URL and Open Graph/Twitter metadata so search engines and social platforms resolve to the primary org host.
- Use a single canonical origin of `https://goldshore.org` to standardize canonical URL construction across pages.
- Thread `canonicalPath`, `ogTitle`, and `ogDescription` through layouts so page-specific values can override defaults consistently.

### Description
- Added a `CANONICAL_ORIGIN` constant and composed `canonicalUrl` in `apps/gs-web/src/layouts/WebLayout.astro` using `new URL(canonicalPath, CANONICAL_ORIGIN)`.
- Emitted `rel=canonical`, Open Graph (`og:type`, `og:url`, `og:title`, `og:description`) and Twitter (`twitter:card`, `twitter:url`, `twitter:title`, `twitter:description`) meta tags in the shared head.
- Updated `apps/gs-web/src/layouts/MarketingLayout.astro` and `apps/gs-web/src/layouts/DocsLayout.astro` to accept and forward `canonicalPath`, `ogTitle`, and `ogDescription` to `WebLayout`, while `BaseLayout.astro` continues to pass the same props unchanged.
- Left Cloudflare canonical redirect rules intact and relied on `infra/Cloudflare/desired-state.yaml` which canonicalizes `goldshore.ai` and `www.*` variants to `https://goldshore.org/...`.

### Testing
- Ran `pnpm -C apps/gs-web check` (invokes `astro check`), which surfaced pre-existing unrelated TypeScript/content errors and did not fail due to the layout changes themselves.
- Attempted live header/redirect checks with `curl -I -L` against production host variants but requests were blocked by upstream (403) and could not validate live redirects from this environment.
- Verified redirect rules and the changes by searching/inspecting `infra/Cloudflare/desired-state.yaml` and the modified layout files (`apps/gs-web/src/layouts/WebLayout.astro`, `MarketingLayout.astro`, `DocsLayout.astro`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d8300b083318f5fff3f81e22d85)