### PR TITLE
[PR #4813 follow-up] Fix deploy-gateway wrangler invocation and gs-gateway prod binding regressions

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm --filter @goldshore/gs-platform build
 
       - name: Deploy to Cloudflare
-        run: wrangler deploy --config apps/gs-platform/wrangler.toml --env prod
+        run: pnpm exec wrangler deploy --config apps/gs-platform/wrangler.toml --env prod
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -66,10 +66,10 @@ bucket_name = "gs-assets"
 # service = "gs-api"
 # environment = "prod"
 #
-# [[env.prod.services]]
-# binding = "AGENT"
-# service = "gs-agent"
-# environment = "prod"
+[[env.prod.services]]
+binding = "AGENT"
+service = "gs-agent"
+environment = "prod"
 
 # ── Phase 2: Joinery — security + signals spokes ──────────
 [[env.prod.services]]
@@ -110,14 +110,3 @@ queue = "gs-platform-checkout-events-preview"
 [[env.preview.queues.producers]]
 binding = "CONTACT_EVENTS_QUEUE"
 queue = "gs-platform-contact-events-preview"
-[[env.prod.services]]
-binding = "SECURITY"
-service = "banproof-me"
-
-[[env.prod.services]]
-binding = "SIGNALS"
-service = "gs-signals-prod"
-
-[[env.prod.queues.producers]]
-binding = "MAIL_QUEUE"
-queue = "gs-mail-jobs"


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Prevent the `deploy-gateway` GitHub Actions job from failing when `wrangler` is not globally installed by aligning it with other jobs that use the workspace `pnpm` toolchain. 
- Restore routing for `agent.goldshore.ai/*` so agent-host traffic reaches the `gs-agent` worker in production. 
- Eliminate duplicate binding declarations in the gateway Wrangler config that make the config invalid and block deployments.

### Description
- Updated `.github/workflows/deploy-platform.yml` so the `deploy-gateway` job runs `pnpm exec wrangler deploy --config apps/gs-platform/wrangler.toml --env prod` instead of invoking `wrangler` directly. 
- Re-enabled the `[[env.prod.services]]` block for the `AGENT` service in `apps/gs-gateway/wrangler.toml` so `agent.goldshore.ai` resolves to `gs-agent`. 
- Removed duplicate trailing `env.prod` binding blocks from `apps/gs-gateway/wrangler.toml` that re-declared `SECURITY`/`SIGNALS` and `MAIL_QUEUE`, resolving duplicate-binding validation errors.

### Testing
- Ran `pnpm exec wrangler deploy --config apps/gs-gateway/wrangler.toml --env prod --dry-run` and it completed successfully showing resolved bindings including `AGENT`, `SECURITY_CHECK`, `SIGNALS`, and the queue bindings with no duplicate-binding errors. 
- Verified the `deploy-gateway` workflow step now uses `pnpm exec wrangler` and local validation produced no further configuration errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006591c748331b1c8029ce30d7840)