### PR TITLE
fix(ci/build): repair lockfile merge corruption, root wrangler.jsonc shadowing, and broken worker sources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,12 @@
-# High-churn files auto-resolve to the branch version (`merge=ours`) to keep rebases deterministic.
-pnpm-lock.yaml merge=ours
+# High-churn docs auto-resolve to the branch version (`merge=ours`) to keep rebases deterministic.
+#
+# NOTE: pnpm-lock.yaml was intentionally REMOVED from this list. The `merge=ours`
+# driver is a custom driver that is not configured in CI / GitHub's PR-merge
+# machinery (.git/config has no [merge "ours"] driver), so the lockfile fell back
+# to a concatenation-style merge when GitHub computed refs/pull/<n>/merge. That
+# produced a two-document pnpm-lock.yaml in the merge ref, breaking every PR with
+# `ERR_PNPM_BROKEN_LOCKFILE: expected a single document in the stream, but found
+# more` — even though the committed lockfile on every branch was clean. Letting
+# git do a normal 3-way merge of the lockfile avoids that corruption.
 README.md merge=ours
 CURRENT_MONOREPO_STATE.md merge=ours

--- a/apps/armsway-com/package.json
+++ b/apps/armsway-com/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --bundle",
-    "deploy": "wrangler deploy --env prod --bundle",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle"
+    "dev": "wrangler dev src/index.ts --bundle --config wrangler.toml",
+    "deploy": "wrangler deploy --env prod --bundle --config wrangler.toml",
+    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle --config wrangler.toml"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230419.0",

