### PR TITLE
Harden Cloudflare deploy token boundaries

### DIFF
--- a/.github/workflows/cf-discover.yml
+++ b/.github/workflows/cf-discover.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
 
 jobs:
   discover:
@@ -18,7 +18,7 @@ jobs:
       - name: Verify credentials
         run: |
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing: CLOUDFLARE_ACCOUNT_ID" && exit 1)
-          test -n "$CLOUDFLARE_API_TOKEN"   || (echo "Missing: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_API_TOKEN"   || (echo "Missing: CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN" && exit 1)
 
       - name: Discover CF Access Applications (AUDs)
         run: |

--- a/.github/workflows/cf-pages-setup.yml
+++ b/.github/workflows/cf-pages-setup.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
 
 jobs:
   setup:
@@ -29,7 +29,7 @@ jobs:
       - name: Verify credentials
         run: |
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing: CLOUDFLARE_ACCOUNT_ID" && exit 1)
-          test -n "$CLOUDFLARE_API_TOKEN"   || (echo "Missing: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          test -n "$CLOUDFLARE_API_TOKEN"   || (echo "Missing: CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN" && exit 1)
 
       - name: Run CF setup (dry-run)
         if: inputs.dry_run == true

--- a/.github/workflows/cf-worker-ops.yml
+++ b/.github/workflows/cf-worker-ops.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/deploy-dispatch.yml
+++ b/.github/workflows/deploy-dispatch.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
 
 jobs:
   deploy:
@@ -37,7 +37,7 @@ jobs:
           test -n "${{ github.event.client_payload.install_command }}"   || (echo 'Missing payload: install_command' && exit 1)
           test -n "${{ github.event.client_payload.wrangler_command }}"  || (echo 'Missing payload: wrangler_command' && exit 1)
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo 'Missing secret: CLOUDFLARE_ACCOUNT_ID' && exit 1)
-          test -n "$CLOUDFLARE_API_TOKEN"  || (echo 'Missing secret: CLOUDFLARE_BUILD_API_TOKEN' && exit 1)
+          test -n "$CLOUDFLARE_API_TOKEN"  || (echo 'Missing secret: CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN' && exit 1)
 
       - name: Checkout ${{ github.event.client_payload.repo }}
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -50,7 +50,7 @@ concurrency:
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN || secrets.CF_WORKERS_BUILDS }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
 
 # ── Shared setup ──────────────────────────────────────────────────────────────
 # Each job repeats the three setup steps (checkout / pnpm / node) because

--- a/.github/workflows/infrastructure-guard.yml
+++ b/.github/workflows/infrastructure-guard.yml
@@ -154,20 +154,20 @@ jobs:
       - name: Verify Cloudflare credentials
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
         run: |
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing: CLOUDFLARE_ACCOUNT_ID" && exit 1)
-          test -n "$CF_WORKERS_BUILDS" || (echo "Missing: CF_WORKERS_BUILDS" && exit 1)
+          test -n "$CLOUDFLARE_API_TOKEN" || (echo "Missing: CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN" && exit 1)
 
       - name: Audit live Cloudflare state against manifest
         env:
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           python3 - <<'PY'
           import json, os, urllib.request, urllib.error
 
-          TOKEN = os.environ["CF_WORKERS_BUILDS"]
+          TOKEN = os.environ["CLOUDFLARE_API_TOKEN"]
           ACCOUNT = os.environ["CLOUDFLARE_ACCOUNT_ID"]
 
           def cf_get(path):

--- a/.github/workflows/preview-gs-api.yml
+++ b/.github/workflows/preview-gs-api.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Deploy GS API worker preview to Cloudflare
         working-directory: apps/gs-api
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm exec wrangler deploy --env preview --config wrangler.toml

--- a/.github/workflows/setup-preview-dns.yml
+++ b/.github/workflows/setup-preview-dns.yml
@@ -18,15 +18,15 @@ jobs:
 
       - name: Run DNS setup script
         env:
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          test -n "$CF_WORKERS_BUILDS" || (echo "Missing required secret: CF_WORKERS_BUILDS" && exit 1)
+          test -n "$CLOUDFLARE_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN" && exit 1)
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
 
       - name: Configure preview DNS
         env:
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: node scripts/setup-preview-dns.mjs

