### PR TITLE
ci: fix pnpm version mismatch in deploy-gs-www-redirect workflow

### DIFF
--- a/.github/workflows/deploy-gs-api.yml
+++ b/.github/workflows/deploy-gs-api.yml
@@ -17,10 +17,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9.0.0
+          version: 9.15.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/deploy-gs-web.yml
+++ b/.github/workflows/deploy-gs-web.yml
@@ -17,10 +17,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9.0.0
+          version: 9.15.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/deploy-gs-www-redirect.yml
+++ b/.github/workflows/deploy-gs-www-redirect.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
-          version: 9.0.0
+          version: 9.15.4
       - uses: actions/setup-node@v6
         with:
           node-version: 22


### PR DESCRIPTION
## Summary\n\n- Upgrades `pnpm/action-setup@v4` → `@v6` (Node.js 24 compatible, fixes deprecation warning)\n- Changes pnpm `version: 9.0.0` → `9.15.4` to match `packageManager: pnpm@9.15.4` in `package.json` (fixes `ERR_PNPM_BAD_PM_VERSION` error)\n- Upgrades `actions/checkout@v6` → `@v7` (consistent with other workflows in this repo)\n\nThese annotations appeared on the first run of the workflow after #5380 merged. No functional change — same deploy logic, just correct action versions."}]

---
_Generated by [Claude Code](https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5)_