### PR TITLE
[ci] enforce Cloudflare build token migration policy

### DIFF
--- a/.github/workflows/cloudflare-infra-guard.yml
+++ b/.github/workflows/cloudflare-infra-guard.yml
@@ -29,18 +29,8 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
-      - name: Enforce canonical build token usage in worker deploy workflows
-        run: |
-          worker_deploy_workflows=(
-            ".github/workflows/deploy-platform.yml"
-          )
-
-          for workflow in "${worker_deploy_workflows[@]}"; do
-            grep -qE 'CLOUDFLARE_API_TOKEN:[[:space:]]+\$\{\{[[:space:]]*secrets\.CLOUDFLARE_BUILD_API_TOKEN[[:space:]]*\}\}' "$workflow" \
-              || (echo "Workflow must set CLOUDFLARE_API_TOKEN from secrets.CLOUDFLARE_BUILD_API_TOKEN: $workflow" && exit 1)
-            ! grep -qE 'secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\|\|' "$workflow" \
-              || (echo "Fallback token source is not allowed: $workflow" && exit 1)
-          done
+      - name: Enforce canonical build token usage in workflow env blocks
+        run: scripts/check-cloudflare-token-policy.sh
 
   verify-cloudflare:
     needs:
@@ -69,7 +59,7 @@ jobs:
           python - <<'PY'
           import json, os, urllib.error, urllib.parse, urllib.request
           def cf_get(url, context):
-              req = urllib.request.Request(url, method='GET', headers={'Authorization': f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}", 'Content-Type': 'application/json'})
+              req = urllib.request.Request(url, method='GET', headers={'Authorization': f"Bearer {os.environ['CLOUDFLARE_BUILD_API_TOKEN']}", 'Content-Type': 'application/json'})
               try:
                   with urllib.request.urlopen(req) as resp:
                       data = json.loads(resp.read().decode())

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -578,13 +578,15 @@ wrangler d1 execute gs_platform_db --remote \
 
 ```bash
 # Find fallback expressions
-grep -r "CLOUDFLARE_BUILD_API_TOKEN || CLOUDFLARE_API_TOKEN" .github/workflows/
+scripts/check-cloudflare-token-policy.sh
 
 # Replace with canonical token only
 # Example: change from
 #   env:
-#     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
-# to
+# Migration behavior
+# - Do NOT use workflow fallback expressions.
+# - If compatibility is needed, mirror legacy secret values in secret management temporarily.
+# Canonical
 #   env:
 #     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
 

--- a/infra/Cloudflare/README.md
+++ b/infra/Cloudflare/README.md
@@ -50,3 +50,10 @@ Policy:
 
 - `CLOUDFLARE_BUILD_API_TOKEN` is the single canonical deploy token secret for worker CI.
 - Do not add fallback expressions (for example `secretA || secretB`) in worker deploy workflows unless a documented exception is added to Cloudflare runbooks.
+
+
+Migration behavior:
+
+- If older tooling still references `CLOUDFLARE_API_TOKEN`, migrate by updating that tooling to set runtime env `CLOUDFLARE_API_TOKEN` from `secrets.CLOUDFLARE_BUILD_API_TOKEN` in CI.
+- Do not add `||` fallbacks in workflow env blocks.
+- Temporary compatibility, if required, must be managed in secret administration (mirrored secret values), with a tracked removal task.

--- a/policy/CICD_POLICY.md
+++ b/policy/CICD_POLICY.md
@@ -42,7 +42,7 @@ steps:
     run: wrangler deploy --env prod
 ```
 
-### ❌ PROHIBITED: Fallback expressions
+### ❌ PROHIBITED: Fallback expressions (except explicit migration windows)
 
 ```yaml
 # WRONG — do not do this
@@ -60,6 +60,14 @@ env:
 ```
 
 ---
+
+
+### Migration behavior from `CLOUDFLARE_API_TOKEN`
+
+- CI/deploy and infra automation must use `secrets.CLOUDFLARE_BUILD_API_TOKEN` as the primary and only token source.
+- Backward compatibility is handled by **secret mirroring at the repository/org secret store**, not by workflow `||` expressions.
+- During migration, platform ops may keep `CLOUDFLARE_API_TOKEN` secret value synchronized to the same token out-of-band, then remove legacy secret references after verification.
+- Workflow-level fallback (`secrets.A || secrets.B`) is disallowed because it obscures which credential was used during deployment.
 
 ## Workflow Standards
 

--- a/scripts/check-cloudflare-token-policy.sh
+++ b/scripts/check-cloudflare-token-policy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflows_dir=".github/workflows"
+
+echo "Checking for disallowed fallback secret expressions in workflow env blocks..."
+if rg -n 'CLOUDFLARE_(BUILD_)?API_TOKEN:\s*\$\{\{[^}]*\|\|[^}]*\}\}' "$workflows_dir"; then
+  echo "❌ Disallowed token fallback expression found in workflow env block."
+  echo "Migration: replace fallback expressions with secrets.CLOUDFLARE_BUILD_API_TOKEN only."
+  exit 1
+fi
+
+echo "Checking canonical deploy token wiring..."
+if ! rg -n 'CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\}\}' "$workflows_dir/deploy-platform.yml" >/dev/null; then
+  echo "❌ deploy-platform.yml must set CLOUDFLARE_API_TOKEN from secrets.CLOUDFLARE_BUILD_API_TOKEN"
+  exit 1
+fi
+
+echo "✅ Cloudflare token policy checks passed."


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Replace ambiguous `CLOUDFLARE_API_TOKEN` fallback patterns with a single canonical deploy secret to preserve auditability for CI/deploy and infra automation.
- Prevent workflows from silently using legacy or unintended tokens via `secrets.A || secrets.B` expressions.
- Provide a repository-level guard and clear migration guidance so maintainers can move to `CLOUDFLARE_BUILD_API_TOKEN` safely.

### Description
- Add `scripts/check-cloudflare-token-policy.sh` which scans `.github/workflows` for disallowed `||` fallback expressions and verifies `CLOUDFLARE_API_TOKEN` is wired from `secrets.CLOUDFLARE_BUILD_API_TOKEN` in the deploy workflow. 
- Update `.github/workflows/cloudflare-infra-guard.yml` to call the new check script and to use `CLOUDFLARE_BUILD_API_TOKEN` for Cloudflare API authorization in the Python validation step. 
- Update `policy/CICD_POLICY.md`, `infra/Cloudflare/README.md`, and `docs/DEPLOYMENT_RUNBOOK.md` to document explicit migration behavior requiring secret-store mirroring (not workflow fallbacks) and to clarify that `CLOUDFLARE_BUILD_API_TOKEN` is the canonical deploy token. 
- Make the new script executable and fail CI checks if disallowed fallback patterns are present.

### Testing
- Executed `scripts/check-cloudflare-token-policy.sh` locally and it completed successfully, confirming the guard logic. 
- No other CI flows were modified for functional behavior; the updated infra guard workflow will enforce checks on CI when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006bab1f08331b6a83319d6527a2a)