### PR TITLE
fix: replace placeholder D1 IDs and add wrangler placeholder guard

### DIFF
--- a/apps/armsway-com/wrangler.toml
+++ b/apps/armsway-com/wrangler.toml
@@ -12,7 +12,7 @@ routes = [
 [[env.prod.d1_databases]]
 binding = "GS_AUDIT_DB"
 database_name = "gs_audit_db"
-database_id = "TODO_REPLACE_WITH_REAL_GS_AUDIT_DB_ID"
+database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
 
 [[env.prod.r2_buckets]]
 binding = "TELEMETRY_STORAGE"

--- a/apps/gs-core-worker/wrangler.toml
+++ b/apps/gs-core-worker/wrangler.toml
@@ -10,4 +10,4 @@ STELLAR_AIO_WEBHOOK_URL = ""
 [[env.prod.d1_databases]]
 binding = "GS_SIGNALS_DB"
 database_name = "gs_signals_db"
-database_id = "TODO_REPLACE_WITH_REAL_GS_SIGNALS_DB_ID"
+database_id = "76af4653-7f44-417b-b46e-250143d906fd"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "validate:workers": "tsx scripts/validate-worker-names.ts",
     "validate:queues": "node scripts/validate-queue-contracts.mjs",
     "validate:workspace": "tsx scripts/validate-workspace-contract.ts",
-    "validate": "pnpm check:naming && pnpm check:workspace-protocol && pnpm validate:workspace && pnpm validate:structure && pnpm validate:names",
+    "validate": "pnpm check:naming && pnpm check:workspace-protocol && pnpm check:wrangler-placeholders && pnpm validate:workspace && pnpm validate:structure && pnpm validate:names",
     "branch:bootstrap": "bash scripts/branch-bootstrap.sh",
     "scaffold:worker": "node scripts/scaffold-worker.mjs",
     "workspaces:list": "pnpm -r list --depth -1",
@@ -33,7 +33,8 @@
     "repo:health": "node scripts/repo-health.mjs",
     "audit": "pnpm run repo:health",
     "build:api": "turbo run build --filter=@goldshore/gs-api",
-    "build:control": "turbo run build --filter=@goldshore/gs-control"
+    "build:control": "turbo run build --filter=@goldshore/gs-control",
+    "check:wrangler-placeholders": "node scripts/check-wrangler-placeholders.mjs"
   },
   "devDependencies": {
     "@astrojs/mdx": "^5.0.4",

--- a/scripts/check-wrangler-placeholders.mjs
+++ b/scripts/check-wrangler-placeholders.mjs
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { globSync } from "node:fs";
+
+const TODO_PATTERN = /TODO_REPLACE_WITH_REAL_/;
+const wranglerFiles = globSync("**/wrangler.toml", {
+  exclude: ["**/node_modules/**", "**/.wrangler/**", "**/.git/**"],
+});
+
+const offenders = [];
+for (const file of wranglerFiles) {
+  const raw = readFileSync(file, "utf8");
+  if (TODO_PATTERN.test(raw)) offenders.push(file);
+}
+
+if (offenders.length > 0) {
+  console.error("Found unresolved Wrangler placeholder IDs in:");
+  for (const file of offenders) console.error(`- ${file}`);
+  process.exit(1);
+}
+
+console.log(`Wrangler placeholder check passed (${wranglerFiles.length} files scanned).`);


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Replace unresolved D1 placeholder IDs in worker configs so deployed workers bind to the canonical D1 databases instead of TODO markers. 
- Prevent future regressions by adding an automated check that fails CI when `wrangler.toml` files still contain placeholder IDs.

### Description
- Replaced `TODO_REPLACE_WITH_REAL_GS_AUDIT_DB_ID` with `1ae71d76-188f-481b-91d9-db2d39013f68` in `apps/armsway-com/wrangler.toml` for the existing `GS_AUDIT_DB` binding. 
- Replaced `TODO_REPLACE_WITH_REAL_GS_SIGNALS_DB_ID` with `76af4653-7f44-417b-b46e-250143d906fd` in `apps/gs-core-worker/wrangler.toml` for the existing `GS_SIGNALS_DB` binding. 
- Added `scripts/check-wrangler-placeholders.mjs` which scans all `wrangler.toml` files and exits non-zero if any contain the `TODO_REPLACE_WITH_REAL_` marker. 
- Updated `package.json` to add a `check:wrangler-placeholders` script and inserted it into the root `validate` script so the guard runs during validation/CI.

### Testing
- Executed `node scripts/check-wrangler-placeholders.mjs`, which scanned all `wrangler.toml` files and passed with no placeholders found. 
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006b24de48331a121e14da7a7bcc0)