--- a/infra/Cloudflare/README.md
+++ b/infra/Cloudflare/README.md
@@ -49,15 +49,21 @@ Cloudflare worker deploy workflows and infra guard checks use the following cano
 | Secret name | Required for | Ownership |
 |---|---|---|
 | `CLOUDFLARE_ACCOUNT_ID` | All worker deploy jobs and Cloudflare infra guard checks | Cloudflare account owner / platform ops |
-| `CLOUDFLARE_BUILD_API_TOKEN` | All worker deploy jobs and Cloudflare infra guard API calls | `gs-control` service token owner / platform ops |
+| `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` | Deploy jobs for Cloudflare resources owned by `marzton/goldshore-ai` | `goldshore-ai` service owner / platform ops |
 
 Policy:
 
-- `CLOUDFLARE_BUILD_API_TOKEN` is the single canonical deploy token secret for worker CI.
+- `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` is the canonical deploy token secret for this repository; it must be scoped only to the Workers, Pages projects, Queues, Workflows, and zones deployed from `marzton/goldshore-ai`.
 - Do not add fallback expressions such as `secretA || secretB` in worker deploy workflows unless a documented exception is added to Cloudflare runbooks.
 
 Migration behavior:
 
-- If older tooling still references `CLOUDFLARE_API_TOKEN`, migrate by updating that tooling to set runtime env `CLOUDFLARE_API_TOKEN` from `secrets.CLOUDFLARE_BUILD_API_TOKEN` in CI.
+- If older tooling still references `CLOUDFLARE_API_TOKEN`, migrate by updating that tooling to set runtime env `CLOUDFLARE_API_TOKEN` from `secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` in CI.
 - Do not add `||` fallbacks in workflow env blocks.
 - Temporary compatibility, if required, must be managed in secret administration with mirrored secret values and a tracked removal task.
+
+Repository token boundary:
+
+- Keep the mother/build repository token (`CLOUDFLARE_GOLDSHORE_BUILD_TOKEN` for `marzton/goldshore`) out of this repository.
+- Remove broad or legacy app-repo secrets such as `CLOUDFLARE_BUILD_API_TOKEN`, `CLOUDFLARE_API_TOKEN`, and `CF_WORKERS_BUILDS` after the repository-specific deploy token is installed.
+- Do not grant this repository token account-wide edit access; grant only the zones, Workers, Pages projects, Queues, and Workflows documented above.

--- a/policy/CICD_POLICY.md
+++ b/policy/CICD_POLICY.md
@@ -13,7 +13,7 @@
 
 | Secret | Purpose | Scope | Owner | Rotation |
 |---|---|---|---|---|
-| `CLOUDFLARE_BUILD_API_TOKEN` | Deploy all workers + infra operations | All gs-* workers, Pages, API calls | gs-control service owner | 90 days |
+| `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` | Deploy this repository's Cloudflare resources | `goldshore-ai` Workers, Pages, Queues, and Workflows only | goldshore-ai service owner / platform ops | 90 days |
 
 ### Secondary Secrets (Per-Service)
 
