### PR TITLE
docs: align admin access allowlist

### DIFF
--- a/docs/REMEDIATION.md
+++ b/docs/REMEDIATION.md
@@ -5,7 +5,7 @@
 # PRIORITY 1 — CF ACCESS SECURITY FIX (CRITICAL)
 # ══════════════════════════════════════════════════════════════
 # PROBLEM: "Require Login" policy = non_identity + everyone = NO REAL AUTH
-# Anyone who hits admin.goldshore.ai and any other CF Access app gets in.
+# Anyone who hits admin.goldshore.ai, admin-preview.goldshore.ai, and any other CF Access app gets in.
 #
 # FIX — Zero Trust → Access → Policies → "Require Login" → Edit:
 #   Change from:
@@ -15,6 +15,7 @@
 #     Rule type: identity (not non_identity)
 #     Include: Emails ending in: @goldshore.ai
 #     Include: Specific email: marstonr6@gmail.com
+#     Apply the same identity-based allowlist to admin.goldshore.ai and admin-preview.goldshore.ai
 #     Auth method: Google GoldShore Workspace OR GitHub
 #
 # Also: Create a REUSABLE policy to replace the 8 legacy non-reusable ones:
@@ -149,7 +150,7 @@
 # goldshore.org     → goldshore-org Pages (goldshore/goldshore.github.io) — LIVE ✓
 # api.goldshore.ai  → gs-api Worker — NEEDS custom domain added
 # gw.goldshore.ai   → gs-gateway Worker — NEEDS custom domain added
-# admin.goldshore.ai → goldshore-admin Pages (CF Access) — LIVE, fix policy
+# admin.goldshore.ai and admin-preview.goldshore.ai → goldshore-admin Pages (CF Access) — LIVE, fix identity-based allow policy
 # agent.goldshore.ai → gs-agent Worker — NEEDS custom domain added
 # mail.goldshore.ai  → gs-mail Worker — LIVE ✓
 # banproof.me       → banproof-me Worker — fix build first

--- a/infra/INFRASTRUCTURE.md
+++ b/infra/INFRASTRUCTURE.md
@@ -217,7 +217,7 @@ Create one Access application per protected subdomain group. All require Gate 4 
 
 | # | Subdomain(s) | Application name | Policy | Where | Status |
 |---|---|---|---|---|---|
-| 5a | `admin.goldshore.ai`, `admin.goldshore.org` | Goldshore Admin | Email = marstonr6@gmail.com (allow) | [CF Access Apps](https://one.dash.cloudflare.com/f77de112d2019e5456a3198a8bb50bd2/access/apps) | ⬜ TODO |
+| 5a | `admin.goldshore.ai`, `admin-preview.goldshore.ai`, `admin.goldshore.org` | Goldshore Admin | Identity-based allow policy (not `non_identity` / `everyone`): Email domains `@goldshore.ai`, `@marzton.dev`; Specific email = marstonr6@gmail.com (allow) | [CF Access Apps](https://one.dash.cloudflare.com/f77de112d2019e5456a3198a8bb50bd2/access/apps) | ⬜ TODO |
 | 5b | `trading.goldshore.ai` | Goldshore Trading | Email = marstonr6@gmail.com (allow). Add **bypass policy** for `/oauth/schwab/callback` and `/oauth/robinhood/callback` (everyone) — Schwab/Robinhood redirect to these paths without an Access session. | CF Access Apps | ⬜ TODO |
 | 5c | `ops.goldshore.ai` | Goldshore Ops | Email = marstonr6@gmail.com (allow) | CF Access Apps | ⬜ TODO |
 | 5d | `gw.goldshore.ai` + `api.goldshore.ai` + `agent.goldshore.ai` | Goldshore Gateway | All three route to the same `gs-gateway` Worker — must share one Access app and one AUD tag. Email = marstonr6@gmail.com (allow). Add **bypass policy** for paths `/health`, `/status`, and `/version` (everyone). | CF Access Apps | ⬜ TODO |

--- a/policy/ROUTE_POLICY.md
+++ b/policy/ROUTE_POLICY.md
@@ -221,8 +221,8 @@ When accessed via:
 
 | Route | Zone | Audience | Policy |
 |---|---|---|---|
-| `admin.goldshore.ai` | goldshore.ai | gs-admin | Email: @goldshore.ai, @marzton.dev |
-| `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview | Same as admin |
+| `admin.goldshore.ai` | goldshore.ai | gs-admin | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |
+| `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |
 | `ops.goldshore.ai` | goldshore.ai | gs-control | Email: @goldshore.ai (ops team only) |
 
 ### Public Routes


### PR DESCRIPTION
Merge strategy: squash

### Motivation

- Ensure the Cloudflare Access allowlist for admin hostnames is identity-based (not `non_identity`/`everyone`) and consistently includes `marstonr6@gmail.com` as the intended admin identity. 
- Remove ambiguity between source-of-truth docs so the live Zero Trust policy can be configured to match repository expectations. 

### Description

- Updated `policy/ROUTE_POLICY.md` so `admin.goldshore.ai` and `admin-preview.goldshore.ai` explicitly use an identity-based allow (email domains `@goldshore.ai`, `@marzton.dev`) and include `Specific email: `marstonr6@gmail.com``. 
- Updated `infra/INFRASTRUCTURE.md` (Gate 5a) to include `admin-preview.goldshore.ai` and to document the identity-based allow policy (and call out that it must not be `non_identity`/`everyone`). 
- Updated `docs/REMEDIATION.md` to mention both admin hostnames and to require applying the same identity-based allowlist in Zero Trust. 
- Committed the documentation updates on the current branch with a commit message that includes the merge strategy. 

### Testing

- Ran `rg -n 'admin-preview\.goldshore\.ai|marstonr6@gmail\.com|non_identity|everyone|Identity-based allow' policy/ROUTE_POLICY.md docs/REMEDIATION.md infra/INFRASTRUCTURE.md` and confirmed the updated entries were present (success). 
- Ran `pnpm -s exec wrangler whoami` to attempt live verification but Wrangler reported `You are not authenticated`, so no Cloudflare Zero Trust API changes were performed from this environment (failed to verify live). 
- Performed `git commit` to record the changes and the commit completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352445d1c483319d9064b249c7761f)