### PR TITLE
feat: copper-on-black theme (theme files only)

### DIFF
--- a/apps/gs-web/src/components/RiskRadar.astro
+++ b/apps/gs-web/src/components/RiskRadar.astro
@@ -73,8 +73,8 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
     gap: 1rem;
     padding: 0.9rem 1rem;
     border-radius: 14px;
-    border: 1px solid rgba(90, 162, 255, 0.12);
-    background: rgba(90, 162, 255, 0.06);
+    border: 1px solid rgba(217, 106, 50, 0.12);
+    background: rgba(217, 106, 50, 0.06);
   }
 
   .risk-radar-signal span {
@@ -96,11 +96,11 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
     border-radius: 50%;
     overflow: hidden;
     background:
-      radial-gradient(circle at center, rgba(90, 162, 255, 0.2), rgba(90, 162, 255, 0.02) 42%, rgba(3, 8, 18, 0.98) 75%),
+      radial-gradient(circle at center, rgba(217, 106, 50, 0.2), rgba(217, 106, 50, 0.02) 42%, rgba(3, 8, 18, 0.98) 75%),
       #06101d;
-    border: 1px solid rgba(90, 162, 255, 0.24);
+    border: 1px solid rgba(217, 106, 50, 0.24);
     box-shadow:
-      inset 0 0 80px rgba(90, 162, 255, 0.08),
+      inset 0 0 80px rgba(217, 106, 50, 0.08),
       0 24px 80px rgba(0, 0, 0, 0.45);
   }
 
@@ -115,8 +115,8 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
 
   .risk-radar-grid {
     background:
-      linear-gradient(rgba(90, 162, 255, 0.08) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(90, 162, 255, 0.08) 1px, transparent 1px);
+      linear-gradient(rgba(217, 106, 50, 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(217, 106, 50, 0.08) 1px, transparent 1px);
     background-size: 18% 18%;
     opacity: 0.45;
   }
@@ -124,21 +124,21 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
   .risk-radar-rings {
     border-radius: 50%;
     background:
-      radial-gradient(circle, transparent 18%, rgba(90, 162, 255, 0.18) 18.4%, transparent 19%),
-      radial-gradient(circle, transparent 34%, rgba(90, 162, 255, 0.18) 34.4%, transparent 35%),
-      radial-gradient(circle, transparent 50%, rgba(90, 162, 255, 0.18) 50.4%, transparent 51%),
-      radial-gradient(circle, transparent 66%, rgba(90, 162, 255, 0.18) 66.4%, transparent 67%);
+      radial-gradient(circle, transparent 18%, rgba(217, 106, 50, 0.18) 18.4%, transparent 19%),
+      radial-gradient(circle, transparent 34%, rgba(217, 106, 50, 0.18) 34.4%, transparent 35%),
+      radial-gradient(circle, transparent 50%, rgba(217, 106, 50, 0.18) 50.4%, transparent 51%),
+      radial-gradient(circle, transparent 66%, rgba(217, 106, 50, 0.18) 66.4%, transparent 67%);
   }
 
   .risk-radar-crosshair {
     background:
-      linear-gradient(rgba(90, 162, 255, 0.18), rgba(90, 162, 255, 0.18)) center/1px 100% no-repeat,
-      linear-gradient(90deg, rgba(90, 162, 255, 0.18), rgba(90, 162, 255, 0.18)) center/100% 1px no-repeat;
+      linear-gradient(rgba(217, 106, 50, 0.18), rgba(217, 106, 50, 0.18)) center/1px 100% no-repeat,
+      linear-gradient(90deg, rgba(217, 106, 50, 0.18), rgba(217, 106, 50, 0.18)) center/100% 1px no-repeat;
   }
 
   .risk-radar-sweep {
     border-radius: 50%;
-    background: conic-gradient(from 0deg, rgba(90, 162, 255, 0.34), rgba(90, 162, 255, 0.02) 18%, rgba(90, 162, 255, 0) 42%);
+    background: conic-gradient(from 0deg, rgba(217, 106, 50, 0.34), rgba(217, 106, 50, 0.02) 18%, rgba(217, 106, 50, 0) 42%);
     mix-blend-mode: screen;
     animation: radar-spin 2.4s linear infinite;
     transform-origin: center;
@@ -160,8 +160,8 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
     margin-left: calc(var(--size) * -0.5);
     margin-top: calc(var(--size) * -0.5);
     border-radius: 999px;
-    background: rgba(150, 214, 255, 0.98);
-    box-shadow: 0 0 0 rgba(150, 214, 255, 0.5);
+    background: rgba(255, 180, 120, 0.98);
+    box-shadow: 0 0 0 rgba(255, 180, 120, 0.5);
     animation:
       radar-blip var(--duration) ease-in-out infinite,
       radar-drift calc(var(--duration) * 1.35) ease-in-out infinite;
@@ -177,7 +177,7 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
     padding: 0.8rem 0.95rem;
     border-radius: 14px;
     background: rgba(8, 14, 28, 0.82);
-    border: 1px solid rgba(90, 162, 255, 0.18);
+    border: 1px solid rgba(217, 106, 50, 0.18);
     backdrop-filter: blur(12px);
   }
 
@@ -201,17 +201,17 @@ const { title = 'Risk Radar', subtitle = 'Loopable surveillance surface for risk
     0%, 18%, 100% {
       opacity: 0.25;
       transform: scale(0.8);
-      box-shadow: 0 0 0 0 rgba(150, 214, 255, 0);
+      box-shadow: 0 0 0 0 rgba(255, 180, 120, 0);
     }
 
     24%, 38% {
       opacity: 1;
       transform: scale(1.2);
-      box-shadow: 0 0 0 14px rgba(150, 214, 255, 0);
+      box-shadow: 0 0 0 14px rgba(255, 180, 120, 0);
     }
 
     30% {
-      box-shadow: 0 0 0 4px rgba(150, 214, 255, 0.3);
+      box-shadow: 0 0 0 4px rgba(255, 180, 120, 0.3);
     }
   }
 

--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -57,11 +57,11 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
     {shouldRenderCspMeta && <meta http-equiv="Content-Security-Policy" content={HTML_CSP_META_FALLBACK} />}
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.png" type="image/png" sizes="32x32" />
-    <!-- Bolt: Preconnect to external origins to speed up resource loading -->
+    <!-- Preconnect to external origins to speed up resource loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
     <link rel="manifest" href="/site.webmanifest"/>
@@ -83,7 +83,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
                 </a>
               ))}
             </div>
