### PR TITLE
Document Gold Shore repository operations map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,96 @@
 # Gold Shore AI — Repository Operations Map
 
-This repository contains the Gold Shore public web surface, Cloudflare Workers, routing configuration, and shared packages that support the Gold Shore web domains and operational subdomains.
+```text
+             /\
+            /__\        GOLD SHORE LABS
+           /\  /\       Applied intelligence · digital systems · consulting
+          /__\/__\      Penrose direction: impossible geometry, real routes
 
-## Purpose
+          GS·LAB·v2.84  40°42′N · 074°00′W · goldshore.ai
+```
 
-This README is the repository-level map for humans and agents. Use it to find where domains, DNS, Workers, Pages-style assets, bindings, deploy workflows, layouts, styles, scripts, and public-route collision risks live.
+This README is the root map for humans, agents, and future Codex sessions working in `marzton/goldshore-ai`.
+
+It should explain what is true in the repository today: where domains are routed, where Cloudflare Workers live, what deploys them, where visual styles are sourced, and which static files can silently override Astro pages.
+
+## First rule
+
+Do not guess the runtime owner of a domain. Check these sources in order:
+
+1. `apps/*/wrangler.toml`
+2. `.github/workflows/*`
+3. `infra/INFRASTRUCTURE.md`
+4. Cloudflare DNS and Worker routes
+5. Deployed `curl -I` / `curl -sL` evidence
+
+Secrets, API tokens, dashboard credentials, R2 keys, Access JWTs, and OpenAI keys do **not** belong in this repository.
+
+## System sketch
+
+```text
+                               GitHub Actions
+                                    │
+                                    ▼
+                            Cloudflare Deploys
+                                    │
+          ┌─────────────────────────┼─────────────────────────┐
+          │                         │                         │
+          ▼                         ▼                         ▼
+   gs-web-app                gs-www-redirect             service Workers
+   Astro + Worker Assets     canonical www redirects     api / gateway / mail / ops
+          │                         │                         │
+          ▼                         ▼                         ▼
+ goldshore.ai              www.goldshore.ai             api.goldshore.ai
+ goldshore.org             www.goldshore.org            gw.goldshore.ai
+                                                     agent.goldshore.ai
+                                                     trading.goldshore.ai
+                                                     mail.goldshore.ai
+                                                     ops.goldshore.ai
+                                                     mcp.goldshore.ai
+```
 
 ## Production surface overview
 
 | Surface | Source location | Runtime | Purpose |
 | --- | --- | --- | --- |
-| Public web app | `apps/gs-web` | Cloudflare Worker with Assets | Main Astro website |
+| Public web app | `apps/gs-web` | Cloudflare Worker with Assets | Main Astro website for `goldshore.ai` and `goldshore.org` |
 | WWW redirect | `apps/gs-www-redirect` | Cloudflare Worker | Canonical `www` redirect handling |
-| Shared packages | `packages/*` | Workspace packages | Shared code used by apps |
+| Admin app | `apps/gs-admin` | Cloudflare Pages / Worker-adjacent app | Protected operator UI |
+| API | `apps/gs-api` | Cloudflare Worker | Core API surface |
+| Gateway | `apps/gs-gateway` | Cloudflare Worker | Gateway, agent ingress, bindings |
+| Agent | `apps/gs-agent` | Route-free Worker behind gateway binding | Agent service implementation |
+| Trading | `apps/gs-trading` | Cloudflare Worker | Trading / OAuth / paper trading surface |
+| Mail | `apps/gs-mail` | Cloudflare Worker | Mail/event handling |
+| Ops / control | `apps/gs-control` | Cloudflare Worker | Operator control plane |
+| Shared packages | `packages/*` | Workspace packages | Shared auth, engine, brand, and theme code |
+| Infrastructure docs | `infra/*`, `docs/*` | Documentation | Desired state, domain/auth notes, operational gates |
 | GitHub Actions | `.github/workflows/*` | GitHub CI/CD | Build and deploy automation |
+
+## Canonical domain ownership
+
+Current verified target model:
+
+```text
+goldshore.ai                 -> gs-web-app
+goldshore.org                -> gs-web-app
+www.goldshore.ai             -> gs-www-redirect-prod -> goldshore.ai
+www.goldshore.org            -> gs-www-redirect-prod -> goldshore.ai
+
+preview.goldshore.ai         -> gs-web preview / preview route as configured
+admin.goldshore.ai           -> gs-admin / protected operator UI
+admin-preview.goldshore.ai   -> gs-admin preview
+api.goldshore.ai             -> gs-api
+api-preview.goldshore.ai     -> gs-api preview
+gw.goldshore.ai              -> gs-gateway-prod
+agent.goldshore.ai           -> gs-gateway-prod service binding to gs-agent
+mcp.goldshore.ai             -> gs-mcp / MCP surface
+trading.goldshore.ai         -> gs-trading-prod
+mail.goldshore.ai            -> gs-mail
+ops.goldshore.ai             -> gs-control
+dashboard.goldshore.ai       -> intended dashboard/admin redirect surface
+```
+
+When this table disagrees with live Cloudflare, Cloudflare is the current truth and the repo is drifted. Fix the repo after confirming live state.
 
 ## Cloudflare Worker apps
 
