### PR TITLE
Audit Cloudflare v4 API calls; require build token and improve error logging

### DIFF
--- a/.github/workflows/cloudflare-infra-guard.yml
+++ b/.github/workflows/cloudflare-infra-guard.yml
@@ -61,21 +61,38 @@ jobs:
       - name: Verify Cloudflare deploy token is present
         env:
           CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
       - name: Validate routes and DNS
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
         run: |
           python - <<'PY'
-          import json, os, urllib.parse, urllib.request
+          import json, os, urllib.error, urllib.parse, urllib.request
           def cf_get(url):
-              req = urllib.request.Request(url, headers={'Authorization': f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}", 'Content-Type': 'application/json'})
-              with urllib.request.urlopen(req) as resp:
-                  data = json.loads(resp.read().decode())
+              req = urllib.request.Request(url, headers={'Authorization': f"Bearer {os.environ['CLOUDFLARE_BUILD_API_TOKEN']}", 'Content-Type': 'application/json'})
+              try:
+                  with urllib.request.urlopen(req) as resp:
+                      status = resp.getcode()
+                      body = resp.read().decode()
+              except urllib.error.HTTPError as err:
+                  body = err.read().decode()
+                  raise SystemExit(f"Cloudflare API error url={url} status={err.code} body={body}")
+              except urllib.error.URLError as err:
+                  raise SystemExit(f"Cloudflare API error url={url} status=network-error body={err}")
+
+              try:
+                  data = json.loads(body)
+              except json.JSONDecodeError:
+                  raise SystemExit(f"Cloudflare API error url={url} status={status} body={body}")
+
               if not data.get('success'):
-                  raise SystemExit(f"Cloudflare API error for {url}: {data}")
+                  raise SystemExit(f"Cloudflare API error url={url} status={status} body={body}")
               return data['result']
+          if not os.environ.get('CLOUDFLARE_BUILD_API_TOKEN'):
+              raise SystemExit('Missing required env var: CLOUDFLARE_BUILD_API_TOKEN')
           cfg = json.load(open('ops/cloudflare-required.json', 'r', encoding='utf-8'))
           zone_name = urllib.parse.quote(cfg['zone_name'])
           zones = cf_get(f"https://api.cloudflare.com/client/v4/zones?name={zone_name}")

--- a/.github/workflows/setup-preview-dns.yml
+++ b/.github/workflows/setup-preview-dns.yml
@@ -18,7 +18,15 @@ jobs:
 
       - name: Run DNS setup script
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
+
+      - name: Configure preview DNS
+        env:
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: node scripts/setup-preview-dns.mjs

--- a/scripts/setup-preview-dns.mjs
+++ b/scripts/setup-preview-dns.mjs
@@ -2,19 +2,20 @@
 /**
  * One-shot script: configure preview.goldshore.ai DNS + Cloudflare Pages custom domain.
  *
- * Accepts either naming convention for env vars:
- *   CLOUDFLARE_API_TOKEN  or  CF_API_TOKEN
- *   CLOUDFLARE_ACCOUNT_ID or  CF_ACCOUNT_ID
- *   CLOUDFLARE_ZONE_ID    or  CF_ZONE_ID  (optional — auto-resolved from domain if omitted)
+ * Required env vars:
+ *   CLOUDFLARE_BUILD_API_TOKEN
+ *   CLOUDFLARE_ACCOUNT_ID
+ * Optional env vars:
+ *   CLOUDFLARE_ZONE_ID (auto-resolved from zone name if omitted)
  */
 
 const API = "https://api.cloudflare.com/client/v4";
-const TOKEN = process.env.CLOUDFLARE_API_TOKEN || process.env.CF_API_TOKEN;
-const ACCOUNT = process.env.CLOUDFLARE_ACCOUNT_ID || process.env.CF_ACCOUNT_ID;
-let ZONE = process.env.CLOUDFLARE_ZONE_ID || process.env.CF_ZONE_ID;
+const TOKEN = process.env.CLOUDFLARE_BUILD_API_TOKEN;
+const ACCOUNT = process.env.CLOUDFLARE_ACCOUNT_ID;
+let ZONE = process.env.CLOUDFLARE_ZONE_ID;
 
 if (!TOKEN || !ACCOUNT) {
-  console.error("Missing required env vars: set either CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID or CF_API_TOKEN/CF_ACCOUNT_ID. (CLOUDFLARE_ZONE_ID/CF_ZONE_ID is optional; it will be auto-resolved if omitted.)");
+  console.error("Missing required env vars: CLOUDFLARE_BUILD_API_TOKEN and CLOUDFLARE_ACCOUNT_ID. (CLOUDFLARE_ZONE_ID is optional; it will be auto-resolved if omitted.)");
   process.exit(1);
 }
 
@@ -66,7 +67,8 @@ function sanitizeErrorForLog(err) {
 }
 
 async function cf(path, init = {}) {
-  const res = await fetch(`${API}${path}`, {
+  const url = `${API}${path}`;
+  const res = await fetch(url, {
     ...init,
     headers: {
       "Authorization": `Bearer ${TOKEN}`,
@@ -74,9 +76,20 @@ async function cf(path, init = {}) {
       ...(init.headers || {}),
     },
   });
-  const json = await res.json();
-  if (!json.success) {
-    throw new Error(`CF ${path} failed: ${JSON.stringify(json.errors)}`);
+  const bodyText = await res.text();
+  let json;
+  try {
+    json = JSON.parse(bodyText);
+  } catch {
+    json = null;
+  }
+
+  if (!res.ok) {
+    throw new Error(`Cloudflare API request failed: url=${url} status=${res.status} body=${bodyText}`);
+  }
+
+  if (!json || !json.success) {
+    throw new Error(`Cloudflare API logical failure: url=${url} status=${res.status} body=${bodyText}`);
   }
   return json.result;
 }
@@ -91,7 +104,7 @@ async function resolveZoneId(domain) {
   if (zones.length > 1) {
     throw new Error(
       `Multiple Cloudflare zones found for ${domain} under account ${ACCOUNT}. ` +
-      `Refusing to choose arbitrarily. Please set CLOUDFLARE_ZONE_ID or CF_ZONE_ID explicitly.`
+      "Refusing to choose arbitrarily. Please set CLOUDFLARE_ZONE_ID explicitly."
     );
   }
   console.log(`  ✓ Zone ID: ${zones[0].id}`);


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Ensure all direct calls to the Cloudflare v4 API use the canonical build token and explicit account id to avoid accidental fallback to less-restricted tokens.  
- Improve observability and triageability by surfacing the request `url`, HTTP `status`, and response `body` on failures.  
- Add preflight secret presence checks to fail fast and avoid leaking partial or misleading error output.  

### Description
- Require `CLOUDFLARE_BUILD_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in `scripts/setup-preview-dns.mjs`, remove the previous fallback env-var behavior, and keep the API base at `https://api.cloudflare.com/client/v4`.  
- Harden `cf()` in `scripts/setup-preview-dns.mjs` to capture response text and status, parse JSON defensively, and throw errors that include `url`, `status`, and `body` for triage.  
- Update `.github/workflows/setup-preview-dns.yml` to run explicit preflight checks for `CLOUDFLARE_BUILD_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` and to pass `CLOUDFLARE_BUILD_API_TOKEN` (no fallback) into the script.  
- Harden the inline Python client in `.github/workflows/cloudflare-infra-guard.yml` to use `CLOUDFLARE_BUILD_API_TOKEN`, require `CLOUDFLARE_ACCOUNT_ID`, handle `HTTPError`/`URLError` cases, and emit `url`, `status`, and `body` on failures.  

### Testing
- Ran `node --check scripts/setup-preview-dns.mjs` and it succeeded.  
- Ran `git diff --check` and it reported no issues.  
- Verified call-site scanning with `rg -n "api\.cloudflare\.com/client/v4|CLOUDFLARE_BUILD_API_TOKEN|CLOUDFLARE_API_TOKEN|dns_records\?|workers/routes|pages/projects"` and confirmed the updated locations.  
- Attempted YAML parsing via Python with `yaml` but the environment lacked `pyyaml` resulting in `ModuleNotFoundError: No module named 'yaml'` (non-blocking for these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaee3af7c83319f09b9bb1d7b3709)