-            <a href="/contact" class="header-cta">Request Briefing</a>
+            <a href="/contact" class="header-cta">Get a Briefing</a>
           </nav>
 
           <button
@@ -121,7 +121,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
             </div>
 
             <div class="menu-panel__actions">
-              <a href="/contact" class="header-cta header-cta--mobile">Request Briefing</a>
+              <a href="/contact" class="header-cta header-cta--mobile">Get a Briefing</a>
               <a href="/developer" class="menu-secondary-link">Open Developer Hub</a>
             </div>
           </div>
@@ -257,7 +257,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
         padding-inline: clamp(1rem, 3vw, 2rem);
         backdrop-filter: blur(16px);
         -webkit-backdrop-filter: blur(16px);
-        background: rgba(8, 12, 22, 0.78);
+        background: rgba(5, 5, 7, 0.82);
         border-bottom: 1px solid rgba(255, 255, 255, 0.06);
       }
 
@@ -350,7 +350,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
       .desktop-nav__links a:hover,
       .desktop-nav__links a[aria-current='page'] {
         color: var(--gs-text);
-        background: rgba(90, 162, 255, 0.09);
+        background: rgba(217, 106, 50, 0.09);
       }
 
       .header-cta {
@@ -360,8 +360,8 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
         padding: 0.82rem 1.2rem;
         border-radius: 999px;
         text-decoration: none;
-        background: linear-gradient(135deg, rgba(90, 162, 255, 0.28), rgba(90, 162, 255, 0.16));
-        border: 1px solid rgba(90, 162, 255, 0.34);
+        background: linear-gradient(135deg, rgba(217, 106, 50, 0.42), rgba(217, 106, 50, 0.22));
+        border: 1px solid rgba(217, 106, 50, 0.5);
         color: var(--gs-text);
         font-weight: 700;
         white-space: nowrap;
@@ -371,7 +371,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
       .header-cta:hover,
       .header-cta:focus-visible {
         transform: translateY(-1px);
-        background: linear-gradient(135deg, rgba(90, 162, 255, 0.34), rgba(90, 162, 255, 0.2));
+        background: linear-gradient(135deg, rgba(217, 106, 50, 0.52), rgba(217, 106, 50, 0.30));
       }
 
       .menu-button,
@@ -388,7 +388,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
         gap: 4px;
         border-radius: 999px;
         border: 1px solid var(--gs-border);
-        background: rgba(90, 162, 255, 0.08);
+        background: rgba(217, 106, 50, 0.08);
         cursor: pointer;
       }
 