@@ -24,7 +101,7 @@ Primary Astro web app deployed as a Cloudflare Worker with Assets.
 Important files:
 
 - `apps/gs-web/src/pages/index.astro` — current homepage source.
-- `apps/gs-web/src/styles/home-theme.css` — homepage GS LAB visual system.
+- `apps/gs-web/src/styles/home-theme.css` — current GS LAB homepage visual system.
 - `apps/gs-web/src/layouts/WebLayout.astro` — current subpage layout.
 - `apps/gs-web/src/styles/global.css` — current subpage/global style stack.
 - `apps/gs-web/public/_headers` — static route security headers.
@@ -32,17 +109,14 @@ Important files:
 - `apps/gs-web/wrangler.toml` — Worker name, routes, KV, D1, R2, and environment variables.
 - `.github/workflows/deploy-gs-web.yml` — production deploy workflow.
 
-The production Worker route configuration is stored in `apps/gs-web/wrangler.toml` under the production environment.
+Expected production deploy command:
 
-Bindings to check in `wrangler.toml`:
+```bash
+pnpm --filter @goldshore/gs-web build
+pnpm --filter @goldshore/gs-web exec wrangler deploy --env prod
+```
 
-- Worker assets binding.
-- KV namespace binding.
-- D1 database binding.
-- R2 bucket binding.
-- Environment variables.
-
-Secrets must never be committed. Keep tokens, API keys, R2 credentials, dashboard secrets, and OpenAI keys only in Cloudflare secrets, GitHub Actions secrets, or the appropriate platform secret manager.
+The production environment is `env.prod`. Do not accidentally deploy a route-free or differently named environment and then assume the public route changed.
 
 ### `apps/gs-www-redirect`
 
@@ -57,43 +131,63 @@ Important files:
 Expected behavior:
 
 ```text
-www primary domain   -> canonical apex domain
-www secondary domain -> canonical apex domain
+www.goldshore.ai   -> https://goldshore.ai/
+www.goldshore.org  -> https://goldshore.ai/   after explicit route/custom-domain binding
 ```
 
-## GitHub Actions deployment
+## Bindings and runtime resources
 
-### Deploy `gs-web`
+Check bindings in each app's `wrangler.toml`, not from memory.
 
-Workflow:
+Typical resources in this repo include:
 
 ```text
-.github/workflows/deploy-gs-web.yml
+KV     -> namespace bindings for app/cache/control state
+D1     -> gs_platform_db, gs_audit_db, gs_signals_db, gs_jobs_db, trading DBs
+R2     -> gs-assets, gs-assets-preview, telemetry/user upload buckets
+DO     -> AuthSession and app-specific Durable Objects where configured
+Queues -> app-specific event and signal processing queues where configured
 ```
 
-Manual deploy:
+Do not rename a binding casually. Application code expects exact binding names.
 
-```bash
-gh workflow run deploy-gs-web.yml --ref main
-WEB=$(gh run list --workflow "Deploy gs-web" --branch main --limit 1 --json databaseId -q '.[0].databaseId')
-gh run watch "$WEB"
-```
+## Homepage visual identity
 
-### Deploy `gs-www-redirect`
-
-Workflow:
+The preferred homepage direction is the GS LAB / Applied Intelligence page:
 
 ```text
-.github/workflows/deploy-gs-www-redirect.yml
+GS·LAB·v2.84
+Gold Shore Labs
+Where
+Strategy
+Operates.
+Applied intelligence for institutions that need clarity under pressure.
 ```
 
-Manual deploy:
+The homepage currently owns a standalone visual system:
 
