### PR TITLE
fix(gs-web): resolve duplicate jsonResponse, missing RiskRadar import, and proofPoints

### DIFF
--- a/apps/gs-web/src/pages/api/contact.ts
+++ b/apps/gs-web/src/pages/api/contact.ts
@@ -65,27 +65,44 @@ type FormConfig = {
   updatedAt: string;
 };
 
-type ApiResponseBody = {
-  success: boolean;
-  code: string;
-  message: string;
-  submissionId?: string;
-  redirectTo?: string;
+type ApiSuccessPayload = {
+  ok: true;
+  submissionId: string;
+  redirectTo: string;
+  mail: {
+    notification: 'sent' | 'failed' | 'skipped';
+    autoResponder: 'sent' | 'failed' | 'skipped';
+  };
 };
 
-const jsonResponse = (status: number, body: ApiResponseBody) =>
-  new Response(JSON.stringify(body), {
+type ApiErrorPayload = {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  };
+};
+
+const jsonResponse = (payload: ApiSuccessPayload | ApiErrorPayload, status = 200) =>
+  new Response(JSON.stringify(payload), {
     status,
     headers: {
       'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
     },
   });
 
-const requestExpectsJson = (request: Request) => {
-  const accept = request.headers.get('accept') ?? '';
-  const requestedWith = request.headers.get('x-requested-with') ?? '';
-  return accept.includes('application/json') || requestedWith === 'XMLHttpRequest';
-};
+const buildError = (
+  status: number,
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+) => jsonResponse({ ok: false, error: { code, message, details } }, status);
+
+const shouldReturnJson = (request: Request) =>
+  request.headers.get('x-gs-request-mode') === 'spa' ||
+  request.headers.get('accept')?.includes('application/json');
 
 const storeInKv = async (
   kv: KVNamespace,
@@ -333,45 +350,6 @@ const safeRedirect = (redirectTo: string | null, origin: string) => {
   return new URL(trimmed, origin);
 };
 
-type ApiSuccessPayload = {
-  ok: true;
-  submissionId: string;
-  redirectTo: string;
-  mail: {
-    notification: 'sent' | 'failed' | 'skipped';
-    autoResponder: 'sent' | 'failed' | 'skipped';
-  };
-};
-
-type ApiErrorPayload = {
-  ok: false;
-  error: {
-    code: string;
-    message: string;
-    details?: Record<string, unknown>;
-  };
-};
-
-const jsonResponse = (payload: ApiSuccessPayload | ApiErrorPayload, status = 200) =>
-  new Response(JSON.stringify(payload), {
-    status,
-    headers: {
-      'content-type': 'application/json; charset=utf-8',
-      'cache-control': 'no-store',
-    },
-  });
-
-const buildError = (
-  status: number,
-  code: string,
-  message: string,
-  details?: Record<string, unknown>,
-) => jsonResponse({ ok: false, error: { code, message, details } }, status);
-
-const shouldReturnJson = (request: Request) =>
-  request.headers.get('x-gs-request-mode') === 'spa' ||
-  request.headers.get('accept')?.includes('application/json');
-
 const parseNotificationRecipients = (
   configRecipients: FormRecipient[],
   fallbackRecipients: string | undefined,
@@ -482,7 +460,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
     dedupeKey: extractString(formData.get('dedupeKey')),
   };
 
-  const env = locals.runtime?.env as Env | undefined;
+  const normalizedSubmission = normalizeContactSubmission(submission);
 
   if (isSpam) {
     console.info('contact_submission_spam_blocked', {
@@ -548,11 +526,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
         fields: missingFields.map((field) => field.name)
       });
     }
-    console.info('contact_submission_validation_failed', {
-      submissionId: submission.id,
-      formType,
-      missingFields: missingFields.map((field) => field.name),
-    });
     return buildError(400, 'missing_required_fields', 'Missing required fields.', {
       fields: missingFields.map((field) => field.name),
     });
@@ -592,7 +565,6 @@ export const POST: APIRoute = async ({ request, locals }) => {
   );
 
   if (!storedSuccessfully) {
-    console.error('Contact submission storage failed.', storageResults);
     console.error('contact_submission_persistence_failed', {
       submissionId: submission.id,
       formType,
@@ -693,9 +665,4 @@ export const POST: APIRoute = async ({ request, locals }) => {
   return Response.redirect(redirectUrl, 303);
 };
 
-export const GET: APIRoute = async () =>
-  jsonResponse(405, {
-    success: false,
-    code: 'METHOD_NOT_ALLOWED',
-    message: 'Method not allowed.',
-  });
+export const GET: APIRoute = async () => buildError(405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Logo from '../components/brand/Logo.astro';
 import ParallaxHero from '../components/hero/ParallaxHero.astro';
+import RiskRadar from '../components/RiskRadar.astro';
 import WebLayout from '../layouts/WebLayout.astro';
 
 export const prerender = true;
@@ -49,6 +50,21 @@ const capabilities = [
   {
     title: 'Proven controls',
     body: 'Controls are demonstrated in live use with logs, thresholds, review modes, and fallback paths.',
+  },
+];
+
+const proofPoints = [
+  {
+    title: 'Human-in-the-loop by default',
+    body: 'Every high-stakes model decision routes through a configured review step before action is taken.',
+  },
+  {
+    title: 'Full observability stack',
+    body: 'Events, thresholds, and evidence logs are captured at runtime and retained for regulatory review.',
+  },
+  {
+    title: 'Controlled deployment posture',
+    body: 'Staged rollouts, feature flags, and rollback paths are wired into the deployment pipeline from day one.',
   },
 ];
 ---


### PR DESCRIPTION
## Summary

- **contact.ts**: Remove duplicate `jsonResponse` declaration (old-style at top conflicted with new-style below), remove unused `requestExpectsJson` helper, remove duplicate `const env` in POST handler, add missing `normalizedSubmission = normalizeContactSubmission(submission)` before first use, fix `GET` handler to use `buildError` instead of the removed old signature
- **index.astro**: Add missing `import RiskRadar from '../components/RiskRadar.astro'` and define `proofPoints` array — both were referenced in the template but not declared, causing `astro check` / build failures

## Test plan

- [ ] `pnpm --filter @goldshore/gs-web build` succeeds without duplicate-symbol errors
- [ ] `astro check` passes on `index.astro` (no missing symbol errors for `RiskRadar` or `proofPoints`)
- [ ] Contact form POST still stores submission and sends mail in staging
- [ ] `GET /api/contact` returns 405 JSON response

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z3NQEQMm5aA4Wgfh74s9m)_