@@ -34,7 +34,7 @@
 ```yaml
 # .github/workflows/deploy-gs-api.yml
 env:
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
 steps:
@@ -64,10 +64,51 @@ env:
 
 ### Migration behavior from `CLOUDFLARE_API_TOKEN`
 
-- CI/deploy and infra automation must use `secrets.CLOUDFLARE_BUILD_API_TOKEN` as the primary and only token source.
+- CI/deploy and infra automation in this repository must use `secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` as the primary and only token source.
 - Backward compatibility is handled by **secret mirroring at the repository/org secret store**, not by workflow `||` expressions.
 - During migration, platform ops may keep `CLOUDFLARE_API_TOKEN` secret value synchronized to the same token out-of-band, then remove legacy secret references after verification.
 - Workflow-level fallback (`secrets.A || secrets.B`) is disallowed because it obscures which credential was used during deployment.
+
+
+## Cloudflare Token Compartmentalization
+
+### Incident response for exposed tokens
+
+1. Revoke the exposed Cloudflare API token immediately in the Cloudflare dashboard.
+2. Search GitHub organization, repository, environment, and Dependabot secrets for aliases of the exposed value.
+3. Remove any mirrored or fallback secrets that can still resolve to the exposed token.
+4. Re-run the affected deploy workflow only after the replacement token is installed.
+5. Record the revocation time, replacement token name, and affected repositories in the security incident log.
+
+### Token classes
+
+| Token | Repository secret | Intended repository | Allowed use |
+|---|---|---|---|
+| Mother/build token | `CLOUDFLARE_GOLDSHORE_BUILD_TOKEN` | `marzton/goldshore` | Central build orchestration and controlled cross-repo dispatch only. |
+| `goldshore-ai` deploy token | `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` | `marzton/goldshore-ai` | Deploy only the Cloudflare assets owned by this repository. |
+| `goldshore-admin` deploy token | `CLOUDFLARE_GOLDSHORE_ADMIN_DEPLOY_TOKEN` | `marzton/goldshore-admin` | Deploy only the admin Pages/Worker assets owned by that repository. |
+| `goldshore-api` deploy token | `CLOUDFLARE_GOLDSHORE_API_DEPLOY_TOKEN` | `marzton/goldshore-api` | Deploy only the API Workers, Queues, Workflows, and related bindings owned by that repository. |
+| `goldshore-gateway` deploy token | `CLOUDFLARE_GOLDSHORE_GATEWAY_DEPLOY_TOKEN` | `marzton/goldshore-gateway` | Deploy only gateway Workers and route bindings owned by that repository. |
+
+### Required scoping rules
+
+- Do not grant account-wide edit permissions to app repository deploy tokens.
+- Scope each deploy token to the minimum Cloudflare account, zones, Workers scripts, Pages projects, Queues, and Workflows that the repository actually deploys.
+- Keep the mother/build token out of app repositories; app repositories must store only their own deploy token plus `CLOUDFLARE_ACCOUNT_ID`.
+- Remove legacy aliases such as `CLOUDFLARE_API_TOKEN`, `CF_WORKERS_BUILDS`, and broad `CLOUDFLARE_BUILD_API_TOKEN` secrets from app repositories after migration.
+- Do not add GitHub Actions fallback expressions between Cloudflare token secrets. A workflow must fail if its repository-specific token is missing.
+
+### `goldshore-ai` GitHub Actions contract
+
+`marzton/goldshore-ai` deploy workflows must read Cloudflare credentials from:
+
+```yaml
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+The repository secret `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` must be able to deploy only the canonical Cloudflare resources listed for this repository in `infra/Cloudflare/README.md` and `policy/REPO_OWNERSHIP.md`.
 
 ## Workflow Standards
 
@@ -82,7 +123,7 @@ env:
 2. **Use canonical token only**
    ```yaml
    env:
-     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+     CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
    ```
 
 3. **Log deployment metadata**
@@ -95,7 +136,7 @@ env:
    ```yaml
    - name: Check secrets
      run: |
-       [[ -n "$CLOUDFLARE_BUILD_API_TOKEN" ]] || { echo "Missing CLOUDFLARE_BUILD_API_TOKEN"; exit 1; }
+       [[ -n "$CLOUDFLARE_API_TOKEN" ]] || { echo "Missing CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN"; exit 1; }
        [[ -n "$CLOUDFLARE_ACCOUNT_ID" ]] || { echo "Missing CLOUDFLARE_ACCOUNT_ID"; exit 1; }
    ```
 

--- a/policy/REPO_OWNERSHIP.md
+++ b/policy/REPO_OWNERSHIP.md
@@ -1,8 +1,8 @@
 # Repository Ownership & Service Registry
 
-**Source of truth for:** App locations, build paths, deployment targets, domain ownership  
-**Authority:** Marzton (account owner); gs-control (CI/CD authority for worker deployments)  
-**Last updated:** 2026-04-24  
+**Source of truth for:** App locations, build paths, deployment targets, domain ownership
+**Authority:** Marzton (account owner); gs-control (CI/CD authority for worker deployments)
+**Last updated:** 2026-04-24
 **Review cycle:** Quarterly or when new apps are added
 
 ---
@@ -68,20 +68,20 @@ marzton/goldshore-ai/
 
 ## Deployment Authority
 
-### Workers (`CLOUDFLARE_BUILD_API_TOKEN`)
+### Workers (`CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN`)
 
-**Authority:** `gs-control` service  
-**Owned by:** Platform ops  
-**Scope:** Deploy any worker on the account (gs-api, gs-platform, gs-control, gs-mail, gs-agent, goldshore-org, banproof-me)
+**Authority:** Repository-specific Cloudflare deploy token
+**Owned by:** Platform ops and the owning service team
+**Scope:** Deploy only the Cloudflare Workers, Pages projects, Queues, Workflows, and zones owned by `marzton/goldshore-ai`; do not grant account-wide edit permissions.
 
 **CI/CD:** All worker deployments must:
