### PR TITLE
fix: deploy gs-www-redirect to resolve www.goldshore.ai 522 error

### DIFF
--- a/.github/workflows/deploy-gs-www-redirect.yml
+++ b/.github/workflows/deploy-gs-www-redirect.yml
@@ -1,0 +1,29 @@
+name: Deploy gs-www-redirect
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/gs-www-redirect/**'
+      - '.github/workflows/deploy-gs-www-redirect.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @goldshore/gs-www-redirect exec wrangler deploy --env production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GS_CONTROL }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary\n\n- Adds `deploy-gs-www-redirect.yml` GitHub Actions workflow\n- Triggers on push to `main` when `apps/gs-www-redirect/**` changes, and on `workflow_dispatch`\n- Deploys `gs-www-redirect` worker with `--env production` (binds `www.goldshore.ai` as a custom domain)\n- Follows the same pattern as `deploy-gs-api.yml` and `deploy-gs-web.yml`\n\n## Root Cause\n\n`gs-www-redirect` exists in the monorepo at `apps/gs-www-redirect/` but has never been deployed to Cloudflare. `www.goldshore.ai` has a DNS record pointing through Cloudflare's proxy, but with no Worker bound to that custom domain, Cloudflare cannot reach an origin — resulting in a 522 (TCP connection timeout).\n\n## Test Plan\n\n- [ ] Merge this PR\n- [ ] Confirm the `Deploy gs-www-redirect` workflow runs automatically on merge\n- [ ] Verify `curl -I https://www.goldshore.ai` returns `308 Permanent Redirect` → `https://goldshore.ai`\n\n## Immediate Fix (no need to wait for merge)\n\nRun in the `goldshore-ai` repo root in Git Bash:\n\n```bash\ncd apps/gs-www-redirect\nnpx wrangler deploy --env production\n```\n\nRequires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` env vars, or an active `wrangler login` session.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5)_