### PR TITLE
Fix gs-agent wrangler config path and fail sync on KV write errors

### DIFF
--- a/apps/gs-agent/package.json
+++ b/apps/gs-agent/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --env dev --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "deploy": "wrangler deploy src/index.ts --env prod --minify --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "deploy:preview": "wrangler deploy src/index.ts --env preview --config ../../infra/cloudflare/gs-agent.wrangler.toml",
-    "build": "wrangler deploy src/index.ts --dry-run --outdir=dist --env prod --config ../../infra/cloudflare/gs-agent.wrangler.toml"
+    "dev": "wrangler dev src/index.ts --env dev --config ../../infra/Cloudflare/gs-agent.wrangler.toml",
+    "deploy": "wrangler deploy src/index.ts --env prod --minify --config ../../infra/Cloudflare/gs-agent.wrangler.toml",
+    "deploy:preview": "wrangler deploy src/index.ts --env preview --config ../../infra/Cloudflare/gs-agent.wrangler.toml",
+    "build": "wrangler deploy src/index.ts --dry-run --outdir=dist --env prod --config ../../infra/Cloudflare/gs-agent.wrangler.toml"
   },
   "dependencies": {
     "@goldshore/auth": "workspace:*",

--- a/scripts/sync-gateway.ts
+++ b/scripts/sync-gateway.ts
@@ -38,9 +38,10 @@ function assertEnvironment(): void {
 
 async function syncConfig(config: MasterConfig): Promise<void> {
   console.log('🚀 Starting GoldShore System Sync...');
+  const failedKeys: string[] = [];
 
   for (const [key, value] of Object.entries(config)) {
-    const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workers/kv/namespaces/${NAMESPACE_ID}/values/${key}`;
+    const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${key}`;
 
     try {
       const response = await fetch(url, {
@@ -57,10 +58,16 @@ async function syncConfig(config: MasterConfig): Promise<void> {
       } else {
         const error = await response.text();
         console.error(`❌ Failed to sync ${key}: ${error}`);
+        failedKeys.push(key);
       }
     } catch (error) {
       console.error(`🚨 Network Error syncing ${key}:`, error);
+      failedKeys.push(key);
     }
+  }
+
+  if (failedKeys.length > 0) {
+    throw new Error(`KV synchronization failed for keys: ${failedKeys.join(', ')}`);
   }
 }
 


### PR DESCRIPTION
### Motivation

- Fix incorrect case-sensitive Wrangler config path so `wrangler` commands in `apps/gs-agent` work on Linux/CI and dev containers. 
- Use the correct Cloudflare KV HTTP endpoint so sync writes are accepted by the API. 
- Make the infra sync job fail when any KV write fails to avoid silent/partial synchronization.

### Description

- Updated `apps/gs-agent/package.json` script entries (`dev`, `deploy`, `deploy:preview`, `build`) to use `../../infra/Cloudflare/gs-agent.wrangler.toml` (correct casing). 
- Changed the Cloudflare endpoint in `scripts/sync-gateway.ts` to `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/values/${key}`. 
- Hardened `syncConfig` in `scripts/sync-gateway.ts` by tracking failed keys in a `failedKeys` array and throwing an error after the loop if any uploads failed so CI/automation sees sync failures.

### Testing

- Ran `node -e "JSON.parse(require('fs').readFileSync('apps/gs-agent/package.json','utf8'))"` which succeeded and confirmed valid JSON for `apps/gs-agent/package.json`. 
- Ran `pnpm exec tsc --noEmit scripts/sync-gateway.ts` which surfaced repository baseline TypeScript/environment issues unrelated to this patch (missing libs/`@types/node`/tsconfig flags), so type-check failures are environmental rather than caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb4d48be083319b544b24fbaffea1)