-1. Use `CLOUDFLARE_BUILD_API_TOKEN` exclusively (no fallback expressions)
+1. Use `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` exclusively in this repository (no fallback expressions)
 2. Target the canonical wrangler manifest path (from this table)
 3. Pass pre-deploy validation (scripts/validate-worker-names.ts)
 
 ### Pages Projects (GitHub Actions)
 
-**Authority:** Individual repo maintainers (gs-web, gs-admin repos if separate)  
+**Authority:** Individual repo maintainers (gs-web, gs-admin repos if separate)
 **Scope:** Deploy frontend builds to Cloudflare Pages
 
 **If separate repos:**
@@ -97,7 +97,7 @@ marzton/goldshore-ai/
 ### Primary Rules
 
 1. **One domain, one owner.** No service can claim routes on two domains without explicit permission from the owner.
-   - Exception: `goldshore.ai` is shared between gs-web (Pages) and workers (api.*, gw.*, ops.*, agent.*)  
+   - Exception: `goldshore.ai` is shared between gs-web (Pages) and workers (api.*, gw.*, ops.*, agent.*)
    - These are subdomains — no conflict.
 
 2. **Zone authority.** Each Cloudflare zone has one owner:
@@ -106,9 +106,9 @@ marzton/goldshore-ai/
    - `banproof.me` → BanProof (Marzton)
 
 3. **Custom domain vs. route distinction:**
-   - **Custom domain (Pages):** Cloudflare automatically routes apex/www to Pages project  
+   - **Custom domain (Pages):** Cloudflare automatically routes apex/www to Pages project
      Example: `goldshore.ai` → `gs-web.pages.dev`
-   - **Routes (Workers):** Explicit route patterns registered with worker  
+   - **Routes (Workers):** Explicit route patterns registered with worker
      Example: `api.goldshore.ai/*` → `gs-api` worker
 
 4. **No route conflicts.** If two workers claim the same route pattern, the first deployed wins (and breaks the second).
@@ -179,24 +179,24 @@ banproof-me (Worker)
 
 ### ❌ DO NOT
 
-1. **Deploy a worker without checking wrangler.toml is in the canonical path**  
-   ✅ Correct: `infra/Cloudflare/gs-api.wrangler.toml`  
+1. **Deploy a worker without checking wrangler.toml is in the canonical path**
+   ✅ Correct: `infra/Cloudflare/gs-api.wrangler.toml`
    ❌ Wrong: `apps/gs-api/wrangler.toml` (may be stale)
 
-2. **Use fallback expressions for `CLOUDFLARE_BUILD_API_TOKEN`**  
-   ✅ Correct: `${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}`  
+2. **Use fallback expressions for Cloudflare deploy tokens**
+   ✅ Correct: `${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}`
    ❌ Wrong: `${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}`
 
-3. **Deploy a Pages project with the same name as a worker**  
-   ✅ Correct: Worker `gs-api`, Pages project `gs-web`  
+3. **Deploy a Pages project with the same name as a worker**
+   ✅ Correct: Worker `gs-api`, Pages project `gs-web`
    ❌ Wrong: Worker `gs-api`, Pages project `gs-api`
 
-4. **Add a service to the monorepo without updating this registry**  
-   ✅ Correct: Add to monorepo, update REPO_OWNERSHIP.md, commit together  
+4. **Add a service to the monorepo without updating this registry**
+   ✅ Correct: Add to monorepo, update REPO_OWNERSHIP.md, commit together
    ❌ Wrong: Add service, deploy, leave docs out of sync
 
-5. **Deploy from a local machine or branch without an audit trail**  
-   ✅ Correct: All deployments go through `marzton/goldshore-ai` main branch + GitHub Actions  
+5. **Deploy from a local machine or branch without an audit trail**
+   ✅ Correct: All deployments go through `marzton/goldshore-ai` main branch + GitHub Actions
    ❌ Wrong: `wrangler deploy` from laptop (like current banproof-me)
 
 ---

--- a/scripts/check-cloudflare-token-policy.sh
+++ b/scripts/check-cloudflare-token-policy.sh
@@ -6,13 +6,13 @@ workflows_dir=".github/workflows"
 echo "Checking for disallowed fallback secret expressions in workflow env blocks..."
 if rg -n 'CLOUDFLARE_(BUILD_)?API_TOKEN:\s*\$\{\{[^}]*\|\|[^}]*\}\}' "$workflows_dir"; then
   echo "❌ Disallowed token fallback expression found in workflow env block."
