### PR TITLE
fix(gs-web): import Logo in WebLayout frontmatter

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -3,8 +3,7 @@ import '@goldshore/theme/styles/tokens.css';
 import '@goldshore/theme/styles/base.css';
 import '@goldshore/theme/styles/components.css';
 import '@goldshore/theme/styles/layout.css';
-import { GSButton } from '@goldshore/ui';
-import SiteFooter from '../components/SiteFooter.astro';
+import Logo from '../components/brand/Logo.astro';
 import { HTML_CSP_META_FALLBACK } from '../security/policy';
 import { WEB_META_CSP } from '../utils/csp';
 


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Ensure the `<Logo />` usages in `apps/gs-web/src/layouts/WebLayout.astro` resolve to a concrete component and remove unnecessary unused imports from the layout frontmatter.

### Description
- Add `import Logo from '../components/brand/Logo.astro';` to the frontmatter and remove the unused `GSButton` and `SiteFooter` imports in `WebLayout.astro`.

### Testing
- Ran `rg` to confirm `<Logo` occurrences and `import Logo` are present in `WebLayout.astro`, ran `pnpm --filter @goldshore/gs-web check` which did not report unresolved `Logo` errors but the workspace check failed due to pre-existing type/content issues in other files, and ran `pnpm --filter @goldshore/gs-web build` which failed with an unrelated Astro/Rollup session-driver externalization error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d809c4483318698e30c2a4003fe)