-```bash
-gh workflow run deploy-gs-www-redirect.yml --ref main
-WWW=$(gh run list --workflow "Deploy gs-www-redirect" --branch main --limit 1 --json databaseId -q '.[0].databaseId')
-gh run watch "$WWW"
+```text
+apps/gs-web/src/pages/index.astro
+apps/gs-web/src/styles/home-theme.css
 ```
+
+This is where the orange/gold and white hero typography, coordinates mark, GS LAB panel language, telemetry cards, marquee, cursor orb, reveal animations, magnetic CTA behavior, and Risk Radar / Financial Signals previews live.
+
+## Penrose / brand asset direction
+
+The historical brand direction includes Penrose-style impossible geometry. Repository history includes references such as:
+
+```text
+public/logo/gs-penrose.svg
+public/assets/ui/penrose.svg
+packages/theme/README.md
+packages/theme/src/assets.js
+docs/brand-asset-plan.md
+```
+
+Planning guidance found in repo history says the canonical brand asset source should be `packages/theme/assets`, with web consuming the asset by URL and admin preferring inline SVG for styling control.
+
+That does **not** mean every current page already consumes the package correctly. Treat this as the intended migration direction until verified in current files.
 
 ## Homepage vs subpage styling
 
@@ -147,7 +241,7 @@ import WebLayout from '../../layouts/WebLayout.astro';
 import '../styles/global.css';
 ```
 
-This means subpages do not automatically inherit the homepage stylesheet, homepage nav, homepage footer, modals, starfield/cursor effects, or homepage interaction JavaScript.
+This means subpages do **not** automatically inherit the homepage stylesheet, homepage nav, homepage footer, modals, starfield/cursor effects, or homepage interaction JavaScript.
 
 Known areas to inspect:
 
@@ -177,6 +271,13 @@ Archive old static files under a non-colliding location such as:
 apps/gs-web/public/_archived-static/
 ```
 
+Before every web deploy, run or confirm equivalent checks:
+
+```bash
+find apps/gs-web/public -type f | sort
+gh run view <run-id> --log | grep -Ei 'Skipping src/pages|public folder|index.html'
+```
+
 ## Recommended UI architecture
 
 Create a shared shell for all public pages:
@@ -184,7 +285,8 @@ Create a shared shell for all public pages:
 ```text
 apps/gs-web/src/layouts/GoldShoreShell.astro
 apps/gs-web/src/styles/gs-shell.css
-apps/gs-web/src/scripts/gs-shell.js
+apps/gs-web/src/scripts/gs-shell.ts
+apps/gs-web/src/config/navigation.ts
 ```
 
 Move shared UI into that shell:
@@ -192,49 +294,32 @@ Move shared UI into that shell:
 - coordinates header
 - brand mark
 - primary nav
-- Access modal
+- Access menu or modal
 - Request Briefing CTA
 - shared footer
 - reveal animation
 - magnetic hover
-- starfield or cursor behavior
-- modal open and close behavior
+- cursor/starfield behavior
+- consistent CTA link handling
 
-Then migrate subpages from `WebLayout` to `GoldShoreShell` gradually.
+Then migrate subpages from `WebLayout.astro` to `GoldShoreShell.astro` gradually. Do not rewrite every content page in one uncontrolled commit.
 
-Recommended first migration target:
+## Deployment commands
 
-```text
-apps/gs-web/src/pages/risk-radar.astro
-```
-
-## Audit commands
-
-Find subpages still using the old layout:
+### Deploy `gs-web`
 
 ```bash
-grep -R "import WebLayout" -n apps/gs-web/src/pages apps/gs-web/src/layouts
+gh workflow run deploy-gs-web.yml --ref main
+WEB=$(gh run list --workflow "Deploy gs-web" --branch main --limit 1 --json databaseId -q '.[0].databaseId')
+gh run watch "$WEB"
 ```
 
-Find public files that may override Astro routes:
+### Deploy `gs-www-redirect`
 
 ```bash
-find apps/gs-web/public -type f | sort
-```
-
-Check build logs for route collisions:
-
-```bash
-gh run view <RUN_ID> --log | grep -Ei 'Skipping src/pages|public folder|index.html|risk-radar'
-```
-
-Compare homepage and subpage imports:
-
-```bash
-grep -nE "import .*css|import .*Layout|WebLayout|home-theme" \
-  apps/gs-web/src/pages/index.astro \
-  apps/gs-web/src/pages/risk-radar.astro \
-  apps/gs-web/src/layouts/WebLayout.astro
+gh workflow run deploy-gs-www-redirect.yml --ref main
+WWW=$(gh run list --workflow "Deploy gs-www-redirect" --branch main --limit 1 --json databaseId -q '.[0].databaseId')
+gh run watch "$WWW"
 ```
 
 ## Live verification commands
@@ -253,23 +338,40 @@ do
 done
 ```
 
-## OpenAI Platform guidance
+Content verification:
 
-No browser page should expose an OpenAI API key.
+```bash
+curl -sL "https://goldshore.ai/?v=$(date +%s)" \
+  | grep -Ei 'Applied Intelligence|Where|Strategy|GS·LAB|Gold Shore Labs' \
+  | head -40
+```
 