-  echo "Migration: replace fallback expressions with secrets.CLOUDFLARE_BUILD_API_TOKEN only."
+  echo "Migration: replace fallback expressions with secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN only."
   exit 1
 fi
 
 echo "Checking canonical deploy token wiring..."
-if ! rg -n 'CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CF_WORKERS_BUILDS\s*\}\}' "$workflows_dir/deploy-platform.yml" >/dev/null; then
-  echo "❌ deploy-platform.yml must set CLOUDFLARE_API_TOKEN from secrets.CF_WORKERS_BUILDS"
+if ! rg -n 'CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN\s*\}\}' "$workflows_dir/deploy-platform.yml" >/dev/null; then
+  echo "❌ deploy-platform.yml must set CLOUDFLARE_API_TOKEN from secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN"
   exit 1
 fi
 

--- a/scripts/setup-preview-dns.mjs
+++ b/scripts/setup-preview-dns.mjs
@@ -3,19 +3,19 @@
  * One-shot script: configure preview.goldshore.ai DNS + Cloudflare Pages custom domain.
  *
  * Required env vars:
- *   CLOUDFLARE_BUILD_API_TOKEN
+ *   CLOUDFLARE_API_TOKEN
  *   CLOUDFLARE_ACCOUNT_ID
  * Optional env vars:
  *   CLOUDFLARE_ZONE_ID (auto-resolved from zone name if omitted)
  */
 
 const API = "https://api.cloudflare.com/client/v4";
-const TOKEN = process.env.CLOUDFLARE_BUILD_API_TOKEN;
+const TOKEN = process.env.CLOUDFLARE_API_TOKEN;
 const ACCOUNT = process.env.CLOUDFLARE_ACCOUNT_ID;
 let ZONE = process.env.CLOUDFLARE_ZONE_ID;
 
 if (!TOKEN || !ACCOUNT) {
-  console.error("Missing required env vars: CLOUDFLARE_BUILD_API_TOKEN and CLOUDFLARE_ACCOUNT_ID. (CLOUDFLARE_ZONE_ID is optional; it will be auto-resolved if omitted.)");
+  console.error("Missing required env vars: CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID. (CLOUDFLARE_ZONE_ID is optional; it will be auto-resolved if omitted.)");
   process.exit(1);
 }
 


### PR DESCRIPTION
Merge strategy: squash

### Motivation

- Reduce blast radius from an exposed Cloudflare token by replacing broad/fallback deploy tokens with repository-scoped deploy tokens and explicit revocation guidance.  
- Enforce least-privilege: each repo should have a deploy-only token scoped to only the zones, Workers, Pages projects, Queues, and Workflows it actually deploys.  
- Remove unsafe fallback wiring and legacy aliases that obscure which credential was used during CI deploys.  
- Make CI and infra guard checks fail fast when a repository-specific token is missing.  

### Description

- Rewired active deploy workflows to read `CLOUDFLARE_API_TOKEN` from the repo-specific secret `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` (updated `.github/workflows/*` including `deploy-platform.yml` and `preview-gs-api.yml`).  
- Added a Cloudflare token compartmentalization section to `policy/CICD_POLICY.md` documenting revocation steps, token classes (`CLOUDFLARE_GOLDSHORE_BUILD_TOKEN`, `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN`, etc.), and least-privilege scoping rules.  
- Updated `infra/Cloudflare/README.md` and `policy/REPO_OWNERSHIP.md` to reflect repository-scoped token boundaries and migration guidance.  
- Updated CI guard and helper scripts to enforce the new contract, including `scripts/check-cloudflare-token-policy.sh` and `scripts/setup-preview-dns.mjs` to use `CLOUDFLARE_API_TOKEN` at runtime.  

### Testing

- Ran the token policy guard and lint-style checks with `bash -n scripts/check-cloudflare-token-policy.sh` which succeeded.  
- Syntax-checked the preview DNS script with `node --check scripts/setup-preview-dns.mjs` which succeeded.  
- Verified repo workflow YAML parses with `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each{|f| YAML.load_file(f); puts "ok #{f}"}'` which succeeded.  
- Ran `git diff --check` and internal `bash scripts/check-cloudflare-token-policy.sh` validation which reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a372598e3dc8331824fd43b85b5a797)