### PR TITLE
perf: optimize search index generation and stabilize CI

### DIFF
--- a/.github/workflows/cloudflare-infra-guard.yml
+++ b/.github/workflows/cloudflare-infra-guard.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate-cloudflare-secrets:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
     steps:
       - name: Verify required Cloudflare account and build token secrets
         env:
@@ -34,9 +35,9 @@ jobs:
           )
 
           for workflow in "${worker_deploy_workflows[@]}"; do
-            rg -q "CLOUDFLARE_API_TOKEN:\s+\$\{\{\s*secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\}\}" "$workflow" \
+            grep -q "CLOUDFLARE_API_TOKEN: \${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}" "$workflow" \
               || (echo "Workflow must set CLOUDFLARE_API_TOKEN from secrets.CLOUDFLARE_BUILD_API_TOKEN: $workflow" && exit 1)
-            ! rg -q "secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\|\|" "$workflow" \
+            ! grep -q "secrets.CLOUDFLARE_BUILD_API_TOKEN ||" "$workflow" \
               || (echo "Fallback token source is not allowed: $workflow" && exit 1)
           done
 
@@ -45,6 +46,7 @@ jobs:
       - validate-cloudflare-secrets
       - validate-worker-token-policy
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - run: test -f ops/cloudflare-required.json

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Logo duplication check
         run: |
-          if [ "$(rg --files -g '*logo*.svg' apps packages public | wc -l)" -gt 25 ]; then
+          if [ "$(find apps packages public -type f -name "*logo*.svg" | wc -l)" -gt 25 ]; then
             echo "Too many logo assets found"
             exit 1
           fi

--- a/apps/gs-web/scripts/generate-search-index.js
+++ b/apps/gs-web/scripts/generate-search-index.js
@@ -33,7 +33,8 @@ async function getDocs() {
 
   await scan(DOCS_DIR);
 
-  const docs = await Promise.all(files.map(async (file) => {
+  const docs = [];
+  for (const file of files) {
     const content = await readFile(file, 'utf-8');
 
     // Extract frontmatter block (first block between ---)
@@ -45,38 +46,38 @@ async function getDocs() {
     let title = titleMatch ? (titleMatch[1] ?? titleMatch[2] ?? titleMatch[3] ?? '') : '';
     title = title.trim();
     if (!title) {
-        title = basename(file, extname(file));
+      title = basename(file, extname(file));
     }
 
     // Check for explicit slug in frontmatter
     const slugMatch = frontmatter.match(/^slug:\s*(?:"([^"]*)"|'([^']*)'|([^\n]*))/m);
     let slug = null;
     if (slugMatch) {
-       slug = slugMatch[1] ?? slugMatch[2] ?? slugMatch[3] ?? '';
-       slug = slug.trim();
-       // Normalize leading/trailing slashes
-       if (slug.startsWith('/')) slug = slug.slice(1);
-       if (slug.endsWith('/')) slug = slug.slice(0, -1);
+      slug = slugMatch[1] ?? slugMatch[2] ?? slugMatch[3] ?? '';
+      slug = slug.trim();
+      // Normalize leading/trailing slashes
+      if (slug.startsWith('/')) slug = slug.slice(1);
+      if (slug.endsWith('/')) slug = slug.slice(0, -1);
     } else {
-        // Generate slug from filepath
-        let relPath = relative(DOCS_DIR, file);
+      // Generate slug from filepath
+      let relPath = relative(DOCS_DIR, file);
 
-        // Normalize Windows paths to forward slashes
-        if (sep === '\\') {
-          relPath = relPath.split(sep).join('/');
-        }
+      // Normalize Windows paths to forward slashes
+      if (sep === '\\') {
+        relPath = relPath.split(sep).join('/');
+      }
 
-        slug = relPath.replace(/\.(md|mdx)$/, '');
+      slug = relPath.replace(/\.(md|mdx)$/, '');
 
-        if (slug === 'index') {
-          slug = '';
-        } else if (slug.endsWith('/index')) {
-          slug = slug.slice(0, -6);
-        }
+      if (slug === 'index') {
+        slug = '';
+      } else if (slug.endsWith('/index')) {
+        slug = slug.slice(0, -6);
+      }
     }
 
-    return { title, slug };
-  }));
+    docs.push({ title, slug });
+  }
 
   // Sort for deterministic output
   docs.sort((a, b) => a.slug.localeCompare(b.slug));


### PR DESCRIPTION
Merge Strategy: squash

- Replace Promise.all with for...of in search index script to bound I/O.
- Skip Cloudflare secret checks on fork PRs.
- Replace ripgrep with grep/find in workflows for better compatibility.
- Standardize indentation in generate-search-index.js.