### PR TITLE
fix: risk agent short handling, broker validation, cross-broker risk,…

### DIFF
--- a/apps/gs-trading/src/agents/riskAgent.ts
+++ b/apps/gs-trading/src/agents/riskAgent.ts
@@ -26,12 +26,21 @@ export function checkOrderRisk(
   const totalDayPL = accounts.reduce((s, a) => s + a.dayPL, 0);
   const isSell = order.side === 'SELL';
 
-  // For sells: only the portion that opens/enlarges a short (beyond the existing long)
-  // must satisfy position-size and concentration limits. Closing an existing long is free.
+  // Separate existing long and short quantities to handle both directions correctly.
+  // existingLong > 0: currently long; existingShort < 0: currently short.
   const existingPos = positions.find(p => p.symbol === order.symbol);
-  const existingLongQty = existingPos?.quantity ?? 0;
+  const existingQty = existingPos?.quantity ?? 0;
+  const existingLong = Math.max(0, existingQty);
+  const existingShort = Math.min(0, existingQty); // negative or 0
   const orderQty = order.quantity ?? 0;
-  const riskableQty = isSell ? Math.max(0, orderQty - existingLongQty) : orderQty;
+
+  // Riskable quantity:
+  // SELL: closing existing longs is free; only the short-opening portion is risk-checked.
+  // BUY:  covering existing shorts is free; only the portion beyond zero is risk-checked.
+  const riskableQty = isSell
+    ? Math.max(0, orderQty - existingLong)      // amount that opens/enlarges a short
+    : Math.max(0, orderQty + existingShort);    // amount that opens/enlarges a long (existingShort is <=0)
+
   const riskableFraction = orderQty > 0 ? riskableQty / orderQty : 0;
   const riskableValue = order.estimatedValue * riskableFraction;
 
@@ -53,11 +62,9 @@ export function checkOrderRisk(
   }
 
   if (riskableQty > 0) {
-    const existingValue = existingPos?.marketValue ?? 0;
-    // For buys, add to existing; for short-opening sells, treat as new negative exposure
-    const combinedValue = isSell
-      ? Math.max(0, existingValue - order.estimatedValue) + riskableValue
-      : existingValue + riskableValue;
+    // Use absolute market value to avoid sign errors with short positions
+    const existingAbsValue = Math.abs(existingPos?.marketValue ?? 0);
+    const combinedValue = existingAbsValue + riskableValue;
     const combinedPct = totalValue > 0 ? combinedValue / totalValue : 0;
     if (combinedPct > config.maxConcentrationPct) {
       violations.push(

--- a/apps/gs-trading/src/routes/trading.ts
+++ b/apps/gs-trading/src/routes/trading.ts
@@ -94,6 +94,16 @@ tradingRoutes.post('/orders', async (c) => {
   if (!['schwab', 'robinhood'].includes(broker)) return c.json({ error: 'broker must be schwab or robinhood' }, 400);
   if (quantity <= 0 || !Number.isFinite(quantity)) return c.json({ error: 'quantity must be a positive number' }, 400);
 
+  // Validate broker is actually configured
+  if (!isDemoMode(c.env)) {
+    if (broker === 'schwab' && !c.env.SCHWAB_CLIENT_ID) {
+      return c.json({ error: 'Schwab is not configured on this deployment' }, 503);
+    }
+    if (broker === 'robinhood' && !c.env.ROBINHOOD_TOKEN) {
+      return c.json({ error: 'Robinhood is not configured on this deployment' }, 503);
+    }
+  }
+
   // Schwab only supports MARKET and LIMIT order types
   const schwabOrderTypes = ['MARKET', 'LIMIT'] as const;
   if (broker === 'schwab' && !schwabOrderTypes.includes(orderType)) {
@@ -103,7 +113,7 @@ tradingRoutes.post('/orders', async (c) => {
     return c.json({ error: 'limitPrice must be a positive number for LIMIT orders' }, 400);
   }
 
-  // Fetch live account, position, and quote data for risk checks
+  // Fetch ALL configured brokers for risk check (cross-broker daily loss must be enforced)
   const accounts: any[] = [];
   const positions: any[] = [];
   let estimatedPrice = orderType === 'LIMIT' ? Number(limitPrice) : 0;
@@ -111,32 +121,50 @@ tradingRoutes.post('/orders', async (c) => {
   if (!isDemoMode(c.env)) {
     try {
       const needsQuote = orderType === 'MARKET';
-      if (broker === 'schwab' && c.env.SCHWAB_CLIENT_ID) {
-        const client = new SchwabClient(c.env);
-        const [acct, pos, quoteArr] = await Promise.all([
-          client.getAccount(),
-          client.getPositions(),
-          needsQuote ? client.getQuotes([symbol]) : Promise.resolve(null),
-        ]);
-        accounts.push(acct); positions.push(...pos);
-        if (needsQuote) {
-          const q = (quoteArr as any)?.[0];
-          estimatedPrice = q?.last ?? q?.ask ?? 0;
-          if (!estimatedPrice) return c.json({ error: `Could not determine market price for ${symbol}` }, 503);
-        }
-      } else if (broker === 'robinhood' && c.env.ROBINHOOD_TOKEN) {
-        const client = new RobinhoodClient(c.env);
-        const [acct, pos, quoteArr] = await Promise.all([
-          client.getAccount(),
-          client.getPositions(),
-          needsQuote ? client.getQuotes([symbol]) : Promise.resolve(null),
-        ]);
-        accounts.push(acct); positions.push(...pos);
-        if (needsQuote) {
-          const q = (quoteArr as any)?.[0];
-          estimatedPrice = q?.last ?? q?.ask ?? 0;
-          if (!estimatedPrice) return c.json({ error: `Could not determine market price for ${symbol}` }, 503);
-        }
+      // Always collect all brokers so risk check sees the full portfolio
+      const tasks: Promise<void>[] = [];
+
+      if (c.env.SCHWAB_CLIENT_ID) {
+        tasks.push((async () => {
+          const client = new SchwabClient(c.env);
+          const [acct, pos, quoteArr] = await Promise.all([
+            client.getAccount(),
+            client.getPositions(),
+            needsQuote && broker === 'schwab' ? client.getQuotes([symbol]) : Promise.resolve(null),
+          ]);
+          accounts.push(acct); positions.push(...pos);
+          if (needsQuote && broker === 'schwab') {
+            const q = (quoteArr as any)?.[0];
+            // Use ask for BUY, bid for SELL; check > 0 to fall through zero values
+            estimatedPrice = side === 'BUY'
+              ? (q?.ask > 0 ? q.ask : 0)
+              : (q?.bid > 0 ? q.bid : 0);
+          }
+        })());
+      }
+
+      if (c.env.ROBINHOOD_TOKEN) {
+        tasks.push((async () => {
+          const client = new RobinhoodClient(c.env);
+          const [acct, pos, quoteArr] = await Promise.all([
+            client.getAccount(),
+            client.getPositions(),
+            needsQuote && broker === 'robinhood' ? client.getQuotes([symbol]) : Promise.resolve(null),
+          ]);
+          accounts.push(acct); positions.push(...pos);
+          if (needsQuote && broker === 'robinhood') {
+            const q = (quoteArr as any)?.[0];
+            estimatedPrice = side === 'BUY'
+              ? (q?.ask > 0 ? q.ask : 0)
+              : (q?.bid > 0 ? q.bid : 0);
+          }
+        })());
+      }
+
+      await Promise.all(tasks);
+
+      if (needsQuote && !estimatedPrice) {
+        return c.json({ error: `Could not determine market price for ${symbol}` }, 503);
       }
     } catch (e: any) {
       return c.json({ error: `Failed to fetch data for risk check: ${e.message}` }, 503);
@@ -214,7 +242,7 @@ tradingRoutes.post('/risk/check', async (c) => {
   try { body = await c.req.json(); } catch { return c.json({ error: 'Invalid JSON' }, 400); }
   const { order, accounts, positions, config } = body;
   if (!order || typeof order !== 'object') return c.json({ error: 'order is required' }, 400);
-  if (typeof order.estimatedValue !== 'number') return c.json({ error: 'order.estimatedValue (number) is required' }, 400);
+  if (!Number.isFinite(order.estimatedValue)) return c.json({ error: 'order.estimatedValue must be a finite number' }, 400);
   const check = checkOrderRisk(
     order,
     accounts ?? [],


### PR DESCRIPTION
… NaN check, lockfile

- riskAgent: separate existingLong/existingShort quantities so buy-to-cover is free but short-enlarging buys are fully risk-checked; sell-to-close is free but short-opening sells are risk-checked; concentration uses abs(marketValue) to avoid sign errors with negative short positions
- trading POST /orders: validate selected broker is configured before risk check (returns 503 instead of crashing with 500)
- trading POST /orders: fetch ALL configured brokers for risk check, not just the order broker (cross-broker daily loss limit now enforced)
- trading POST /orders: use ask > 0 for BUY market orders, bid > 0 for SELL instead of last ?? ask which fails when last == 0
- trading POST /risk/check: reject NaN/Infinity estimatedValue with Number.isFinite
- pnpm-lock.yaml: add apps/gs-trading importer entry to fix ERR_PNPM_OUTDATED_LOCKFILE