-If AI Oracle, MCP, admin, dashboard, or other features call OpenAI-backed systems, route those calls through server-side Workers or API endpoints and store secrets only in:
+If `curl` returns a Cloudflare challenge page, that is not proof the site is blank. Check from a browser session and check Cloudflare security rules separately.
 
-- Cloudflare Worker secrets.
-- GitHub Actions secrets.
-- OpenAI Platform key management.
+## Agent handoff notes
 
-Never commit API tokens, R2 access keys, dashboard/admin secrets, or OpenAI keys.
+When taking over this repository:
 
-## Immediate next PRs
+1. Read this README.
+2. Check `git status --short`.
+3. Check open PRs and active branches.
+4. Check `apps/gs-web/public` for route collisions.
+5. Check whether the homepage is generated from Astro or overridden by `public/index.html`.
+6. Check whether subpages still import `WebLayout.astro`.
+7. Check Cloudflare route ownership before changing DNS or Worker routes.
+8. Never commit secrets.
 
-1. Add a CI guard for public/Astro route collisions.
-2. Create `GoldShoreShell.astro` from the homepage shell.
-3. Move shared homepage effects into `gs-shell.css` and `gs-shell.js`.
-4. Migrate `risk-radar.astro` to `GoldShoreShell`.
-5. Normalize admin, dashboard, API, MCP, and core link targets.
-6. Review CSP for static routes and modal/API behavior.
+## Merge safety checklist
+
+Before merging UI or routing changes:
+
+- [ ] `apps/gs-web/public/index.html` does not override `src/pages/index.astro`.
+- [ ] Build logs show no unexpected `Skipping src/pages/... because public folder...` warnings.
+- [ ] `deploy-gs-web.yml` deploys the routed production environment.
+- [ ] `goldshore.ai` returns `HTTP/2 200`.
+- [ ] `goldshore.org` returns expected canonical behavior.
+- [ ] `www.goldshore.ai` redirects to canonical apex.
+- [ ] `www.goldshore.org` redirects to canonical apex.
+- [ ] Homepage content contains `Applied Intelligence`, `Where`, `Strategy`, and `GS·LAB`.
+- [ ] Subpage layout migration is deliberate and not an accidental partial theme mix.
+- [ ] Access-protected surfaces remain protected.

--- a/apps/gs-web/src/config/navigation.ts
+++ b/apps/gs-web/src/config/navigation.ts
@@ -1,0 +1,37 @@
+export type NavLink = {
+  href: string;
+  label: string;
+  external?: boolean;
+};
+
+export const primaryNavLinks: NavLink[] = [
+  { href: '/platform/', label: 'Platform' },
+  { href: '/risk-radar/', label: 'Risk Radar' },
+  { href: '/services/', label: 'Services' },
+  { href: '/developer/', label: 'Developer' },
+  { href: '/about/', label: 'About' },
+];
+
+export const platformLinks: NavLink[] = [
+  { href: '/risk-radar/', label: 'Risk Radar' },
+  { href: '/platform/financial-signals/', label: 'Financial Signals' },
+  { href: '/platform/workflow-engine/', label: 'Workflow Engine' },
+  { href: '/platform/sentinel/', label: 'Sentinel' },
+  { href: '/platform/ai-oracle/', label: 'AI Oracle' },
+];
+
+export const serviceLinks: NavLink[] = [
+  { href: '/services/digital-strategy/', label: 'Digital Strategy' },
+  { href: '/services/ai-implementation/', label: 'AI Implementation' },
+  { href: '/services/systems-integration/', label: 'Systems Integration' },
+  { href: '/services/design-dev/', label: 'Design & Development' },
+  { href: '/services/consulting/', label: 'Enterprise Consulting' },
+];
+
+export const companyLinks: NavLink[] = [
+  { href: '/about/', label: 'About' },
+  { href: '/team/', label: 'Team' },
+  { href: '/developer/', label: 'Developer Hub' },
+  { href: '/status/', label: 'Status' },
+  { href: '/contact/', label: 'Contact' },
+];

--- a/docs/plans/gs-shell-ui-migration.md
+++ b/docs/plans/gs-shell-ui-migration.md
@@ -43,13 +43,74 @@ apps/gs-web/src/styles/global.css
 
 Many subpages import `WebLayout`, which means they do not inherit the homepage shell, homepage CSS, modal behavior, cursor effects, reveal effects, or homepage nav/footer model.
 
