### PR TITLE
Fix Cloudflare Access IdP alternatives and preserve API Access audience

### DIFF
--- a/docs/domains-and-auth.md
+++ b/docs/domains-and-auth.md
@@ -89,18 +89,18 @@ Cloudflare Access is enforced on internal tooling and protected previews. The ta
 
 ## Canonical Cloudflare Access IdP matrix
 
-This table is the single source of truth for Cloudflare Access identity-provider requirements on protected GoldShore applications. Each Access policy's **Require** rules must allow exactly the IdPs listed for that application: no additional IdPs and no missing IdPs.
+This table is the single source of truth for Cloudflare Access identity-provider requirements on protected GoldShore applications. Configure these IdPs as alternative login methods for the Access application (or as separate OR policies), not as multiple **Require** selectors; Cloudflare evaluates multiple Require selectors conjunctively.
 
-| Protected app | Access application / policy | Allowed IdPs in **Require** rules | Personal Gmail path | Notes |
+| Protected app | Access application / policy | Allowed IdPs / login methods | Personal Gmail path | Notes |
 | --- | --- | --- | --- | --- |
 | `admin.goldshore.ai` | `GoldShore-Admin-ZT` | Google Workspace; GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Production admin cockpit. |
 | `admin-preview.goldshore.ai` | `GoldShore-Admin-ZT` | Google Workspace; GitHub GoldShore Deploy; generic GitHub; email OTP | Same as production admin. | Admin preview must mirror production admin IdP requirements. |
 | `ops.goldshore.ai` | `Goldshore Ops` | Google Workspace; GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Internal control plane. |
 | `gw.goldshore.ai` | `Goldshore Gateway` | GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Gateway Access app; keep public probe bypasses separate from IdP requirements. |
-| `api.goldshore.ai` | `Goldshore Gateway` | GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Shares the gateway Access application/AUD where Access is enforced for protected paths. |
-| `agent.goldshore.ai` | `Goldshore Gateway` | GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Shares the gateway Access application/AUD with gateway/API routes. |
+| `api.goldshore.ai` | `Goldshore API` | GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Use the API Access application/AUD (`d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b`) expected by `gs-api`; keep public probe bypasses separate from IdP requirements. |
+| `agent.goldshore.ai` | `Goldshore Gateway` | GitHub GoldShore Deploy; generic GitHub; email OTP | `marstonr6@gmail.com` must be allowed through email OTP or through a GitHub identity with verified email `marstonr6@gmail.com`. | Shares the gateway Access application/AUD with gateway and agent routes; API traffic keeps the API Access AUD. |
 
-When changing Cloudflare Zero Trust, verify each Access policy's **Require** rules against this matrix. If personal Gmail access is needed without Google Workspace membership, do not rely on Workspace domain membership; keep either the email OTP path for `marstonr6@gmail.com` or the verified-email GitHub path enabled.
+When changing Cloudflare Zero Trust, verify each Access application's allowed login methods or OR policies against this matrix. Do not place alternative IdPs in the same policy's **Require** list. If personal Gmail access is needed without Google Workspace membership, do not rely on Workspace domain membership; keep either the email OTP path for `marstonr6@gmail.com` or the verified-email GitHub path enabled.
 
 ## Cloudflare Access service-token handling
 

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -89,8 +89,9 @@ cloudflare:
 
   access:
     # Canonical human-readable IdP matrix: docs/domains-and-auth.md.
-    # Keep these desired-state Require rules aligned with that table; do not
-    # introduce separate per-app IdP decisions here.
+    # Keep Access application login methods aligned with that table, but do
+    # not encode alternative IdPs as multiple Require selectors because
+    # Cloudflare evaluates Require selectors conjunctively.
     policies:
       - name: "GoldShore-Admin-ZT"
         domains:
@@ -101,11 +102,11 @@ cloudflare:
           include:
             - email_domain: "goldshore.ai"
             - email: "marstonr6@gmail.com"
-          require:
-            - identity_provider: "google_workspace"
-            - identity_provider: "github_goldshore_deploy"
-            - identity_provider: "github"
-            - identity_provider: "email_otp"
+          allowed_identity_providers:
+            - "google_workspace"
+            - "github_goldshore_deploy"
+            - "github"
+            - "email_otp"
 
       - name: "Goldshore Ops"
         domains:
