### PR TITLE
Align api.goldshore.ai route ownership (#5219)

### DIFF
--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -7,6 +7,7 @@ workers_dev = false
 
 [env.prod]
 routes = [
+  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" }
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 

--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -28,7 +28,6 @@ queue = "gs-platform-contact-events-dev"
 routes = [
   { pattern = "gw.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "dashboard.goldshore.ai", custom_domain = true }
 ]
 

--- a/docs/DNS_AND_ROUTES.md
+++ b/docs/DNS_AND_ROUTES.md
@@ -22,11 +22,11 @@
 # Worker route (in Cloudflare Dashboard → Workers → goldshore-gateway → Triggers):
 #   Pattern: gw.goldshore.ai/*   Zone: goldshore.ai
 
-## api.goldshore.ai → goldshore-api worker
+## api.goldshore.ai → gs-api worker (direct ownership)
 # Type: CNAME, Proxied: YES
-# Name: api  →  goldshore-api.<account>.workers.dev
-# Worker route: api.goldshore.ai/*  (check routes in dashboard — currently 404)
-# FIX: Ensure wrangler.jsonc has routes = [{pattern:"api.goldshore.ai/*", zone_name:"goldshore.ai"}]
+# Name: api  →  gs-api.<account>.workers.dev
+# Worker route: api.goldshore.ai/*
+# Source of truth: apps/gs-api/wrangler.toml [env.prod]. Do not also attach this route to gs-gateway.
 
 ## admin.goldshore.ai → goldshore-admin worker (CF Access protected — WORKING CORRECTLY)
 # Type: CNAME, Proxied: YES
@@ -104,7 +104,7 @@
 # goldshore-gateway routes:
 #   gw.goldshore.ai/*  (zone: goldshore.ai)
 
-# goldshore-api routes:
+# gs-api routes:
 #   api.goldshore.ai/*  (zone: goldshore.ai)
 
 # goldshore-agent routes:
@@ -154,8 +154,8 @@
 
 # 1. Add DNS CNAME: gw.goldshore.ai → goldshore-gateway worker
 # 2. Add DNS CNAME: agent.goldshore.ai → goldshore-agent worker
-# 3. Fix api.goldshore.ai worker route (currently 404)
-#    → wrangler deploy --name goldshore-api (with routes in wrangler.jsonc)
+# 3. Deploy gs-api with the direct api.goldshore.ai worker route
+#    → wrangler deploy --env prod from apps/gs-api (routes in wrangler.toml)
 # 4. Deploy rmarston-com with fixed wrangler.toml (routes now attached)
 # 5. Deploy armsway with new medical theme
 # 6. Verify CF Access on admin.goldshore.ai allows your email

--- a/infra/INFRASTRUCTURE.md
+++ b/infra/INFRASTRUCTURE.md
@@ -96,7 +96,7 @@
 | `www.goldshore.ai` | `gs-www-redirect` | 1 (public) | 308 → goldshore.ai |
 | `dashboard.goldshore.ai` | `gs-gateway` | 1 (public) | 308 → admin.goldshore.ai |
 | `gw.goldshore.ai` | `gs-gateway` | 2 (auth) | Fail closed |
-| `api.goldshore.ai` | `gs-gateway` → `gs-api` | 2 (auth) | Fail closed; /health /version /status public |
+| `api.goldshore.ai` | `gs-api` | 2 (auth) | Direct API route; fail closed; /health /version /status public |
 | `agent.goldshore.ai` | `gs-gateway` → `gs-agent` | 2 (auth) | Fail closed |
 | `trading.goldshore.ai` | `gs-trading` | 3 (admin) | Fail closed |
 | `ops.goldshore.ai` | `gs-control` | 3 (admin) | Fail closed |
@@ -214,6 +214,7 @@ Configure the identity providers required by the canonical Cloudflare Access IdP
 
 Create one Access application per protected subdomain group. All require Gate 4 to be complete.
 
+**Important:** `api.goldshore.ai` is owned directly by the `gs-api` Worker route, while `agent.goldshore.ai` routes through the `gs-gateway` Worker. Configure Cloudflare Access audiences per owning Worker, and exclude public probes (`/health`, `/status`) via bypass policy so monitoring scripts do not hit the login wall.
 **Important:** `api.goldshore.ai` and `agent.goldshore.ai` both route to the same `gs-gateway` Worker, which holds a single `CLOUDFLARE_ACCESS_AUDIENCE` binding. They **must share one Access application** so the same AUD tag validates tokens from either subdomain. Public probes (`/health`, `/status`) must be excluded via a bypass policy so monitoring scripts do not hit the login wall. Set all policy **Require** rules from the canonical Cloudflare Access IdP matrix in `docs/domains-and-auth.md`.
 
 | # | Subdomain(s) | Application name | Policy | Where | Status |
@@ -221,7 +222,7 @@ Create one Access application per protected subdomain group. All require Gate 4 
 | 5a | `admin.goldshore.ai`, `admin-preview.goldshore.ai`, `admin.goldshore.org` | Goldshore Admin | Identity-based allow policy (not `non_identity` / `everyone`): Email domains `@goldshore.ai`, `@marzton.dev`; Specific email = marstonr6@gmail.com (allow) | [CF Access Apps](https://one.dash.cloudflare.com/f77de112d2019e5456a3198a8bb50bd2/access/apps) | ⬜ TODO |
 | 5b | `trading.goldshore.ai` | Goldshore Trading | Email = marstonr6@gmail.com (allow). Add **bypass policy** for `/oauth/schwab/callback` and `/oauth/robinhood/callback` (everyone) — Schwab/Robinhood redirect to these paths without an Access session. | CF Access Apps | ⬜ TODO |
 | 5c | `ops.goldshore.ai` | Goldshore Ops | Email = marstonr6@gmail.com (allow) | CF Access Apps | ⬜ TODO |
-| 5d | `gw.goldshore.ai` + `api.goldshore.ai` + `agent.goldshore.ai` | Goldshore Gateway | All three route to the same `gs-gateway` Worker — must share one Access app and one AUD tag. Email = marstonr6@gmail.com (allow). Add **bypass policy** for paths `/health`, `/status`, and `/version` (everyone). | CF Access Apps | ⬜ TODO |
+| 5d | `gw.goldshore.ai` + `agent.goldshore.ai`; `api.goldshore.ai` separately | Goldshore Gateway / Goldshore API | `gw` and `agent` route to `gs-gateway`; `api` routes directly to `gs-api`. Use separate Access audiences if protected. Email = marstonr6@gmail.com (allow). Add **bypass policy** for paths `/health`, `/status`, and `/version` (everyone). | CF Access Apps | ⬜ TODO |
 | 5e | Copy the **Audience (AUD) tag** for each app and store it as a GitHub Actions secret (`CLOUDFLARE_ACCESS_AUDIENCE_ADMIN`, `CLOUDFLARE_ACCESS_AUDIENCE_TRADING`, `CLOUDFLARE_ACCESS_AUDIENCE_GATEWAY`) and as wrangler secrets in each Worker. | CF Access App → Overview tab | ⬜ TODO |
 
 ---

--- a/policy/ROUTE_POLICY.md
+++ b/policy/ROUTE_POLICY.md
@@ -47,6 +47,7 @@ admin-preview.goldshore.ai
 ```
 api.goldshore.ai/*
 ├── gs-api worker
+├── Direct route owner; not proxied through gs-gateway
 ├── Public endpoint
 └── Methods: GET, POST, PUT, DELETE (documented)
 
@@ -144,9 +145,9 @@ This script runs in CI before deploy — if it fails, the deployment blocks.
 
 ## Gateway Forwarding Rules
 
-### gs-platform (Gateway Worker)
+### gs-platform / gs-gateway (Gateway Worker)
 
-The gateway routes inbound requests to downstream services:
+The gateway owns `gw.goldshore.ai/*` and `agent.goldshore.ai/*`. It does **not** own `api.goldshore.ai/*`; direct API traffic is served by `gs-api`. For gateway-hosted requests, it routes inbound requests to downstream services:
 
 ```
 Request: POST /query?agent=true


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Ensure a single authoritative owner for `api.goldshore.ai/*` to prevent overlapping worker routes and clarify Access configuration.
- Move the production API route off the gateway so `gs-api` can be the direct runtime for API traffic.
- Keep policy/docs/infra in sync with the actual Wrangler manifests to make the canonical routing manifest authoritative.

### Description
- Add the production route `{ pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" }` to `apps/gs-api/wrangler.toml` under `[env.prod]` so `gs-api` owns the API subdomain.
- Remove the `api.goldshore.ai/*` entry from `apps/gs-gateway/wrangler.toml` so the gateway no longer claims the API route.
- Update `policy/ROUTE_POLICY.md` to state that `api.goldshore.ai/*` is a direct route owned by `gs-api` and adjust gateway wording to own only `gw`/`agent`.
- Update `docs/DNS_AND_ROUTES.md` and `infra/INFRASTRUCTURE.md` to reflect `gs-api` direct ownership and revised Cloudflare Access guidance for separate audiences.

### Testing
- Ran `node scripts/check-route-collisions.mjs` locally and it succeeded with "No route collisions detected."

------
[Codex
Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3524597c3c8331ad4af2a569d81e94)