@@ -479,7 +479,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
       .menu-panel__links a[aria-current='page'] {
         color: var(--gs-text);
         border-color: var(--gs-border);
-        background: rgba(90, 162, 255, 0.08);
+        background: rgba(217, 106, 50, 0.08);
       }
 
       .menu-panel__actions {

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -81,7 +81,7 @@ const proofPoints = [
       eyebrow="AI risk operations for financial services"
       headline={"Control AI Decisions.\nPass Every Review."}
       sub="GoldShore gives risk and compliance leaders a single operating layer to monitor model behavior, escalate exceptions, and prove governance in every audit."
-      ctaPrimary={{ label: 'Book a risk review', href: '/contact' }}
+      ctaPrimary={{ label: 'Get a Briefing', href: '/contact' }}
       ctaSecondary={{ label: 'See services', href: '/services' }}
       ctaPrimaryEventName="hero_primary_contact_click"
       ctaSecondaryEventName="hero_secondary_services_click"
@@ -377,7 +377,7 @@ const proofPoints = [
     .hero::after {
       content: '';
       background:
-        radial-gradient(circle at 25% 20%, rgba(90, 162, 255, 0.18), transparent 28%),
+        radial-gradient(circle at 25% 20%, rgba(217, 106, 50, 0.18), transparent 28%),
         linear-gradient(180deg, rgba(7, 11, 20, 0.18), rgba(7, 11, 20, 0.84));
       pointer-events: none;
       z-index: 0;
@@ -419,9 +419,9 @@ const proofPoints = [
       align-items: center;
       gap: 0.5rem;
       padding: 0.5rem 0.85rem;
-      border: 1px solid rgba(90, 162, 255, 0.22);
+      border: 1px solid rgba(217, 106, 50, 0.22);
       border-radius: 999px;
-      background: rgba(90, 162, 255, 0.1);
+      background: rgba(217, 106, 50, 0.10);
       color: #dcedff;
       text-transform: uppercase;
       letter-spacing: 0.16em;
@@ -533,8 +533,8 @@ const proofPoints = [
       padding: 0.95rem 1rem;
       margin-bottom: 1rem;
       border-radius: 18px;
-      border: 1px solid var(--gs-border);
-      background: var(--gs-primary-soft);
+      border: 1px solid rgba(217, 106, 50, 0.18);
+      background: rgba(217, 106, 50, 0.08);
     }
 
     .status-banner strong {
@@ -696,8 +696,8 @@ const proofPoints = [
     }
 
     .team-card--founder {
-      border-color: rgba(90, 162, 255, 0.2);
-      background: rgba(90, 162, 255, 0.08);
+      border-color: rgba(217, 106, 50, 0.2);
+      background: rgba(217, 106, 50, 0.08);
     }
 
     .contact-cta {

--- a/apps/gs-web/src/styles/global.css
+++ b/apps/gs-web/src/styles/global.css
@@ -4,20 +4,31 @@
 
 :root {
   --font-sans:
-    Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+    'Space Grotesk', 'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
     Arial, 'Apple Color Emoji', 'Segoe UI Emoji';
-  --gs-bg: #0b0f18;
-  --gs-surface: rgba(10, 18, 36, 0.85);
-  --gs-surface-strong: rgba(7, 14, 30, 0.96);
-  --gs-border: rgba(90, 162, 255, 0.18);
-  --gs-primary: #5aa2ff;
-  --gs-primary-soft: rgba(90, 162, 255, 0.12);
-  --gs-text: #e9eefc;
-  --gs-text-dim: rgba(233, 238, 252, 0.6);
-  --gs-radius: 14px;
-  --gs-radius-lg: 24px;
-  --gs-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
+  --gs-bg: #050507;
+  --gs-surface: rgba(14, 16, 20, 0.84);
+  --gs-surface-strong: rgba(20, 23, 29, 0.94);
+  --gs-border: rgba(255, 120, 54, 0.14);
+  --gs-border-subtle: rgba(255, 255, 255, 0.06);
+  --gs-primary: #d96a32;
+  --gs-primary-soft: rgba(217, 106, 50, 0.14);
+  --gs-primary-glow: rgba(217, 106, 50, 0.28);
+  --gs-copper: #d96a32;
+  --gs-copper-soft: rgba(217, 106, 50, 0.14);
+  --gs-copper-glow: rgba(217, 106, 50, 0.28);
+  --gs-copper-strong: rgba(217, 106, 50, 0.42);
+  --gs-text: #f1f4f8;
+  --gs-text-dim: #9ca5b4;
+  --gs-success: #5ddb9a;
+  --gs-warning: #f0b35b;
+  --gs-danger: #f56b6b;
+  --gs-radius: 16px;
+  --gs-radius-lg: 32px;
+  --gs-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
   --gs-max-width: 1200px;
+  --gs-font-display: 'Space Grotesk', 'Inter', system-ui, sans-serif;
+  --gs-font-body: 'Inter', system-ui, sans-serif;
 }
 
 html {
@@ -29,13 +40,17 @@ body {
   margin: 0;
   min-height: 100vh;
   background:
-    radial-gradient(circle at top, rgba(90, 162, 255, 0.12), transparent 26%),
-    linear-gradient(180deg, #0b0f18 0%, #0a1020 42%, #09111d 100%);
-  color: var(--gs-text);
-  font-family: var(--font-sans);
+    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(217, 106, 50, 0.18) 0%, transparent 70%),
+    var(--gs-bg);
+  color: var(--gs-text, #f1f4f8);
+  font-family: var(--gs-font-body, 'Inter', system-ui, sans-serif);
   text-rendering: geometricPrecision;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--gs-font-display, 'Space Grotesk', 'Inter', system-ui, sans-serif);
 }
 
 body.menu-open {
@@ -65,9 +80,9 @@ textarea {
 }
 
 ::selection {
-  background: rgba(90, 162, 255, 0.28);
+  background: rgba(217, 106, 50, 0.28);
   color: var(--gs-text);
 }
 
-/* GSL Brand Theme — navy + gold + responsive */
+/* GSL Brand Theme — copper + responsive */
 @import './gs-brand-theme.css';

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "@astrojs/cloudflare": "13.7.0",
       "@astrojs/adapter-cloudflare": "12.6.12",
       "postal-mime": "2.7.3",
-      "wrangler": "4.98.0",
+      "wrangler": "^4.63.0",
       "typescript": "^5.4.2",
       "esbuild": "0.25.12"
     }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "@astrojs/cloudflare": "13.7.0",
       "@astrojs/adapter-cloudflare": "12.6.12",
       "postal-mime": "2.7.3",
-      "wrangler": "^4.63.0",
+      "wrangler": "4.98.0",
       "typescript": "^5.4.2",
       "esbuild": "0.25.12"
     }

--- a/packages/theme/src/styles/base.css
+++ b/packages/theme/src/styles/base.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Source+Sans+3:wght@400;500;600;700&display=swap');
 @import './tokens.css';
 
 * { box-sizing: border-box; }
@@ -10,7 +9,7 @@ body {
   margin: 0;
   background: var(--gs-color-bg);
   color: var(--gs-color-text);
-  font-family: var(--gs-font-body);
+  font-family: var(--gs-font-body, 'Inter', system-ui, sans-serif);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   line-height: var(--gs-line-height);
@@ -26,7 +25,7 @@ a:hover { color: var(--gs-accent-strong); }
 a.button-link { text-decoration: none; }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--gs-font-display);
+  font-family: var(--gs-font-display, 'Space Grotesk', 'Inter', system-ui, sans-serif);
   letter-spacing: -0.02em;
   margin: var(--gs-space-6) 0 var(--gs-space-3);
   color: var(--gs-color-text);

--- a/packages/theme/src/styles/tokens.css
+++ b/packages/theme/src/styles/tokens.css
@@ -1,7 +1,7 @@
 :root {
   /* Typography */
   --gs-font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --gs-font-display: 'Inter Tight', 'Inter', system-ui, sans-serif;
+  --gs-font-display: 'Space Grotesk', 'Inter', system-ui, sans-serif;
   --gs-font-heading: var(--gs-font-display);
   --gs-line-height: 1.6;
   --gs-line-height-heading: 1.2;
@@ -33,27 +33,27 @@
   --gs-radius-lg: 18px;
   --gs-radius-pill: 999px;
 
-  /* Color palette */
-  --gs-color-primary: #22d3ee;
+  /* Color palette — copper-on-black */
+  --gs-color-primary: #d96a32;
   --gs-color-text: #e4ecfa;    /* General body text (slightly off-white for readability) */
-  --gs-color-bg: #050914;
+  --gs-color-bg: #050507;
   --gs-color-surface: #0c1221;
   --gs-color-surface-strong: #0f172a;
   --gs-color-muted-surface: #111a2f;
-  --gs-color-border: #1f2a3d;
+  --gs-color-border: rgba(255, 120, 54, 0.14);
   --gs-color-border-strong: #2d3c52;
   --gs-color-subtle: #9fb2d4;
   --gs-color-faint: #7a8cae;
-  --gs-accent: #7dd3fc;
-  --gs-accent-strong: #0ea5e9;
-  --gs-accent-soft: rgba(14, 165, 233, 0.15);
+  --gs-accent: var(--gs-copper);
+  --gs-accent-strong: var(--gs-copper-glow);
+  --gs-accent-soft: var(--gs-copper-soft);
   --gs-accent-contrast: #031122;
   --gs-success: #22c55e;
   --gs-warning: #fbbf24;
   --gs-danger: #ef4444;
   --gs-info: #38bdf8;
   --gs-accent-blue: #5882ff;
-  --gs-accent-cyan: var(--gs-color-primary); /* alias of --gs-color-primary (#22d3ee) */
+  --gs-accent-cyan: #22d3ee;
 
   /* Shadows */
   --gs-shadow-soft: 0 10px 40px rgba(0, 0, 0, 0.28);
@@ -74,45 +74,78 @@
   --gs-effect-sweep-core: var(--gs-effect-signal-blue-32);
   --gs-effect-sweep-edge: var(--gs-effect-signal-blue-08);
 
-  /* Text — --gs-text-primary is bright white for high-contrast UI elements */
+  /* Text */
   --gs-text-primary: #fff;
   --gs-text-secondary: rgba(255, 255, 255, 0.7);
 
   /* Header */
-  --gs-header-bg-glass: rgba(3, 3, 5, 0.7);
+  --gs-header-bg-glass: rgba(5, 5, 7, 0.82);
   --gs-header-bg-scrolled: rgba(0, 0, 0, 0.95);
   --gs-header-border-subtle: rgba(255, 255, 255, 0.05);
-  --gs-header-border-accent: rgba(34, 211, 238, 0.15);
+  --gs-header-border-accent: rgba(217, 106, 50, 0.15);
   --gs-header-shadow-scrolled: 0 10px 40px -10px rgba(0, 0, 0, 0.8);
 
   /* Logo */
-  --gs-logo-glow-soft: rgba(34, 211, 238, 0.3);
-  --gs-logo-glow-strong: rgba(34, 211, 238, 0.6);
+  --gs-logo-glow-soft: rgba(217, 106, 50, 0.3);
+  --gs-logo-glow-strong: rgba(217, 106, 50, 0.6);
 
   /* Nav */
-  --gs-nav-indicator-bg: var(--gs-accent-cyan);
-  --gs-nav-indicator-shadow: 0 0 8px var(--gs-accent-cyan);
+  --gs-nav-indicator-bg: var(--gs-copper);
+  --gs-nav-indicator-shadow: 0 0 8px var(--gs-copper);
 
   /* Mobile menu */
   --gs-mobile-menu-bg: #000;
   --gs-mobile-menu-border: rgba(255, 255, 255, 0.1);
-  --gs-bg-primary: #020408;
+
+  /* Background system */
+  --gs-bg-primary: #050507;
   --gs-bg-secondary: #0a0c12;
   --gs-bg-surface: #0e121a;
+  --gs-bg: #050507;
+  --gs-surface: rgba(14, 16, 20, 0.84);
+  --gs-surface-strong: rgba(20, 23, 29, 0.94);
 
-  --gs-accent-blue: #3b82f6;
+  /* Accent palette */
   --gs-accent-gold: #eab308;
 
-  --gs-text-primary: #f1f5f9;
-  --gs-text-muted: #94a3b8;
+  /* Text system */
+  --gs-text: #f1f4f8;
+  --gs-text-dim: #9ca5b4;
+  --gs-text-muted: #9ca5b4;
 
-  --gs-border-subtle: rgba(255, 255, 255, 0.08);
+  /* Border system */
+  --gs-border: rgba(255, 120, 54, 0.14);
+  --gs-border-subtle: rgba(255, 255, 255, 0.06);
 
+  /* Radius overrides */
   --gs-radius-lg: 20px;
   --gs-radius-md: 12px;
 
+  /* Layout */
   --gs-section-spacing: 6rem;
   --gs-content-width: 1100px;
+  --gs-max-width: 1200px;
+
+  /* Copper palette */
+  --gs-copper: #d96a32;
+  --gs-copper-soft: rgba(217, 106, 50, 0.14);
+  --gs-copper-glow: rgba(217, 106, 50, 0.28);
+  --gs-copper-strong: rgba(217, 106, 50, 0.42);
+
+  /* Blue signal palette */
+  --gs-blue: #59a8ff;
+  --gs-blue-soft: rgba(89, 168, 255, 0.12);
+  --gs-blue-glow: rgba(89, 168, 255, 0.24);
+
+  /* Semantic */
+  --gs-success: #5ddb9a;
+  --gs-warning: #f0b35b;
+  --gs-danger: #f56b6b;
+
+  /* Primary alias (copper) */
+  --gs-primary: var(--gs-copper);
+  --gs-primary-soft: var(--gs-copper-soft);
+  --gs-primary-glow: var(--gs-copper-glow);
 
   /* Compatibility aliases */
   --gs-color-bg: var(--gs-bg-primary);
@@ -120,8 +153,8 @@
   --gs-color-muted-surface: var(--gs-bg-surface);
   --gs-color-text: var(--gs-text-primary);
   --gs-color-subtle: var(--gs-text-muted);
-  --gs-color-border: var(--gs-border-subtle);
-  --gs-accent: var(--gs-accent-blue);
+  --gs-color-border: var(--gs-border);
+  --gs-accent: var(--gs-primary);
   --gs-accent-strong: var(--gs-accent-gold);
 
   /* Hero and marketing effect tokens */


### PR DESCRIPTION
## Summary

- Ports copper-on-black design system to main branch, unblocking production deploy
- Theme-files-only cherry-pick from `claude/clean-integration-BJD0q` (avoids the 94-file structural conflicts in PR #5258)
- No app deletions, no new apps, no new workflows

## Files changed

| File | Change |
|---|---|
| `packages/theme/src/styles/tokens.css` | Copper palette, blue signal palette, semantic tokens, font/layout tokens appended |
| `packages/theme/src/styles/base.css` | Removed Fraunces/Source Sans 3 import; body/heading font-family → token vars |
| `apps/gs-web/src/layouts/WebLayout.astro` | Space Grotesk + Inter font link; header `rgba(5,5,7,0.82)`; CTA copper gradient; "Get a Briefing" |
| `apps/gs-web/src/styles/global.css` | Copper-on-black rewrite: body bg copper radial gradient, purple/blue vars removed |
| `apps/gs-web/src/pages/index.astro` | Hero, eyebrow, button, team-card → copper; CTA "Get a Briefing" |
| `apps/gs-web/src/components/RiskRadar.astro` | All blue rgba(90,162,255,...) → copper rgba(217,106,50,...); blips copper |

## Test plan
- [ ] `goldshore.ai` header: copper CTA button, Space Grotesk headings, dark true-black bg
- [ ] RiskRadar: amber/copper sweep and blips
- [ ] "Get a Briefing" in desktop nav, mobile panel, hero
- [ ] Mobile 390px: responsive, copper-accented drawer nav
- [ ] `wrangler dev` local tunnel matches production after pulling main

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z3NQEQMm5aA4Wgfh74s9m)_