@@ -115,16 +116,15 @@ cloudflare:
           include:
             - email_domain: "goldshore.ai"
             - email: "marstonr6@gmail.com"
-          require:
-            - identity_provider: "google_workspace"
-            - identity_provider: "github_goldshore_deploy"
-            - identity_provider: "github"
-            - identity_provider: "email_otp"
+          allowed_identity_providers:
+            - "google_workspace"
+            - "github_goldshore_deploy"
+            - "github"
+            - "email_otp"
 
       - name: "Goldshore Gateway"
         domains:
           - "gw.goldshore.ai"
-          - "api.goldshore.ai"
           - "agent.goldshore.ai"
         action: "allow"
         paths:
@@ -146,10 +146,39 @@ cloudflare:
           include:
             - email_domain: "goldshore.ai"
             - email: "marstonr6@gmail.com"
-          require:
-            - identity_provider: "github_goldshore_deploy"
-            - identity_provider: "github"
-            - identity_provider: "email_otp"
+          allowed_identity_providers:
+            - "github_goldshore_deploy"
+            - "github"
+            - "email_otp"
+
+      - name: "Goldshore API"
+        domains:
+          - "api.goldshore.ai"
+        action: "allow"
+        audience: "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
+        paths:
+          - "/admin/*"
+          - "/internal/*"
+          - "/system/*"
+          - "/users/*"
+          - "/user/*"
+          - "/templates/*"
+          - "/media/*"
+          - "/pages/*"
+          - "/ai/*"
+        public_paths:
+          - "/"
+          - "/health"
+          - "/status"
+          - "/version"
+        rules:
+          include:
+            - email_domain: "goldshore.ai"
+            - email: "marstonr6@gmail.com"
+          allowed_identity_providers:
+            - "github_goldshore_deploy"
+            - "github"
+            - "email_otp"
 
       - name: "GoldShore-Web-Preview"
         domain: "preview.goldshore.ai"
@@ -158,11 +187,11 @@ cloudflare:
           include:
             - email_domain: "goldshore.ai"
             - email: "marstonr6@gmail.com"
-          require:
-            - identity_provider: "google_workspace"
-            - identity_provider: "github_goldshore_deploy"
-            - identity_provider: "github"
-            - identity_provider: "email_otp"
+          allowed_identity_providers:
+            - "google_workspace"
+            - "github_goldshore_deploy"
+            - "github"
+            - "email_otp"
 
   pages:
     projects:

--- a/infra/INFRASTRUCTURE.md
+++ b/infra/INFRASTRUCTURE.md
@@ -214,15 +214,16 @@ Configure the identity providers required by the canonical Cloudflare Access IdP
 
 Create one Access application per protected subdomain group. All require Gate 4 to be complete.
 
