### PR TITLE
Add AGENT_HANDOFF.md and link it from deployment runbook

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,0 +1,72 @@
+# AGENT_HANDOFF
+
+> Living handoff document for cross-agent continuity on deployment and D1 integration work.
+
+## Canonical Repository
+
+- **Repo:** `goldshore-ai`
+- **Default branch:** `main`
+- **Primary working branch for this pass:** _set by active agent at runtime_
+
+## Wrangler Configuration Map
+
+### Active (authoritative)
+- `apps/gs-control/wrangler.toml`
+- `apps/gs-api/wrangler.toml` (if present and used directly)
+- `apps/gs-web/wrangler.toml` (if present and used directly)
+
+### Reference (infra-managed manifests)
+- `infra/Cloudflare/gs-api.wrangler.toml`
+- `infra/Cloudflare/` (additional worker/page manifests)
+
+### Legacy (do not update unless explicitly migrating)
+- `infra/Cloudflare/legacy/`
+
+## Completed Items
+
+- Created baseline handoff artifact with standardized sections for future agent passes.
+- Added D1 integration definition-of-done checklist.
+- Added per-pass changelog format with owner, scope, and status fields.
+- Added discoverability link from deployment runbook.
+
+## Missing Items
+
+- Confirm and document the exact **single canonical wrangler path per deployable service**.
+- Validate all D1 bindings are present in active production configs.
+- Validate all D1 migrations have been applied in remote environments.
+- Confirm `Env` typings are synchronized with runtime bindings for each worker.
+- Confirm health checks include D1 readiness signals.
+- Confirm CI/CD workflows enforce migration + typing checks.
+- Add/refresh ops docs with final D1 deployment and rollback procedure.
+
+## Do-Not-Commit Secrets
+
+Never commit any of the following values or equivalents:
+
+- Cloudflare API tokens (including build/deploy tokens)
+- `CLOUDFLARE_BUILD_API_TOKEN`
+- Account IDs, database IDs, and access audiences when treated as sensitive in your org policy
+- JWT secrets, signing keys, private keys, service credentials
+- `.env*` files with real credentials
+- Session dumps, auth headers, or copied production logs containing secrets
+
+## D1 Integration — Definition of Done (Checklist)
+
+- [ ] **Bindings:** D1 bindings are defined in canonical wrangler config(s) for each required environment.
+- [ ] **Migrations:** All required migrations are applied remotely and migration status is clean.
+- [ ] **Env typings:** Worker `Env` typings include D1 bindings and any related variables.
+- [ ] **Health checks:** Health endpoints verify D1 connectivity/readiness and fail clearly.
+- [ ] **Workflows:** CI/CD validates migrations and typing/build checks before deploy.
+- [ ] **Docs:** Runbook/handoff/docs reflect the final source of truth and recovery steps.
+
+## Agent Pass Changelog
+
+### 2026-05-22 — Pass 1
+- **Owner:** Codex (GPT-5.3-Codex)
+- **Scope:** Create `AGENT_HANDOFF.md`; add discovery link from deployment docs.
+- **Status:** Completed
+
+### YYYY-MM-DD — Pass N (Template)
+- **Owner:** _agent or engineer name_
+- **Scope:** _what was changed in this pass_
+- **Status:** _completed / partial / blocked_

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -7,6 +7,8 @@
 
 ---
 
+> Handoff: See `AGENT_HANDOFF.md` at repo root for cross-agent status, missing work, and D1 DoD checklist.
+
 ## Phase 1: Security Fixes (CRITICAL)
 
 ### Step 1.1: Deploy corrected `packages/auth/verify.ts`


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Provide a single living handoff document so agents and engineers can discover agent-pass status, missing work, and D1 integration requirements quickly.
- Surface an explicit D1 definition-of-done and per-pass changelog to improve continuity and reduce repeated discovery work across agent passes.

### Description
- Add `AGENT_HANDOFF.md` at the repository root containing canonical repo info, active/reference/legacy Wrangler config paths, completed and missing items, a do-not-commit secrets list, a D1 integration DoD checklist, and an agent-pass changelog template.
- Link the handoff file from `docs/DEPLOYMENT_RUNBOOK.md` near the top so the runbook references the new handoff for discoverability.

### Testing
- Confirmed the files were created and staged/committed with `git add AGENT_HANDOFF.md docs/DEPLOYMENT_RUNBOOK.md` and `git commit` which succeeded.
- Verified file contents and presence via `nl -ba AGENT_HANDOFF.md` and `nl -ba docs/DEPLOYMENT_RUNBOOK.md` which printed the expected additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006c09cd08331a49c8954a5933796)