### PR TITLE
Strengthen Cloudflare Access token rotation runbook

### DIFF
--- a/docs/CLOUDFLARE_ACCESS_TOKEN_ROTATION_RUNBOOK.md
+++ b/docs/CLOUDFLARE_ACCESS_TOKEN_ROTATION_RUNBOOK.md
@@ -5,18 +5,18 @@ Use this runbook when a Cloudflare Access service-token client ID or client secr
 ## Immediate containment
 
 1. In the Cloudflare Dashboard, open **Zero Trust** > **Access** > **Service Auth** > **Service Tokens**.
-2. Locate the service token by matching the exposed client ID prefix.
-3. Revoke or delete the exposed service token immediately.
+2. Locate the service token by matching the exposed client ID prefix. For urgent incidents, search for the full exposed prefix in the token list before opening individual token records.
+3. Revoke or delete the exposed service token immediately; do not wait for the replacement token to be created before containment.
 4. Record the token name, associated Access applications, service account or build identity, revocation time, and incident owner in the incident notes. Do not record the client secret.
 
 ## Replacement token
 
 1. Create a new Access service token for the same approved service account or build identity. Cloudflare Worker build automation must use the `gs-control` build token identity.
 2. Store the replacement values only in the approved secret store or deployment environment.
-3. Update every affected deployment environment with the new `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` values.
-4. Redeploy or restart affected automation so the new headers are used:
-   - `CF-Access-Client-Id`
-   - `CF-Access-Client-Secret`
+3. Update every affected deployment environment with the new service-token values, including both environment variable and HTTP header names used by the affected automation:
+   - `CF_ACCESS_CLIENT_ID` / `CF-Access-Client-Id`
+   - `CF_ACCESS_CLIENT_SECRET` / `CF-Access-Client-Secret`
+4. Redeploy or restart affected automation so the new headers are used.
 5. Run a smoke test against the Access-protected endpoint using the replacement token.
 
 ## Access-log audit
@@ -28,8 +28,8 @@ Use this runbook when a Cloudflare Access service-token client ID or client secr
 
 ## Repository and history audit
 
-1. Search the current tree for the exposed client ID prefix and Access service-token headers before committing any remediation.
-2. Search Git history for the exposed client ID prefix.
+1. Search the current tree for the exposed client ID prefix and Access service-token headers before committing any remediation. Include hidden and ignored files so local environment files are checked.
+2. Search Git history for the exposed client ID prefix across all refs.
 3. If any committed secret value is found, rotate the replacement token again after removal because the first replacement may have been exposed during remediation.
 4. Remove the secret from source and purge it from Git history using the repository-approved secret-removal process before publishing the branch.
 5. Re-run the current-tree and Git-history searches after the purge to verify the exposed value is absent.
@@ -41,5 +41,5 @@ Use this runbook when a Cloudflare Access service-token client ID or client secr
 - Secret store or deployment environment updated with `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET`.
 - Affected automation redeployed or restarted.
 - Access logs audited for unexpected use.
-- Repository current tree and Git history checked for the exposed value.
+- Repository current tree and Git history checked for the exposed value, including hidden and ignored files in the working tree and all refs in Git history.
 - Any committed secret removed, purged from history, and rotated again.


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Improve the runbook to ensure faster containment and clearer guidance when a Cloudflare Access service-token client ID or secret is exposed. 
- Reduce risk by making repository-audit and replacement steps more explicit so secrets are rotated and redeployed correctly.

### Description
- Update immediate containment to recommend searching the full exposed client-ID prefix for urgent incidents and to revoke/delete the exposed token immediately. 
- Clarify replacement-token instructions to update both environment variable names and HTTP header names (`CF_ACCESS_CLIENT_ID` / `CF-Access-Client-Id`, `CF_ACCESS_CLIENT_SECRET` / `CF-Access-Client-Secret`) and to redeploy affected automation. 
- Strengthen repository and history audit guidance to include hidden and ignored working-tree files and to search Git history across all refs. 
- Adjust the verification checklist to reflect the expanded current-tree and Git-history audit coverage.

### Testing
- Ran `rg -n --hidden --no-ignore "6935ce7381464b058c75c16ce264713e" . || true` to verify the exposed client-id prefix is not present in the working tree, and it completed successfully. 
- Ran `git log --all --full-history --pretty=format:'%H %ad %s' --date=iso -S'6935ce7381464b058c75c16ce264713e' -- .` to search history for the prefix across the repository, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a373490f0408331a97d6ab0b532d241)