### PR TITLE
fix: unblock deploy-platform.yml workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -118,10 +118,11 @@ jobs:
   # and applied by infra/Cloudflare/deploy.ts (or manually via CF Dashboard).
   deploy-workers:
     name: Deploy ${{ matrix.app }}
+    # matrix.app cannot be used in a job-level if; filter per-target inside steps instead
     if: >
       github.event_name == 'push' ||
       inputs.target == 'all' ||
-      inputs.target == matrix.app
+      contains(fromJSON('["gs-gateway","gs-api","gs-agent","gs-control","gs-trading","gs-mail","banproof-me","gs-www-redirect","gs-core-worker","armsway-com"]'), inputs.target)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -150,19 +151,28 @@ jobs:
           - app: armsway-com
             filter: "@goldshore/armsway-com"
     steps:
+      - name: Skip if not targeted
+        if: github.event_name == 'workflow_dispatch' && inputs.target != 'all' && inputs.target != matrix.app
+        run: echo "Skipping ${{ matrix.app }} (target=${{ inputs.target }})" && exit 0
       - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
       - uses: pnpm/action-setup@v4
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
         with:
           version: 9.15.4
       - uses: actions/setup-node@v4
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
+        run: pnpm install --frozen-lockfile
       - name: Build ${{ matrix.app }}
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
         run: pnpm --filter ${{ matrix.filter }} build
       - name: Deploy ${{ matrix.app }}
-        # canonical API worker lives at apps/gs-api
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
         working-directory: apps/${{ matrix.app }}
         run: |
           ENV=${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'prod' }}


### PR DESCRIPTION
## Summary

- Fixes `deploy-platform.yml` workflow parse error: `matrix.app` cannot be used in a job-level `if` expression — GitHub evaluates that before expanding the matrix, causing `422 Invalid Argument` on every `workflow_dispatch` trigger
- Fix: job-level `if` uses `contains(fromJSON([...]), inputs.target)` to check if the target is any worker; step-level `if` conditions skip non-targeted matrix iterations
- This unblocks manual deploys of gs-gateway, gs-api, gs-agent, gs-mail, etc. via the Actions tab

## Test plan

- [ ] Trigger `workflow_dispatch` with `target=gs-gateway` — verify only gs-gateway runs
- [ ] Trigger with `target=all` — verify all workers deploy in parallel
- [ ] Trigger with `target=gs-web` — verify only Pages deploy-web job runs

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z3NQEQMm5aA4Wgfh74s9m)_