+Current subpages still render the older header pattern from `WebLayout.astro`:
+
+```text
+GOLD SHORE
+Home
+About
+Team
+Book Strategy Call
+Contact
+Risk Radar
+Developer Hub
+Log in
+Get a Briefing
+```
+
+That header is not the target look for the public `goldshore.ai` website. It uses a different logo component, different nav labels, and different font loading than the homepage.
+
+## Header and navbar parity requirement
+
+For now, the public `goldshore.ai` site should keep the homepage header language and type direction across pages.
+
+Target header source of truth:
+
+```text
+apps/gs-web/src/pages/index.astro
+apps/gs-web/src/styles/home-theme.css
+```
+
+Target header content:
+
+```text
+40°42′45″N
+74°00′21″W
+GS·LAB·v2.84
+Gold Shore Labs
+GoldShore
+Platform
+Risk Radar
+Services
+Developer
+About
+Access →
+Request Briefing
+```
+
+Target visual behavior:
+
+- White `Gold Shore Labs` wordmark text, not the older SVG lockup as the main public header identity.
+- Large, bold, futuristic display type from the homepage font stack.
+- Homepage font loading should drive the public shell: `Syne`, `DM Sans`, and `DM Mono`.
+- Header should preserve the coordinate block and `GS·LAB·v2.84` metadata.
+- Header should preserve the secondary `GoldShore` line under `Gold Shore Labs`.
+- `Access →` should open the shared access layer or route to the correct protected access surface while the modal is being finished.
+- `Request Briefing` should use the same CTA style and route consistently.
+- Mobile menu should use the same labels and visual hierarchy.
+
+Important distinction:
+
+- `Logo.astro` still contains a Penrose-style SVG asset and may remain useful for footer, favicon, brand package, or future controlled usage.
+- It should not force the older subpage header to replace the homepage text-forward GS LAB header.
+
 ## Non-goals
 
 - Do not delete old static files without an archived copy.
-- Do not expose secrets or platform credentials in browser code.
 - Do not migrate every page in one risky PR.
 - Do not weaken security headers globally just to make interactions work.
 - Do not rewrite page content unless the page is intentionally being redesigned.
+- Do not replace the homepage public header with the old `WebLayout` header.
 
 ## Phase 0 — Inventory and guardrails
 
@@ -57,6 +118,13 @@ Many subpages import `WebLayout`, which means they do not inherit the homepage s
 
 ```bash
 grep -R "import WebLayout" -n apps/gs-web/src/pages apps/gs-web/src/layouts
+```
+
+### Inspect current header differences
+
+```bash
+grep -nE "topbar|brand|coords|GS·LAB|nav-toggle" apps/gs-web/src/pages/index.astro apps/gs-web/src/styles/home-theme.css
+grep -nE "desktop-nav|header-login|header-cta|Logo|Book Strategy Call|dashboard" apps/gs-web/src/layouts/WebLayout.astro
 ```
 
 ### Inspect public files that may override Astro pages
@@ -76,6 +144,7 @@ gh run view <RUN_ID> --log | grep -Ei 'Skipping src/pages|public folder|index.ht
 - All layout usage is known.
 - All public-file route collisions are known.
 - Static files are archived before being moved out of routable paths.
+- The homepage header source and old subpage header source are explicitly identified before migration.
 
 ## Phase 1 — Archive static route collisions
 
@@ -108,12 +177,13 @@ apps/gs-web/src/scripts/gs-shell.js
 Responsibilities:
 
 - page metadata defaults
-- shared font loading
+- shared font loading using the homepage stack: `Syne`, `DM Sans`, `DM Mono`
 - GS LAB body class
 - coordinates header
-- brand mark
-- primary navigation
-- Access modal slot or component
+- `GS·LAB·v2.84` metadata mark
+- text-forward `Gold Shore Labs` / `GoldShore` brand lockup
+- primary navigation matching the homepage labels
+- Access layer slot or component
 - Request Briefing CTA
 - shared footer
 - slot for page content
@@ -123,8 +193,9 @@ Responsibilities:
 
 Responsibilities:
 
-- shared CSS variables
-- header and navigation
+- shared CSS variables from `home-theme.css`
+- white/gold header and navigation styling
+- homepage-equivalent brand text treatment
 - buttons and links
 - footer
 - modal shell
@@ -132,14 +203,14 @@ Responsibilities:
 - reveal utilities
 - magnetic hover utility
 - responsive menu styling
-- shared background/cursor treatments
+- shared background/cursor/starfield treatments
 
 ### `gs-shell.js`
 
 Responsibilities:
 
 - mobile nav open and close
-- Access modal open and close
+- Access layer open and close
 - Escape key behavior
 - click-outside behavior
 - reveal-on-scroll behavior
