### PR TITLE
feat(web): responsive nav, access modal, wired contact form

### DIFF
--- a/apps/gs-web/scripts/release-quality-gate.mjs
+++ b/apps/gs-web/scripts/release-quality-gate.mjs
@@ -191,7 +191,13 @@ const MIME = {
 const createStaticServer = (documents) => {
   const byPath = new Map(documents.map((doc) => [doc.relativePath, doc.html]));
   return createServer(async (req, res) => {
-    const pathname = (req.url || '/').split('?')[0];
+    const rawPathname = (req.url || '/').split('?')[0];
+    let pathname;
+    try {
+      pathname = decodeURIComponent(rawPathname);
+    } catch {
+      pathname = rawPathname;
+    }
     const key = pathname === '/' ? 'index.html' : `${pathname.replace(/^\//, '').replace(/\/$/, '')}/index.html`;
     const html = byPath.get(key);
     if (html) {
@@ -201,9 +207,11 @@ const createStaticServer = (documents) => {
       return;
     }
     // Serve static assets (CSS, JS bundles, fonts, images) from dist directory
-    const filePath = path.resolve(DIST_DIR, pathname.replace(/^\//, ''));
-    // Guard against path traversal: resolved path must stay inside DIST_DIR
-    if (!filePath.startsWith(DIST_DIR + path.sep) && filePath !== DIST_DIR) {
+    const distRoot = path.resolve(DIST_DIR);
+    const filePath = path.resolve(distRoot, pathname.replace(/^\/+/, ''));
+    // Guard against path traversal: resolved path must stay inside distRoot
+    const rel = path.relative(distRoot, filePath);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
       res.statusCode = 404;
       res.end('Not found');
       return;

--- a/apps/gs-web/scripts/release-quality-gate.mjs
+++ b/apps/gs-web/scripts/release-quality-gate.mjs
@@ -201,7 +201,13 @@ const createStaticServer = (documents) => {
       return;
     }
     // Serve static assets (CSS, JS bundles, fonts, images) from dist directory
-    const filePath = path.join(DIST_DIR, pathname.replace(/^\//, ''));
+    const filePath = path.resolve(DIST_DIR, pathname.replace(/^\//, ''));
+    // Guard against path traversal: resolved path must stay inside DIST_DIR
+    if (!filePath.startsWith(DIST_DIR + path.sep) && filePath !== DIST_DIR) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
     try {
       const content = await readFile(filePath);
       const mime = MIME[path.extname(filePath)] || 'application/octet-stream';

--- a/apps/gs-web/scripts/release-quality-gate.mjs
+++ b/apps/gs-web/scripts/release-quality-gate.mjs
@@ -179,20 +179,40 @@ const checkFormLabels = (documents) => {
   }
 };
 
+const MIME = {
+  '.js': 'application/javascript', '.mjs': 'application/javascript',
+  '.css': 'text/css', '.json': 'application/json',
+  '.svg': 'image/svg+xml', '.png': 'image/png',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp',
+  '.woff': 'font/woff', '.woff2': 'font/woff2', '.ico': 'image/x-icon',
+  '.txt': 'text/plain', '.xml': 'application/xml',
+};
+
 const createStaticServer = (documents) => {
   const byPath = new Map(documents.map((doc) => [doc.relativePath, doc.html]));
-  return createServer((req, res) => {
+  return createServer(async (req, res) => {
     const pathname = (req.url || '/').split('?')[0];
     const key = pathname === '/' ? 'index.html' : `${pathname.replace(/^\//, '').replace(/\/$/, '')}/index.html`;
     const html = byPath.get(key);
-    if (!html) {
-      res.statusCode = 404;
-      res.end('Not found');
+    if (html) {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'text/html; charset=utf-8');
+      res.end(html);
       return;
     }
-    res.statusCode = 200;
-    res.setHeader('content-type', 'text/html; charset=utf-8');
-    res.end(html);
+    // Serve static assets (CSS, JS bundles, fonts, images) from dist directory
+    const filePath = path.join(DIST_DIR, pathname.replace(/^\//, ''));
+    try {
+      const content = await readFile(filePath);
+      const mime = MIME[path.extname(filePath)] || 'application/octet-stream';
+      res.statusCode = 200;
+      res.setHeader('content-type', mime);
+      res.setHeader('cache-control', 'no-store');
+      res.end(content);
+    } catch {
+      res.statusCode = 404;
+      res.end('Not found');
+    }
   });
 };
 

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -48,13 +48,16 @@ const marquee   = ['Risk Intelligence','Financial Signal Analysis','Workflow Aut
     <span class="mark">GS·LAB·v2.84</span>
     <span><strong>Gold Shore Labs</strong><em>GoldShore</em></span>
   </a>
-  <nav>
-    <a href="#platform">Platform</a>
-    <a href="#risk-radar">Risk Radar</a>
-    <a href="#services">Services</a>
-    <a href="#developer">Developer</a>
-    <a href="#about">About</a>
-    <a href="https://dashboard.goldshore.ai">Log in</a>
+  <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
+    <span></span><span></span><span></span>
+  </button>
+  <nav id="main-nav">
+    <a href="/platform/">Platform</a>
+    <a href="/risk-radar/">Risk Radar</a>
+    <a href="/services/">Services</a>
+    <a href="/developer/">Developer</a>
+    <a href="/about/">About</a>
+    <button id="open-access-modal" class="nav-login">Access →</button>
     <a class="nav-cta" href="#engage">Request Briefing</a>
   </nav>
 </header>
@@ -284,23 +287,32 @@ export async function verifyAccess(req, env) {
       <a class="btn magnetic" href="/developer">Developer Hub →</a>
     </div>
   </div>
-  <form class="quick-form" method="POST" action="/api/contact">
+  <form class="quick-form" id="quick-form" method="POST" action="/api/contact">
     <h3>Quick Inquiry</h3>
+    <input type="hidden" name="formType" value="homepage-inquiry" />
+    <input type="hidden" name="redirectTo" value="/thank-you" />
+    <input type="hidden" name="formStartedAt" id="qs-form-started" value="" />
+    <input type="hidden" name="dedupeKey" id="qs-dedupe-key" value="" />
+    <div class="gs-honeypot"><input name="companyWebsite" tabindex="-1" autocomplete="off" /></div>
     <div class="form-row">
-      <label>Name<input name="name" placeholder="Your name" /></label>
+      <label>Name<input name="name" required placeholder="Your name" /></label>
       <label>Organisation<input name="company" placeholder="Firm or company" /></label>
     </div>
-    <label>Work Email<input name="email" type="email" placeholder="you@firm.com" /></label>
+    <label>Work Email<input name="email" type="email" required placeholder="you@firm.com" /></label>
     <label>Interest
-      <select name="inquiry">
-        <option>Select area of interest</option>
-        <option>Digital Strategy</option>
-        <option>AI Implementation</option>
-        <option>Systems Integration</option>
-        <option>Risk Radar</option>
+      <select name="inquiry" required>
+        <option value="">Select area of interest</option>
+        <option value="general">General Enquiry</option>
+        <option value="strategy-call">Strategy Call</option>
+        <option value="project-scope">Project Scope</option>
+        <option value="support">Support</option>
       </select>
     </label>
-    <button type="submit" class="btn-form">Submit Request →</button>
+    <label>Message
+      <textarea name="message" id="qs-message" required rows="4" placeholder="Tell us about your inquiry (20+ characters)…"></textarea>
+    </label>
+    <div id="qs-form-status" class="form-status" aria-live="polite"></div>
+    <button type="submit" class="btn-form" id="qs-submit">Submit Request →</button>
   </form>
 </section>
 
@@ -314,18 +326,67 @@ export async function verifyAccess(req, env) {
   </div>
   <div>
     <h3>Platform</h3>
-    <p>Risk Radar</p><p>Financial Signals</p><p>Workflow Engine</p><p>Sentinel</p><p>AI Oracle</p>
+    <p><a href="/risk-radar/">Risk Radar</a></p>
+    <p><a href="/platform/financial-signals">Financial Signals</a></p>
+    <p><a href="/platform/workflow-engine">Workflow Engine</a></p>
+    <p><a href="/platform/sentinel">Sentinel</a></p>
+    <p><a href="/platform/ai-oracle">AI Oracle</a></p>
   </div>
   <div>
     <h3>Services</h3>
-    {services.map((s) => <p>{s}</p>)}
+    <p><a href="/services/digital-strategy">Digital Strategy</a></p>
+    <p><a href="/services/ai-implementation">AI Implementation</a></p>
+    <p><a href="/services/systems-integration">Systems Integration</a></p>
+    <p><a href="/services/design-dev">Design &amp; Development</a></p>
+    <p><a href="/services/consulting">Enterprise Consulting</a></p>
   </div>
   <div>
     <h3>Company</h3>
-    <p>About</p><p>Team</p><p>Developer Hub</p><p>Status</p><p>Contact</p>
+    <p><a href="/about/">About</a></p>
+    <p><a href="/team/">Team</a></p>
+    <p><a href="/developer/">Developer Hub</a></p>
+    <p><a href="/status/">Status</a></p>
+    <p><a href="/contact/">Contact</a></p>
   </div>
-  <small>© 2026 Gold Shore Labs. All rights reserved. 40°42′N · 074°00′W · goldshore.ai · Privacy · Security · Terms</small>
+  <small>© 2026 Gold Shore Labs. All rights reserved. 40°42′N · 074°00′W · goldshore.ai · <a href="/legal/privacy">Privacy</a> · <a href="/legal/">Security</a> · <a href="/legal/terms">Terms</a></small>
 </footer>
+
+<!-- ── Access Modal ──────────────────────────────────────────────────────── -->
+<dialog id="access-modal" class="access-modal">
+  <div class="modal-inner">
+    <button class="modal-close" aria-label="Close">✕</button>
+    <h2>Access Goldshore</h2>
+    <p class="modal-lead">Select a destination to continue.</p>
+    <div class="modal-grid">
+      <a href="/app/dashboard" class="modal-card">
+        <span class="modal-icon">⬡</span>
+        <strong>Dashboard</strong>
+        <span>Portfolio &amp; signals</span>
+      </a>
+      <a href="https://admin.goldshore.org" class="modal-card" rel="noopener noreferrer" target="_blank">
+        <span class="modal-icon">◈</span>
+        <strong>Admin</strong>
+        <span>Organisation management</span>
+      </a>
+      <a href="https://goldshore.org/dash" class="modal-card" rel="noopener noreferrer" target="_blank">
+        <span class="modal-icon">◇</span>
+        <strong>Trading</strong>
+        <span>Active positions</span>
+      </a>
+      <a href="/developer/mcp" class="modal-card">
+        <span class="modal-icon">⬢</span>
+        <strong>MCP</strong>
+        <span>Model Context Protocol</span>
+      </a>
+      <a href="https://api.goldshore.ai" class="modal-card" rel="noopener noreferrer" target="_blank">
+        <span class="modal-icon">◉</span>
+        <strong>API</strong>
+        <span>Developer access</span>
+      </a>
+    </div>
+    <p class="modal-contact">Need access? <a href="/contact/">Contact us →</a></p>
+  </div>
+</dialog>
 
 <script is:inline>
 /* ── Starfield ────────────────────────────────────────────────────────────── */
@@ -395,6 +456,66 @@ document.querySelectorAll('.ticker-item, .anomaly, .metrics div').forEach(el => 
     void el.offsetWidth;
     el.classList.add('is-pinged');
   });
+});
+
+/* ── Hamburger nav toggle ─────────────────────────────────────────────────── */
+const navToggle = document.getElementById('nav-toggle');
+const mainNav   = document.getElementById('main-nav');
+navToggle?.addEventListener('click', () => {
+  const open = mainNav.classList.toggle('nav-open');
+  navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+});
+
+/* ── Access modal ─────────────────────────────────────────────────────────── */
+const accessModal = document.getElementById('access-modal');
+document.getElementById('open-access-modal')?.addEventListener('click', () => accessModal?.showModal());
+document.querySelector('.modal-close')?.addEventListener('click', () => accessModal?.close());
+accessModal?.addEventListener('click', e => { if (e.target === accessModal) accessModal.close(); });
+
+/* ── Quick engage form ────────────────────────────────────────────────────── */
+const qsForm    = document.getElementById('quick-form');
+const qsStarted = document.getElementById('qs-form-started');
+const qsStatus  = document.getElementById('qs-form-status');
+const qsSubmit  = document.getElementById('qs-submit');
+
+if (qsStarted) qsStarted.value = Date.now().toString();
+
+qsForm?.addEventListener('submit', async e => {
+  e.preventDefault();
+  const fd  = new FormData(qsForm);
+  const msg = (fd.get('message') || '').toString().trim();
+  if (msg.length < 20) {
+    qsStatus.textContent = 'Message must be at least 20 characters.';
+    qsStatus.className = 'form-status';
+    return;
+  }
+  qsStatus.textContent = '';
+  qsSubmit.disabled = true;
+  qsSubmit.textContent = 'Sending…';
+  try {
+    const raw = `${fd.get('formType')}|${fd.get('name')}|${fd.get('email')}|${fd.get('inquiry')}|${msg}`;
+    const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(raw));
+    document.getElementById('qs-dedupe-key').value = Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2,'0')).join('');
+    const res  = await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'x-gs-request-mode': 'spa', 'Accept': 'application/json' },
+      body: new FormData(qsForm),
+    });
+    if (res.ok) {
+      window.location.href = '/thank-you';
+    } else {
+      const data = await res.json().catch(() => ({}));
+      qsStatus.textContent = data.error || 'Something went wrong. Please try again.';
+      qsStatus.className = 'form-status';
+      qsSubmit.disabled = false;
+      qsSubmit.textContent = 'Submit Request →';
+    }
+  } catch {
+    qsStatus.textContent = 'Network error. Please try again.';
+    qsStatus.className = 'form-status';
+    qsSubmit.disabled = false;
+    qsSubmit.textContent = 'Submit Request →';
+  }
 });
 </script>
 

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -352,13 +352,13 @@ export async function verifyAccess(req, env) {
 </footer>
 
 <!-- ── Access Modal ──────────────────────────────────────────────────────── -->
-<dialog id="access-modal" class="access-modal">
+<dialog id="access-modal" class="access-modal" aria-labelledby="access-modal-title">
   <div class="modal-inner">
     <button class="modal-close" aria-label="Close">✕</button>
-    <h2>Access Goldshore</h2>
+    <h2 id="access-modal-title">Access Goldshore</h2>
     <p class="modal-lead">Select a destination to continue.</p>
     <div class="modal-grid">
-      <a href="/app/dashboard" class="modal-card">
+      <a href="https://dashboard.goldshore.ai" class="modal-card" rel="noopener noreferrer" target="_blank">
         <span class="modal-icon">⬡</span>
         <strong>Dashboard</strong>
         <span>Portfolio &amp; signals</span>

--- a/apps/gs-web/src/styles/home-theme.css
+++ b/apps/gs-web/src/styles/home-theme.css
@@ -141,6 +141,51 @@ main { display: grid; gap: 1px; position: relative; z-index: 1; }
   border: 1px solid var(--ox-border);
 }
 
+.nav-login {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--t2);
+  padding: 0.65rem 0.8rem;
+  border-radius: 999px;
+  transition: color 0.2s, background 0.2s;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-login:hover {
+  color: var(--ox);
+  background: var(--ox-dim);
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: none;
+  border: 1px solid var(--b1);
+  cursor: pointer;
+  padding: 0.5rem;
+  flex-shrink: 0;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 100%;
+  height: 1px;
+  background: var(--t2);
+  transition: transform 0.25s, opacity 0.25s;
+}
+
+.nav-toggle[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+.nav-toggle[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
+.nav-toggle[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+
 /* ── Hero ─────────────────────────────────────────────────────────────────── */
 .hero {
   min-height: calc(100vh - 72px);
@@ -1074,7 +1119,8 @@ code {
 }
 
 .quick-form input,
-.quick-form select {
+.quick-form select,
+.quick-form textarea {
   width: 100%;
   background: var(--iron);
   border: 1px solid var(--b1);
@@ -1087,8 +1133,33 @@ code {
   appearance: none;
 }
 
+.quick-form textarea {
+  resize: vertical;
+  min-height: 7rem;
+  line-height: 1.6;
+}
+
 .quick-form input:focus,
-.quick-form select:focus { border-color: var(--ox-border); }
+.quick-form select:focus,
+.quick-form textarea:focus { border-color: var(--ox-border); }
+
+.form-status {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  color: var(--red);
+  min-height: 1.2rem;
+}
+
+.form-status.success { color: var(--green); }
+
+.gs-honeypot {
+  position: absolute;
+  left: -10000px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
 
 .btn-form {
   background: var(--ox);
@@ -1196,7 +1267,20 @@ code {
 
 @media (max-width: 768px) {
   .hero { padding-top: 4rem; }
-  .topbar { flex-direction: column; align-items: flex-start; }
+  .topbar { flex-wrap: wrap; align-items: center; gap: 0.75rem; }
+  .nav-toggle { display: flex; margin-left: auto; }
+  .topbar nav {
+    display: none;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    border-top: 1px solid var(--b1);
+    padding-top: 0.5rem;
+  }
+  .topbar nav.nav-open { display: flex; }
+  .topbar nav a,
+  .nav-login { padding: 0.85rem 0.5rem; width: 100%; border-radius: 0; }
   .metrics        { grid-template-columns: repeat(2,1fr); }
   .sector-grid    { grid-template-columns: 1fr 1fr; }
   .telemetry-grid { grid-template-columns: 1fr; }
@@ -1206,7 +1290,124 @@ code {
   .form-row       { grid-template-columns: 1fr; }
   .panel-columns  { grid-template-columns: 1fr; }
   .risk-metrics   { grid-template-columns: 1fr; }
+  .modal-grid     { grid-template-columns: 1fr; }
 }
+
+/* ── Access Modal ─────────────────────────────────────────────────────────── */
+.access-modal {
+  padding: 0;
+  border: 1px solid var(--ox-border);
+  background: var(--iron);
+  color: var(--t1);
+  width: min(480px, 92vw);
+  border-radius: 2px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.access-modal::backdrop {
+  background: rgba(6,6,10,0.85);
+  backdrop-filter: blur(6px);
+}
+
+.modal-inner {
+  padding: 2rem;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  background: none;
+  border: 1px solid var(--b1);
+  color: var(--t3);
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.modal-close:hover { border-color: var(--ox-border); color: var(--ox); }
+
+.modal-inner h2 {
+  font-size: 1.6rem;
+  margin: 0 0 0.35rem;
+  padding-right: 2.5rem;
+}
+
+.modal-lead {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--t3);
+  margin: 0 0 1.75rem;
+}
+
+.modal-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.modal-card {
+  display: block;
+  background: var(--plate);
+  border: 1px solid var(--b1);
+  padding: 1.25rem;
+  text-decoration: none;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.modal-card:hover {
+  border-color: var(--ox-border);
+  background: var(--graphite);
+}
+
+.modal-icon {
+  display: block;
+  font-size: 1.4rem;
+  color: var(--ox);
+  margin-bottom: 0.6rem;
+  line-height: 1;
+}
+
+.modal-card strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--t1);
+  margin-bottom: 0.25rem;
+}
+
+.modal-card span {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--t3);
+}
+
+.modal-contact {
+  font-size: 0.82rem;
+  color: var(--t3);
+  text-align: center;
+  margin: 0;
+  border-top: 1px solid var(--b1);
+  padding-top: 1.25rem;
+}
+
+.modal-contact a { color: var(--ox); text-decoration: none; }
+.modal-contact a:hover { color: var(--ox-bright); }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {


### PR DESCRIPTION
## Summary

- **Nav links** updated from hash anchors to real page routes (`/platform/`, `/risk-radar/`, `/services/`, `/developer/`, `/about/`)
- **"Log in" → Access modal**: replaced direct dashboard link with a native `<dialog>` showing destination cards for Dashboard, Admin, Trading, MCP, and API
- **Mobile hamburger**: `<button class="nav-toggle">` collapses/expands nav at ≤768px with animated icon and `aria-expanded` state
- **Contact form wired**: quick engage form now includes all fields required by `/api/contact` — `formType`, `redirectTo`, `formStartedAt`, SHA-256 `dedupeKey`, `companyWebsite` honeypot, `message` textarea, and corrected `inquiry` enum values (`general` / `strategy-call` / `project-scope` / `support`); submits via SPA fetch with inline error feedback
- **Footer links** updated to real routes for Platform, Services, and Company sections including legal pages

## Test plan

- [ ] Nav links navigate to real pages (not hash-only anchors)
- [ ] "Access →" button opens `<dialog>` modal; backdrop click and ✕ button close it
- [ ] Hamburger visible at ≤768px; clicking expands/collapses nav with correct `aria-expanded`
- [ ] Submit quick form with valid data (name, email, inquiry, 20+ char message) → redirects to `/thank-you`
- [ ] Submit with honeypot field filled → silent 200, no redirect (spam drop)
- [ ] Submit with message < 20 chars → inline error shown, no network request
- [ ] Footer links resolve to correct pages; legal links work
- [ ] Lighthouse CI passes (accessibility, SEO gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5

---
_Generated by [Claude Code](https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5)_