--- a/apps/banproof-me/package.json
+++ b/apps/banproof-me/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --bundle",
-    "deploy": "wrangler deploy --env prod --bundle",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle"
+    "dev": "wrangler dev src/index.ts --bundle --config wrangler.toml",
+    "deploy": "wrangler deploy --env prod --bundle --config wrangler.toml",
+    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle --config wrangler.toml"
   },
   "dependencies": {
     "hono": "^4.10.2"

--- a/apps/gs-control/package.json
+++ b/apps/gs-control/package.json
@@ -10,7 +10,10 @@
   },
   "dependencies": {
     "@goldshore/auth": "workspace:*",
-    "hono": "^4.12.16"
+    "@goldshore/utils": "workspace:*",
+    "@hono/zod-validator": "^0.7.0",
+    "hono": "^4.12.16",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",

--- a/apps/gs-core-worker/package.json
+++ b/apps/gs-core-worker/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --bundle",
-    "deploy": "wrangler deploy --env prod --bundle",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle"
+    "dev": "wrangler dev src/index.ts --bundle --config wrangler.toml",
+    "deploy": "wrangler deploy --env prod --bundle --config wrangler.toml",
+    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle --config wrangler.toml"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230419.0",

--- a/apps/gs-gateway/src/index.ts
+++ b/apps/gs-gateway/src/index.ts
@@ -63,10 +63,10 @@ function isAgentHostnameRequest(request: Request): boolean {
 
 const app = new Hono<{ Bindings: GatewayEnv }>();
 
-// ── Security headers ───────────────────────────────────────
+// ── Security headers ──────────────────────────────
 app.use("*", secureHeaders());
 
-// ── Startup binding guard (production only) ────────────────
+// ── Startup binding guard (production only) ────────────
 app.use("*", async (c, next) => {
   if (c.env.ENV === "production" && !c.env.CLOUDFLARE_ACCESS_AUDIENCE) {
     console.error("CRITICAL: CLOUDFLARE_ACCESS_AUDIENCE is not set. Refusing to serve requests.");
@@ -75,7 +75,7 @@ app.use("*", async (c, next) => {
   await next();
 });
 
-// ── CORS ───────────────────────────────────────────────────
+// ── CORS ──────────────────────────────────
 app.use("*", cors({
   origin: (origin, c) => {
     if (c.env.ENV !== "production") {
@@ -94,10 +94,10 @@ app.use("*", cors({
   credentials: true,
 }));
 
-// ── Auth — fail-closed JWT verification ───────────────────
+// ── Auth — fail-closed JWT verification ───────────
 app.use("*", authMiddleware);
 
-// ── Security check (banproof-me service binding) ───────────
+// ── Security check (banproof-me service binding) ───────
 app.use("*", async (c, next) => {
   const pathname = new URL(c.req.url).pathname;
   if (pathname === "/health") return next();
@@ -127,12 +127,12 @@ app.use("*", async (c, next) => {
   return next();
 });
 
-// ── Integration controls ───────────────────────────────────
+// ── Integration controls ────────────────────────
 // Enforces X-Data-Classification, X-Secrets-Access-Policy, and X-Audit-Trace-Id
 // on /integrations/* and /market-streams/* paths.
 app.use("*", integrationControls);
 
-// ── Agent hostname routing ─────────────────────────────────
+// ── Agent hostname routing ──────────────────────
 // Requests arriving on agent.goldshore.ai are proxied to the AGENT service binding.
 app.use("*", async (c, next) => {
   if (!isAgentHostnameRequest(c.req.raw)) {
@@ -156,97 +156,7 @@ app.use("*", async (c, next) => {
   return withCorrelationId(response, correlationId);
 });
 
-// ── Routes ─────────────────────────────────────────────────
-
-app.get("/health", (c) => c.json({ status: "ok", service: "gs-gateway" }));
-
-app.get("/", (c) => c.html(STATUS_PAGE_HTML));
-
-app.get("/templates", (c) =>
-app.get('/health', (c) => c.json({ status: 'ok', service: 'gs-gateway' }));
-app.get('/templates', (c) =>
-  c.json({
-    service: "gs-gateway",
-    description: "Gateway template routes for routing, auth, and AI dispatch.",
-    modules: [
-      { name: "routing", purpose: "Proxy requests to gs-api or partner services with consistent observability." },
-      { name: "ai-dispatch", purpose: "Send AI requests to Gemini, ChatGPT, Jules, or Cloudflare AI Gateway." },
-      { name: "market-streams", purpose: "Broker market data connections for Alpaca, Thinkorswim, and other feeds." },
-    ],
-    nextSteps: [
-      "Add per-route rate limits and request shaping.",
-      "Define queue-backed workflows for bursty workloads.",
-      "Publish route maps to admin dashboards.",
-    ],
-  }),
-);
-
-app.get("/user/login", (c) => c.json({ message: "Gateway Login Placeholder" }));
-app.post("/v1/chat", (c) => c.json({ message: "Gateway Chat Placeholder" }));
-
-const inferApiOrigin = (requestUrl: string): string | undefined => {
-  const url = new URL(requestUrl);
-  const inferredHostname = url.hostname.replace(/^gs-gateway(?=\.|$)/, "gs-api");
-  if (inferredHostname === url.hostname) {
-    return undefined;
-  }
-  url.hostname = inferredHostname;
-  return url.origin;
-};
-
-// Forward /api/* to the API_SERVICE binding; fall back to API_ORIGIN if unbound.
-app.all("/api/*", async (c) => {
-  const correlationId = getCorrelationId(c.req.raw);
-  const apiOrigin = c.env.API_ORIGIN ?? inferApiOrigin(c.req.url);
-  try {
-    if (c.env.API_SERVICE) {
-      const response = await c.env.API_SERVICE.fetch(c.req.raw);
-      return withCorrelationId(response, correlationId);
-    }
-    if (apiOrigin) {
-      const url = new URL(c.req.url);
-      const targetUrl = new URL(url.pathname + url.search, apiOrigin);
-      const upstreamRequest = new Request(targetUrl, c.req.raw);
-      upstreamRequest.headers.set(TRACE_HEADER, correlationId);
-      const response = await fetch(upstreamRequest);
-      return withCorrelationId(response, correlationId);
-    }
-    console.error(`[gateway] upstream API not configured; trace=${correlationId}`);
-    return c.json(
-      { error: "Upstream API not configured", traceId: correlationId },
-      500,
-      { [TRACE_HEADER]: correlationId },
-    );
-  } catch (error) {
-    console.error(`[gateway] upstream request failed; trace=${correlationId}`, error);
-    return c.json(
-      { error: "Upstream request failed", traceId: correlationId },
-      502,
-      { [TRACE_HEADER]: correlationId },
-    );
-  }
-});
-
-// ── Integration controls ───────────────────────────────────
-// Enforces X-Data-Classification, X-Secrets-Access-Policy, and X-Audit-Trace-Id
-// on /integrations/* and /market-streams/* paths.
-app.use("*", integrationControls);
-
-// ── Agent hostname routing ─────────────────────────────────
-app.use("*", async (c, next) => {
-  if (!isAgentHostnameRequest(c.req.raw)) return next();
-  const correlationId = getCorrelationId(c.req.raw);
-  if (!c.env.AGENT) {
-    console.error(`[gateway] downstream agent not configured; trace=${correlationId}`);
-    return c.json({ error: "Downstream agent not configured", traceId: correlationId }, 503, { [TRACE_HEADER]: correlationId });
-  }
-  const downstreamRequest = new Request(c.req.raw, { headers: new Headers(c.req.raw.headers) });
-  downstreamRequest.headers.set(TRACE_HEADER, correlationId);
-  const response = await c.env.AGENT.fetch(downstreamRequest);
-  return withCorrelationId(response, correlationId);
-});
-
-// ── Routes ─────────────────────────────────────────────────
+// ── Routes ──────────────────────────────
 app.get("/health", (c) => c.json({ status: "ok", service: "gs-gateway" }));
 
 app.get("/", (c) => c.html(STATUS_PAGE_HTML));
@@ -279,6 +189,7 @@ const inferApiOrigin = (requestUrl: string): string | undefined => {
   return url.origin;
 };
 
+// Forward /api/* to the API_SERVICE binding; fall back to API_ORIGIN if unbound.
 app.all("/api/*", async (c) => {
   const correlationId = getCorrelationId(c.req.raw);
   const apiOrigin = c.env.API_ORIGIN ?? inferApiOrigin(c.req.url);

--- a/apps/gs-mail/package.json
+++ b/apps/gs-mail/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev src/index.ts --bundle",
-    "deploy": "wrangler deploy --env prod --bundle",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle"
+    "dev": "wrangler dev src/index.ts --bundle --config wrangler.toml",
+    "deploy": "wrangler deploy --env prod --bundle --config wrangler.toml",
+    "build": "wrangler deploy --env prod --dry-run --outdir=dist --bundle --config wrangler.toml"
   },
   "dependencies": {
     "hono": "^4.12.16"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,9 +216,18 @@ importers:
       '@goldshore/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@goldshore/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      '@hono/zod-validator':
+        specifier: ^0.7.0
+        version: 0.7.6(hono@4.12.24)(zod@4.4.3)
       hono:
         specifier: ^4.12.16
         version: 4.12.24
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260511.1
@@ -968,6 +977,12 @@ packages:
     peerDependencies:
       hono: '>=3.9.0'
       zod: ^3.19.1
+
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4897,6 +4912,11 @@ snapshots:
     dependencies:
       hono: 4.12.24
       zod: 3.25.76
+
+  '@hono/zod-validator@0.7.6(hono@4.12.24)(zod@4.4.3)':
+    dependencies:
+      hono: 4.12.24
+      zod: 4.4.3
 
   '@humanfs/core@0.19.2':
     dependencies:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,4 +1,0 @@
-{
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "//": "Deploy-time Cloudflare values must be provided by the deployment environment; do not define them here as Worker runtime vars."
-}


### PR DESCRIPTION
## Summary

What began as a small wrangler `--config` fix uncovered several systemic issues that were breaking CI for **every** PR in this repo. This PR fixes all of them.

### 1. `.gitattributes` — lockfile merge corruption (repo-wide blocker)
`pnpm-lock.yaml` was marked `merge=ours`, a custom merge driver not configured in CI or GitHub's PR-merge machinery. Computing `refs/pull/<n>/merge` fell back to a concatenation-style merge, producing a **two-document** lockfile in the merge ref — so every PR failed install with `ERR_PNPM_BROKEN_LOCKFILE: expected a single document in the stream, but found more`, even though the committed lockfile was always a clean single document. Removed `pnpm-lock.yaml` from the `merge=ours` list.

### 2. Removed root `wrangler.jsonc` (build blocker)
A placeholder root `wrangler.jsonc` (only `$schema` + a comment) was resolved by wrangler v4's upward config discovery for any app running a bare `wrangler deploy`, causing "Missing entry-point" failures for gs-api, gs-control, gs-gateway, gs-agent, gs-mail, gs-core-worker, armsway-com, banproof-me. Removed it so each app resolves its own `wrangler.toml`.

### 3. `gs-gateway/src/index.ts` — repaired merge-corrupted source
The routes/middleware block was duplicated and syntactically broken (`app.get("/templates", (c) =>` immediately followed by another route). De-duplicated into one coherent module.

### 4. `gs-control` — added missing dependencies
`src/routes/cloudflare.ts` imported `@hono/zod-validator`, `@goldshore/utils`, and `zod` without declaring them. Added to `package.json` and regenerated the lockfile.

### 5. `--config wrangler.toml` on 4 app build scripts
Belt-and-suspenders so those apps always load their local config.

## Expected check states
- ✅ `workspace-install`, `lint-test-build`, `repo-health`
- ⚠️ `Manual Guard: Lockfile Policy Check` (`prevent-lockfile-changes`) will be **red** — this PR intentionally adds dependencies, so the lockfile legitimately changes. Merge past this advisory guard.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z3NQEQMm5aA4Wgfh74s9m)_