-**Important:** `api.goldshore.ai` and `agent.goldshore.ai` both route to the same `gs-gateway` Worker, which holds a single `CLOUDFLARE_ACCESS_AUDIENCE` binding. They **must share one Access application** so the same AUD tag validates tokens from either subdomain. Public probes (`/health`, `/status`) must be excluded via a bypass policy so monitoring scripts do not hit the login wall. Set all policy **Require** rules from the canonical Cloudflare Access IdP matrix in `docs/domains-and-auth.md`.
+**Important:** Keep Access audience tags aligned with the Worker that validates them. `api.goldshore.ai` is validated by `gs-api` with its API Access AUD, so it must stay on the API Access application unless the downstream Worker secret/config changes at the same time. `gw.goldshore.ai` and `agent.goldshore.ai` share the gateway Access application/AUD. Public probes (`/health`, `/status`) must be excluded via a bypass policy so monitoring scripts do not hit the login wall. Configure allowed login methods or OR policies from the canonical Cloudflare Access IdP matrix in `docs/domains-and-auth.md`; do not encode alternative IdPs as multiple conjunctive Require selectors.
 
 | # | Subdomain(s) | Application name | Policy | Where | Status |
 |---|---|---|---|---|---|
 | 5a | `admin.goldshore.ai`, `admin-preview.goldshore.ai`, `admin.goldshore.org` | Goldshore Admin | Identity-based allow policy (not `non_identity` / `everyone`): Email domains `@goldshore.ai`, `@marzton.dev`; Specific email = marstonr6@gmail.com (allow) | [CF Access Apps](https://one.dash.cloudflare.com/f77de112d2019e5456a3198a8bb50bd2/access/apps) | ⬜ TODO |
 | 5b | `trading.goldshore.ai` | Goldshore Trading | Email = marstonr6@gmail.com (allow). Add **bypass policy** for `/oauth/schwab/callback` and `/oauth/robinhood/callback` (everyone) — Schwab/Robinhood redirect to these paths without an Access session. | CF Access Apps | ⬜ TODO |
 | 5c | `ops.goldshore.ai` | Goldshore Ops | Email = marstonr6@gmail.com (allow) | CF Access Apps | ⬜ TODO |
-| 5d | `gw.goldshore.ai` + `api.goldshore.ai` + `agent.goldshore.ai` | Goldshore Gateway | All three route to the same `gs-gateway` Worker — must share one Access app and one AUD tag. Email = marstonr6@gmail.com (allow). Add **bypass policy** for paths `/health`, `/status`, and `/version` (everyone). | CF Access Apps | ⬜ TODO |
-| 5e | Copy the **Audience (AUD) tag** for each app and store it as a GitHub Actions secret (`CLOUDFLARE_ACCESS_AUDIENCE_ADMIN`, `CLOUDFLARE_ACCESS_AUDIENCE_TRADING`, `CLOUDFLARE_ACCESS_AUDIENCE_GATEWAY`) and as wrangler secrets in each Worker. | CF Access App → Overview tab | ⬜ TODO |
+| 5d | `gw.goldshore.ai` + `agent.goldshore.ai` | Goldshore Gateway | These hosts share the gateway Access app and gateway AUD tag. Email = marstonr6@gmail.com (allow). Add **bypass policy** for paths `/health`, `/status`, and `/version` (everyone). | CF Access Apps | ⬜ TODO |
+| 5e | `api.goldshore.ai` | Goldshore API | Preserve the API Access app and AUD tag expected by `gs-api` (`d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b`). Email = marstonr6@gmail.com (allow). Add **bypass policy** for paths `/`, `/health`, `/status`, and `/version` (everyone). | CF Access Apps | ⬜ TODO |
+| 5f | Copy the **Audience (AUD) tag** for each app and store it as GitHub Actions secrets (`CLOUDFLARE_ACCESS_AUDIENCE_ADMIN`, `CLOUDFLARE_ACCESS_AUDIENCE_TRADING`, `CLOUDFLARE_ACCESS_AUDIENCE_GATEWAY`, `CLOUDFLARE_ACCESS_AUDIENCE_API`) and as wrangler secrets in each Worker. | CF Access App → Overview tab | ⬜ TODO |
 
 ---
 


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Avoid modeling alternative Cloudflare Access identity providers as conjunctive `Require` selectors because Cloudflare evaluates `Require` rules conjunctively, which would lock out interactive users. 
- Ensure `api.goldshore.ai` continues to present the API audience expected by the `gs-api` Worker so downstream audience validation does not reject protected API requests. 

### Description
- Replace conjunctive `require: identity_provider:` selectors with an explicit `allowed_identity_providers` list in `infra/Cloudflare/desired-state.yaml` so listed IdPs are treated as alternative login methods. 
- Remove `api.goldshore.ai` from the shared Gateway Access entry and add a dedicated `Goldshore API` Access policy with the preserved audience tag `d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b` in `infra/Cloudflare/desired-state.yaml`. 
- Clarify the canonical IdP matrix in `docs/domains-and-auth.md` to instruct operators to configure IdPs as alternative login methods or OR policies (not multiple `Require` selectors). 
- Update `infra/INFRASTRUCTURE.md` to document the separation of Gateway and API Access audiences and to instruct keeping Access audience tags aligned with the Worker that validates them. 

### Testing
- Ran `git diff --check` to validate diffs and whitespace, which completed successfully. 
- Parsed `infra/Cloudflare/desired-state.yaml` with `ruby -e 'require "yaml"; YAML.load_file("infra/Cloudflare/desired-state.yaml")'`, which succeeded with no YAML errors. 
- Executed a Node guard script that verified non-empty docs, absence of `identity_provider:` Require selectors, and presence of the `Goldshore API` policy plus its audience, which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356bc8260c833183af7581131e0e82)