@@ -151,6 +222,7 @@ Acceptance criteria:
 - A basic page can render through `GoldShoreShell`.
 - Header, footer, nav, modal, and shared interactions work without homepage-only assumptions.
 - The script is safe to run on every public page.
+- The shell visually matches the homepage header before any subpage content migration begins.
 
 ## Phase 3 — Refactor homepage into shared shell
 
@@ -175,7 +247,8 @@ Acceptance criteria:
 - Homepage still visually matches the desired GS LAB design.
 - Homepage title and meta still reflect Applied Intelligence.
 - Hero still reads `Where Strategy Operates.`
-- Access modal opens.
+- Header still shows coordinates, `GS·LAB·v2.84`, `Gold Shore Labs`, and `GoldShore`.
+- Access layer opens or routes correctly.
 - Request Briefing CTA works.
 - Homepage-specific styling remains available.
 
@@ -217,106 +290,4 @@ Acceptance criteria:
 - Content is preserved.
 - CTAs and links route consistently.
 - Mobile navigation and modal behavior work.
-
-## Phase 6 — Normalize link map
-
-Create a shared navigation config:
-
-```text
-apps/gs-web/src/config/navigation.ts
-```
-
-Suggested groups:
-
-- public pages
-- platform pages
-- services
-- developer resources
-- operational surfaces
-- legal/footer links
-
-Acceptance criteria:
-
-- Header and footer use one source of truth.
-- Homepage and subpages use the same nav labels and destinations.
-- Operational links are deliberate and documented.
-
-## Phase 7 — Add CI collision guard
-
-Add a script that fails the build when a public static file conflicts with an Astro route.
-
-Suggested file:
-
-```text
-apps/gs-web/scripts/check-public-route-collisions.js
-```
-
-Acceptance criteria:
-
-- CI fails before deploy if a public file would override an Astro route.
-- Error message lists conflicting files.
-- Archived static files are ignored.
-
-## Phase 8 — Security and interaction review
-
-Review:
-
-```text
-apps/gs-web/src/security/policy.ts
-apps/gs-web/src/utils/csp.ts
-apps/gs-web/src/middleware.ts
-apps/gs-web/public/_headers
-```
-
-Goals:
-
-- Keep browser policy strict.
-- Prefer external first-party JavaScript for shared shell behavior.
-- Do not expose secrets in client code.
-- Permit only required first-party connections.
-
-Acceptance criteria:
-
-- Shared modals and scripts work on Astro-rendered pages.
-- Static routes do not require broad inline-script allowances.
-- Sensitive calls remain server-side.
-
-## Verification checklist
-
-After each migration PR:
-
-```bash
-# Build and deploy
-gh workflow run deploy-gs-web.yml --ref main
-WEB=$(gh run list --workflow "Deploy gs-web" --branch main --limit 1 --json databaseId -q '.[0].databaseId')
-gh run watch "$WEB"
-
-# Check build warnings
-gh run view "$WEB" --log | grep -Ei 'Skipping src/pages|public folder|error|warn' | tail -120
-
-# Check expected homepage markers
-curl -sL "https://goldshore.ai/?v=$(date +%s)" \
-  | grep -Ei 'Applied Intelligence|Where|Strategy|Request Briefing' \
-  | head -40
-```
-
-## Rollout order
-
-1. Repository README map PR.
-2. This planning PR.
-3. Public route collision guard PR.
-4. Shared shell PR.
-5. Homepage shell refactor PR.
-6. Risk Radar migration PR.
-7. Platform page migration PR.
-8. Service page migration PR.
-9. Link-map and security cleanup PR.
-
-## Final success state
-
-- All public pages use one Gold Shore shell.
-- Homepage visual identity carries into subpages.
-- Modals, nav, CTAs, and interactions work consistently.
-- Static public files no longer override Astro pages.
-- Operational links are centralized and intentional.
-- Browser policy remains secure while allowing required first-party UI behavior.
+- The old `WebLayout` header no longer appears on migrated public pages unless intentionally retained for a non-public/internal surface.

