### PR TITLE
Rename Cloudflare worker/pages projects for staging recycle and add CF binding/DNS docs

### DIFF
--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -1,6 +1,6 @@
 # Worker Builds token for this service must be the gs-control build token.
 # wrangler.toml for the gs-gateway worker (deployed as gs-platform on CF)
-name = "gs-gateway"
+name = "gs-platform-legacy"
 main = "src/index.ts"
 compatibility_date = "2026-04-18"
 compatibility_flags = ["nodejs_compat"]

--- a/apps/gs-web/wrangler.jsonc
+++ b/apps/gs-web/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/wrangler/config-schema.json",
-  "name": "gs-web",
+  "name": "gs-web-staging",
   "compatibility_date": "2026-03-13",
   "compatibility_flags": ["nodejs_compat"],
   "pages_build_output_dir": "./dist",

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -1,3 +1,3 @@
-name = "gs-web"
+name = "gs-web-staging"
 compatibility_date = "2026-04-18"
 pages_build_output_dir = "./dist"

--- a/docs/infrastructure/binding-matrix.md
+++ b/docs/infrastructure/binding-matrix.md
@@ -1,0 +1,32 @@
+# Cloudflare Binding and DNS Matrix
+
+## Inputs and limitations
+- DNS source file `docs/infrastructure/dns-zone-2026-04-28.txt` was not present in this repository snapshot, so DNS “actual” values below are taken from the sprint brief and marked as **unverified in repo**.
+- Cloudflare CLI inventory commands are captured in `docs/infrastructure/cf-inventory-snapshot.md`; `wrangler` was unavailable in this environment.
+
+## Route + binding matrix
+
+| subdomain/pattern | expected worker/project | actual route registered (wrangler) | binding name | binding source | env var name | secret name | CI input/output |
+|---|---|---|---|---|---|---|---|
+| `goldshore.ai/*` | `gs-platform-legacy` (formerly `gs-gateway`) | yes (`apps/gs-gateway/wrangler.toml`) | `SECURITY`, `SIGNALS`, `MAIL_QUEUE`, `DB`, `ASSETS`, `AI_CACHE`, `GS_CONFIG`, `GATEWAY_KV` | Worker config (`env.prod.*`) | `ENV`, `CLOUDFLARE_TEAM_DOMAIN` | none declared in file | Deploy workflow not resolved in this task |
+| `www.goldshore.ai/*` | `gs-platform-legacy` | yes | same as above | same | same | same | same |
+| `gw.goldshore.ai/*` | `gs-platform-legacy` | yes | same as above | same | same | same | same |
+| `agent.goldshore.ai/*` | `gs-platform-legacy` | yes | same as above | same | same | same | same |
+| `api.goldshore.ai/*` | `gs-api` | yes (`apps/gs-api/wrangler.toml`) | `KV`, `CONTROL_LOGS`, `ASSETS`, `DB`, `AI`, `TELEMETRY_DB`, `AUTH_SESSION` | Worker config (`env.prod.*`) | `ENV`, `CLOUDFLARE_ACCESS_AUDIENCE`, `CLOUDFLARE_TEAM_DOMAIN`, `CONTROL_SYNC_TOKEN` | `CONTROL_SYNC_TOKEN` placeholder in config | Deploy workflow not resolved in this task |
+| `admin.goldshore.ai/*` | `gs-admin` (Pages project) | no worker route in wrangler (Pages project only) | `KV`, `DB`, `ASSETS`, `API_SERVICE` | Pages Functions wrangler bindings | `ENV`, `CLOUDFLARE_TEAM_DOMAIN`, `CLOUDFLARE_ACCESS_AUDIENCE` | `ADMIN_API_KEY` (commented setup) | Deploy workflow not resolved in this task |
+| `mail.goldshore.ai/*` | `gs-mail` | yes (`apps/gs-mail/wrangler.toml`) | `JOBS_QUEUE`, `JOBS_QUEUE_DLQ` | Worker config (`env.prod.queues`) | none in file | none in file | Deploy workflow not resolved in this task |
+| `ops.goldshore.ai/*` | `gs-control` | yes (`apps/gs-control/wrangler.toml`) | `GS_CONFIG`, `CONTROL_LOGS` | Worker config (`env.prod.kv_namespaces`) | `ENV` | none in file | Deploy workflow not resolved in this task |
+| `signals.goldshore.ai/*` | `gs-signals` (expected) | not found in scoped wrangler files | unknown | unknown | unknown | unknown | Deploy workflow not resolved in this task |
+
+## Known DNS gaps and one-line fixes
+1. **`admin.goldshore.ai`** currently CNAMEs to apex and falls through to legacy Pages routing.  
+   **Fix:** Point `admin.goldshore.ai` CNAME directly to `gs-admin.pages.dev` (dashboard DNS change).
+2. **`api.goldshore.ai`** route is declared in `gs-api` wrangler, but deployment state is unverified.  
+   **Fix:** Trigger/re-run `gs-api` production deploy so `api.goldshore.ai/*` route is attached to latest worker.
+3. **`signals.goldshore.ai`** expected route not found in this repo’s wrangler scope; checklist incomplete.  
+   **Fix:** Add/verify `signals.goldshore.ai/*` route in the `gs-signals` wrangler config and complete first deploy checklist.
+
+## Recycle plan updates applied in this PR
+- Renamed Pages project config name `gs-web` → `gs-web-staging` in `apps/gs-web/wrangler.toml` and `apps/gs-web/wrangler.jsonc`.
+- Renamed worker config `gs-gateway` → `gs-platform-legacy` in `apps/gs-gateway/wrangler.toml` to avoid gateway-name collision during staging recycle work.
+- DNS changes are intentionally **not** applied here (manual dashboard checklist item).

--- a/docs/infrastructure/cf-inventory-snapshot.md
+++ b/docs/infrastructure/cf-inventory-snapshot.md
@@ -1,0 +1,14 @@
+# Cloudflare Inventory Snapshot
+
+Date: 2026-05-02
+Account: f77de112…
+
+## wrangler pages project list
+```
+/bin/bash: line 1: wrangler: command not found
+```
+
+## wrangler deployments list
+```
+/bin/bash: line 1: wrangler: command not found
+```


### PR DESCRIPTION
### Motivation
- Avoid worker/project name collisions during a staging recycle by renaming the gateway and web projects in their Wrangler configs. 
- Capture Cloudflare binding, route and DNS inventory knowledge in-repo to reduce drift between dashboard state and repo configuration. 
- Surface known DNS gaps and simple remediation steps to make later deploys and routing fixes reproducible.

### Description
- Renamed the worker project `name` in `apps/gs-gateway/wrangler.toml` from `gs-gateway` to `gs-platform-legacy` to differentiate the legacy gateway during staging work. 
- Renamed the Pages/worker project `name` in `apps/gs-web/wrangler.toml` and `apps/gs-web/wrangler.jsonc` from `gs-web` to `gs-web-staging`. 
- Added Cloudflare documentation files `docs/infrastructure/binding-matrix.md` and `docs/infrastructure/cf-inventory-snapshot.md` which summarize route/binding expectations, known DNS gaps, and commands/output notes. 
- Noted in the docs that the DNS source file was not present and that `wrangler` was unavailable in the execution environment, so some inventory lines are marked as unverified.

### Testing
- No automated tests were executed as part of this change in the current environment. 
- Linting/formatting checks were not run in-repo due to the limited execution environment where `wrangler` and CI were unavailable. 
- Documentation files were added and validated only by basic file existence checks in the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2798066388331a87021018ff224fb)