### PR TITLE
[Follow-up to #4813] Fix Cloudflare bindings for gateway and banproof deploys

### DIFF
--- a/apps/banproof-me/wrangler.toml
+++ b/apps/banproof-me/wrangler.toml
@@ -39,19 +39,19 @@ id = "goldshore_kv_001"
 [[env.prod.d1_databases]]
 binding = "BAN_DB"
 database_name = "gs_platform_db"
-database_id = "gs_platform_db"
+database_id = "9703574e-adb7-481e-8d98-96f8ce5f8a90"
 
 # 4. AUDIT_DB — gs_audit_db D1 (compliance audit log)
 [[env.prod.d1_databases]]
 binding = "AUDIT_DB"
 database_name = "gs_audit_db"
-database_id = "gs_audit_db"
+database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
 
 # 5. SIGNALS_DB — gs_signals_db D1 (trading signal association for ban context)
 [[env.prod.d1_databases]]
 binding = "SIGNALS_DB"
 database_name = "gs_signals_db"
-database_id = "gs_signals_db"
+database_id = "76af4653-7f44-417b-b46e-250143d906fd"
 
 # 6. ASSETS — shared R2 bucket (media / static assets)
 [[env.prod.r2_buckets]]
@@ -88,17 +88,17 @@ id = "goldshore_kv_preview"
 [[env.preview.d1_databases]]
 binding = "BAN_DB"
 database_name = "gs_platform_db"
-database_id = "gs_platform_db"
+database_id = "9703574e-adb7-481e-8d98-96f8ce5f8a90"
 
 [[env.preview.d1_databases]]
 binding = "AUDIT_DB"
 database_name = "gs_audit_db"
-database_id = "gs_audit_db"
+database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
 
 [[env.preview.d1_databases]]
 binding = "SIGNALS_DB"
 database_name = "gs_signals_db"
-database_id = "gs_signals_db"
+database_id = "76af4653-7f44-417b-b46e-250143d906fd"
 
 [[env.preview.r2_buckets]]
 binding = "ASSETS"

--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -45,7 +45,7 @@ id = "gs_config_001"
 binding = "GATEWAY_KV"
 # TODO: Replace with actual namespace ID from CF dashboard (Storage → KV).
 # Create if missing: wrangler kv namespace create GATEWAY_KV
-id = "REPLACE_WITH_GATEWAY_KV_NAMESPACE_ID"
+id = "17840f9b6ac64cb1a51aeff085efe24c"
 
 # ── D1 Databases ───────────────────────────────────────────
 [[env.prod.d1_databases]]
@@ -66,10 +66,10 @@ bucket_name = "gs-assets"
 # service = "gs-api"
 # environment = "prod"
 #
-# [[env.prod.services]]
-# binding = "AGENT"
-# service = "gs-agent"
-# environment = "prod"
+[[env.prod.services]]
+binding = "AGENT"
+service = "gs-agent"
+environment = "prod"
 
 # ── Phase 2: Joinery — security + signals spokes ──────────
 [[env.prod.services]]


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Prevent misrouting or 404s for agent-host traffic by ensuring the gateway forwards `agent.goldshore.ai/*` requests. 
- Ensure the gateway binds the correct KV namespace so production deploys do not fail with a placeholder `GATEWAY_KV` ID. 
- Ensure `banproof-me` binds the intended D1 databases during deploy by using canonical UUID `database_id` values from the infrastructure manifest.

### Description
- Re-enabled the `AGENT` service binding in `apps/gs-gateway/wrangler.toml` so the gateway router can forward agent traffic. 
- Replaced the placeholder `GATEWAY_KV` namespace ID in `apps/gs-gateway/wrangler.toml` with the canonical ID `17840f9b6ac64cb1a51aeff085efe24c`. 
- Updated `apps/banproof-me/wrangler.toml` to use canonical D1 `database_id` UUIDs for `BAN_DB`, `AUDIT_DB`, and `SIGNALS_DB` in both `prod` and `preview` per `infra/INFRASTRUCTURE.md` (`9703574e-adb7-481e-8d98-96f8ce5f8a90`, `1ae71d76-188f-481b-91d9-db2d39013f68`, `76af4653-7f44-417b-b46e-250143d906fd`).

### Testing
- Ran `rg -n "REPLACE_WITH_GATEWAY_KV_NAMESPACE_ID|binding = \"AGENT\"|database_id = \"gs_.*_db\"" apps/gs-gateway/wrangler.toml apps/banproof-me/wrangler.toml` to validate placeholder removal and presence of the `AGENT` binding, and the command completed successfully. 
- Inspected updated files with `nl -ba` to confirm `GATEWAY_KV` now contains the canonical ID and `AGENT` is present in prod, and that `banproof-me` `database_id` values are UUIDs in both `prod` and `preview`. 
- Created the follow-up PR containing these changes and committed the fixes with a commit message that includes the required merge strategy header.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006664a988331b7ef0a97a9d53f51)