--- a/docs/plans/gs-shell-ui-migration.md
+++ b/docs/plans/gs-shell-ui-migration.md
@@ -1,0 +1,322 @@
+# Gold Shore Shell UI Migration Plan
+
+## Goal
+
+Unify the homepage and subpage experience so all public Gold Shore routes share one visual system, navigation model, footer, modal layer, interaction script, and link map.
+
+The current homepage has the desired GS LAB identity and interaction model. Several subpages still use an older layout system. This plan outlines a safe, phased migration without losing current page content or reference assets.
+
+## Current problem
+
+The site currently has two UI systems.
+
+### Homepage system
+
+Key files:
+
+```text
+apps/gs-web/src/pages/index.astro
+apps/gs-web/src/styles/home-theme.css
+```
+
+This system owns the current homepage identity:
+
+- coordinates header
+- GS LAB brand mark
+- Applied Intelligence hero
+- homepage cards
+- telemetry sections
+- marquee
+- Risk Radar preview
+- financial signal preview
+- contact section
+- homepage-specific CSS and JavaScript behavior
+
+### Subpage system
+
+Key files:
+
+```text
+apps/gs-web/src/layouts/WebLayout.astro
+apps/gs-web/src/styles/global.css
+```
+
+Many subpages import `WebLayout`, which means they do not inherit the homepage shell, homepage CSS, modal behavior, cursor effects, reveal effects, or homepage nav/footer model.
+
+## Non-goals
+
+- Do not delete old static files without an archived copy.
+- Do not expose secrets or platform credentials in browser code.
+- Do not migrate every page in one risky PR.
+- Do not weaken security headers globally just to make interactions work.
+- Do not rewrite page content unless the page is intentionally being redesigned.
+
+## Phase 0 — Inventory and guardrails
+
+### Inspect pages still using old layout
+
+```bash
+grep -R "import WebLayout" -n apps/gs-web/src/pages apps/gs-web/src/layouts
+```
+
+### Inspect public files that may override Astro pages
+
+```bash
+find apps/gs-web/public -type f | sort
+```
+
+### Inspect build logs for route collisions
+
+```bash
+gh run view <RUN_ID> --log | grep -Ei 'Skipping src/pages|public folder|index.html'
+```
+
+### Acceptance criteria
+
+- All layout usage is known.
+- All public-file route collisions are known.
+- Static files are archived before being moved out of routable paths.
+
+## Phase 1 — Archive static route collisions
+
+Astro can skip a source page when a matching output file exists under `public/`.
+
+Move colliding static files into a non-routable archive folder:
+
+```text
+apps/gs-web/public/_archived-static/
+```
+
+Acceptance criteria:
+
+- Current Astro homepage owns the root page.
+- Migrated Astro routes are not skipped during build.
+- Old static files remain available for reference.
+
+## Phase 2 — Create shared shell files
+
+Create:
+
+```text
+apps/gs-web/src/layouts/GoldShoreShell.astro
+apps/gs-web/src/styles/gs-shell.css
+apps/gs-web/src/scripts/gs-shell.js
+```
+
+### `GoldShoreShell.astro`
+
+Responsibilities:
+
+- page metadata defaults
+- shared font loading
+- GS LAB body class
+- coordinates header
+- brand mark
+- primary navigation
+- Access modal slot or component
+- Request Briefing CTA
+- shared footer
+- slot for page content
+- shared script include
+
+### `gs-shell.css`
+
+Responsibilities:
+
+- shared CSS variables
+- header and navigation
+- buttons and links
+- footer
+- modal shell
+- cards and panels
+- reveal utilities
+- magnetic hover utility
+- responsive menu styling
+- shared background/cursor treatments
+
+### `gs-shell.js`
+
+Responsibilities:
+
+- mobile nav open and close
+- Access modal open and close
+- Escape key behavior
+- click-outside behavior
+- reveal-on-scroll behavior
+- magnetic hover behavior
+- optional cursor or starfield behavior
+
+Acceptance criteria:
+
+- A basic page can render through `GoldShoreShell`.
+- Header, footer, nav, modal, and shared interactions work without homepage-only assumptions.
+- The script is safe to run on every public page.
+
+## Phase 3 — Refactor homepage into shared shell
+
+Convert the homepage from a full standalone document into content rendered inside `GoldShoreShell`.
+
+Keep homepage-only sections in `index.astro`:
+
+- hero content
+- metrics
+- deployment surface
+- telemetry
+- marquee
+- capabilities
+- under-the-hood section
+- Risk Radar preview
+- financial signals preview
+- approach section
+- engage form body
+
+Acceptance criteria:
+
+- Homepage still visually matches the desired GS LAB design.
+- Homepage title and meta still reflect Applied Intelligence.
+- Hero still reads `Where Strategy Operates.`
+- Access modal opens.
+- Request Briefing CTA works.
+- Homepage-specific styling remains available.
+
+## Phase 4 — Migrate Risk Radar first
+
+Target:
+
+```text
+apps/gs-web/src/pages/risk-radar.astro
+```
+
+Plan:
+
+- Replace `WebLayout` with `GoldShoreShell`.
+- Keep Risk Radar content intact.
+- Add only page-specific CSS where needed.
+- Confirm page CTAs use the shared link map.
+- Archive any static file that overrides the Astro route.
+
+Acceptance criteria:
+
+- Risk Radar uses the GS LAB header and footer.
+- Risk Radar content remains intact.
+- Modals and navigation work.
+- Build logs do not show the page being skipped due to a public-file collision.
+
+## Phase 5 — Migrate platform and service pages
+
+Targets:
+
+```text
+apps/gs-web/src/pages/platform/*.astro
+apps/gs-web/src/pages/services/*.astro
+```
+
+Acceptance criteria:
+
+- Migrated pages use the shared shell.
+- Content is preserved.
+- CTAs and links route consistently.
+- Mobile navigation and modal behavior work.
+
+## Phase 6 — Normalize link map
+
+Create a shared navigation config:
+
+```text
+apps/gs-web/src/config/navigation.ts
+```
+
+Suggested groups:
+
+- public pages
+- platform pages
+- services
+- developer resources
+- operational surfaces
+- legal/footer links
+
+Acceptance criteria:
+
+- Header and footer use one source of truth.
+- Homepage and subpages use the same nav labels and destinations.
+- Operational links are deliberate and documented.
+
+## Phase 7 — Add CI collision guard
+
+Add a script that fails the build when a public static file conflicts with an Astro route.
+
+Suggested file:
+
+```text
+apps/gs-web/scripts/check-public-route-collisions.js
+```
+
+Acceptance criteria:
+
+- CI fails before deploy if a public file would override an Astro route.
+- Error message lists conflicting files.
+- Archived static files are ignored.
+
+## Phase 8 — Security and interaction review
+
+Review:
+
+```text
+apps/gs-web/src/security/policy.ts
+apps/gs-web/src/utils/csp.ts
+apps/gs-web/src/middleware.ts
+apps/gs-web/public/_headers
+```
+
+Goals:
+
+- Keep browser policy strict.
+- Prefer external first-party JavaScript for shared shell behavior.
+- Do not expose secrets in client code.
+- Permit only required first-party connections.
+
+Acceptance criteria:
+
+- Shared modals and scripts work on Astro-rendered pages.
+- Static routes do not require broad inline-script allowances.
+- Sensitive calls remain server-side.
+
+## Verification checklist
+
+After each migration PR:
+
+```bash
+# Build and deploy
+gh workflow run deploy-gs-web.yml --ref main
+WEB=$(gh run list --workflow "Deploy gs-web" --branch main --limit 1 --json databaseId -q '.[0].databaseId')
+gh run watch "$WEB"
+
+# Check build warnings
+gh run view "$WEB" --log | grep -Ei 'Skipping src/pages|public folder|error|warn' | tail -120
+
+# Check expected homepage markers
+curl -sL "https://goldshore.ai/?v=$(date +%s)" \
+  | grep -Ei 'Applied Intelligence|Where|Strategy|Request Briefing' \
+  | head -40
+```
+
+## Rollout order
+
+1. Repository README map PR.
+2. This planning PR.
+3. Public route collision guard PR.
+4. Shared shell PR.
+5. Homepage shell refactor PR.
+6. Risk Radar migration PR.
+7. Platform page migration PR.
+8. Service page migration PR.
+9. Link-map and security cleanup PR.
+
+## Final success state
+
+- All public pages use one Gold Shore shell.
+- Homepage visual identity carries into subpages.
+- Modals, nav, CTAs, and interactions work consistently.
+- Static public files no longer override Astro pages.
+- Operational links are centralized and intentional.
+- Browser policy remains secure while allowing required first-party UI behavior.


### PR DESCRIPTION
## Summary
- Expands the root README into a repository operations map for humans and agents.
- Adds a truthful text diagram for the Gold Shore runtime surface.
- Documents current app locations, deploy workflows, route-collision risks, homepage/subpage styling split, and verification commands.
- Adds shared public navigation config groundwork.
- Preserves the Penrose / GS LAB visual direction as documented intent, while keeping implementation notes tied to actual repository paths and current migration status.

## Scope
Documentation and navigation-map groundwork only. No Cloudflare route changes or production deploy changes are made here.

## Files changed
- `README.md`
- `docs/plans/gs-shell-ui-migration.md`
- `apps/gs-web/src/config/navigation.ts`

## Validation
Not run in connector. Recommended checks before merge:
```bash
git status --short
pnpm --filter @goldshore/gs-web build
find apps/gs-web/public -type f | sort
gh run view <run-id> --log | grep -Ei 'Skipping src/pages|public folder|index.html'
```

## Merge notes
This is safe to review as documentation first. Runtime UI migration should remain a separate PR so homepage styling, subpage layout changes, and Cloudflare routing are not mixed into one ambiguous merge.