### PR TITLE
fix: remove duplicate deploy-agent job breaking CI deploy workflow

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -66,23 +66,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_WORKERS_BUILDS }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-  deploy-agent:
-    name: Deploy gs-agent
-    runs-on: ubuntu-latest
-    needs: [deploy-api]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with: { node-version: 22, cache: pnpm }
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @goldshore/gs-agent build
-      - name: Deploy to Cloudflare
-        run: pnpm exec wrangler deploy --config apps/gs-agent/wrangler.toml --env prod
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_WORKERS_BUILDS }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
   deploy-control:
     name: Deploy gs-control
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`deploy-platform.yml` contained a duplicate `deploy-agent` job — the same job key appeared twice in the `jobs` map. YAML does not allow duplicate keys; most parsers silently drop one of the entries, but GitHub Actions rejects the workflow entirely, causing **all deploys to fail**.

The second `deploy-agent` block (lines 69–84) was a copy-paste error. It differed from the first only in its `needs` field (`deploy-api` instead of nothing), which would have created a circular/incorrect dependency had the YAML been accepted.

## Fix

Removed the duplicate `deploy-agent` block (lines 69–84). The first `deploy-agent` job (lines 13–27) is correct: it runs first with no dependencies, and all downstream jobs that need it already declare `needs: [deploy-agent]` or transitively depend on it.

## Verification

- `deploy-gateway` uses `--filter @goldshore/gs-gateway` and `--config apps/gs-gateway/wrangler.toml`, which is consistent with the package name `@goldshore/gs-gateway` in `apps/gs-gateway/package.json`. No change needed there.
- Deployment order is preserved: `deploy-agent` → `deploy-api` → `deploy-gateway` → `deploy-web`, with `deploy-control`, `deploy-trading`, `deploy-mail`, and `deploy-admin` all correctly depending on `deploy-api`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z3NQEQMm5aA4Wgfh74s9m)_