### PR TITLE
fix(gs-api): add prod and preview routes for api.goldshore.ai and api…

### DIFF
--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -6,7 +6,10 @@ compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
 [env.prod]
-routes = []
+routes = [
+  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
+]
 
 [env.prod.vars]
 ENV = "production"
@@ -47,7 +50,9 @@ binding = "JOBS_QUEUE"
 queue = "goldshore-jobs"
 
 [env.preview]
-routes = []
+routes = [
+  { pattern = "api-preview.goldshore.ai/*", zone_name = "goldshore.ai" }
+]
 
 [env.preview.vars]
 ENV = "preview"


### PR DESCRIPTION
….goldshore.org

Routes were empty — worker was deployed but served no custom domain. api.goldshore.ai was hitting an R2 bucket instead of this worker.

https://claude.ai/code/session_013Z3NQEQMm5aA4Wgfh74s9m