### PR TITLE
Add SendGrid CNAMEs and strict DMARC to Cloudflare desired state

### DIFF
--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -61,7 +61,7 @@ cloudflare:
         proxied: true
 
       # H. SendGrid domain authentication + DMARC
-      - name: "em5094.goldshore.ai"
+      - name: "em5094"
         type: CNAME
         content: "u106406774.wl025.sendgrid.net"
         proxied: false

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -73,7 +73,7 @@ cloudflare:
         type: CNAME
         content: "s2.domainkey.u106406774.wl025.sendgrid.net"
         proxied: false
-      - name: "_dmarc.goldshore.ai"
+      - name: "_dmarc"
         type: TXT
         content: "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; rua=mailto:1e5ceffc36ce4cc09f1bb2281b5344ae@dmarc-reports.cloudflare.net;"
 

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -60,6 +60,23 @@ cloudflare:
         content: "preview-web.pages.dev"
         proxied: true
 
+      # H. SendGrid domain authentication + DMARC
+      - name: "em5094.goldshore.ai"
+        type: CNAME
+        content: "u106406774.wl025.sendgrid.net"
+        proxied: false
+      - name: "s1._domainkey.goldshore.ai"
+        type: CNAME
+        content: "s1.domainkey.u106406774.wl025.sendgrid.net"
+        proxied: false
+      - name: "s2._domainkey.goldshore.ai"
+        type: CNAME
+        content: "s2.domainkey.u106406774.wl025.sendgrid.net"
+        proxied: false
+      - name: "_dmarc.goldshore.ai"
+        type: TXT
+        content: "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; rua=mailto:1e5ceffc36ce4cc09f1bb2281b5344ae@dmarc-reports.cloudflare.net;"
+
   access:
     policies:
       - name: "GoldShore-Admin-ZT"

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -65,11 +65,11 @@ cloudflare:
         type: CNAME
         content: "u106406774.wl025.sendgrid.net"
         proxied: false
-      - name: "s1._domainkey.goldshore.ai"
+      - name: "s1._domainkey"
         type: CNAME
         content: "s1.domainkey.u106406774.wl025.sendgrid.net"
         proxied: false
-      - name: "s2._domainkey.goldshore.ai"
+      - name: "s2._domainkey"
         type: CNAME
         content: "s2.domainkey.u106406774.wl025.sendgrid.net"
         proxied: false


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Add SendGrid domain authentication records so SendGrid can validate goldshore.ai for sending.
- Enforce a strict DMARC policy for goldshore.ai to improve email security and reporting.

### Description
- Updated `infra/Cloudflare/desired-state.yaml` to add CNAME records for `em5094.goldshore.ai`, `s1._domainkey.goldshore.ai`, and `s2._domainkey.goldshore.ai` pointing to the provided SendGrid targets. 
- Set those SendGrid CNAME entries to `proxied: false` so DNS resolves directly for domain authentication. 
- Added a `_dmarc.goldshore.ai` TXT record with the exact provided strict DMARC policy and Cloudflare DMARC report mailbox. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f02f3bd483319888a79ca18194d0)