### PR TITLE
[codex] update GoldShore menu page audit items

### DIFF
--- a/apps/gs-web/src/pages/about.astro
+++ b/apps/gs-web/src/pages/about.astro
@@ -30,14 +30,18 @@ const sections = [
 
 <BaseLayout
   title="About | GoldShore"
-  description="How GoldShore designs and delivers operational AI systems."
-  canonicalPath="/about"
-  ogTitle="About GoldShore | Operators Behind Mission-Critical AI"
-  ogDescription="Learn how GoldShore works, what we build, and why high-trust teams use our systems-first delivery model."
+  description="GoldShore is a New York-based digital agency for practical web design, purpose-built SaaS apps, AI model integration, and reliable execution."
+  canonicalPath="/about/"
+  ogTitle="About GoldShore | Practical Web, SaaS, and AI Delivery"
+  ogDescription="Learn how GoldShore works, what we build, and why operators use our systems-first delivery model."
 >
   <section class="page-shell gs-shell-section info-page">
     <p class="gs-eyebrow">About</p>
-    <h1>A practical operating model for high-stakes AI delivery.</h1>
+    <h1>A practical operating model for high-stakes digital delivery.</h1>
+    <p class="page-intro">
+      GoldShore is a New York-based digital agency for practical web design, purpose-built SaaS apps,
+      and AI model integration services. Keep up with a world evolving faster than you might think.
+    </p>
     <p class="page-intro">
       GoldShore helps decision-makers move from strategy to reliable execution with systems that stay clear,
       auditable, and usable under pressure.

--- a/apps/gs-web/src/pages/team.astro
+++ b/apps/gs-web/src/pages/team.astro
@@ -15,8 +15,9 @@ export const prerender = true;
         <h3>Robert M.</h3>
         <p>Leads product direction, systems strategy, and applied intelligence.</p>
         <div class="social-links">
-          <a href="#" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-          <a href="#" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://www.linkedin.com/in/r-marston" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+          <a href="https://github.com/marzton" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://rmarston.com" target="_blank" rel="noopener noreferrer">Website</a>
         </div>
       </div>
 
@@ -87,6 +88,7 @@ export const prerender = true;
       display: flex;
       gap: 0.75rem;
       margin-top: 1rem;
+      flex-wrap: wrap;
     }
 
     .social-links a {

--- a/docs/goldshore-menu-pages-update-ack.md
+++ b/docs/goldshore-menu-pages-update-ack.md
@@ -1,0 +1,50 @@
+# GoldShore menu pages update acknowledgement
+
+Date: 2026-06-30
+
+## Acknowledged scope
+
+This branch acknowledges the latest GitHub audit and update request for the GoldShore menu pages and related routing surfaces.
+
+Covered menu areas:
+
+- About
+- Team
+- Book Strategy Call / Intake
+- Contact
+- Risk Radar
+- Developer Hub
+- Navigation and layout shell behavior
+- Footer subscribe / lead capture planning
+
+## PR-1 implementation scope
+
+This PR focuses on low-risk fixes that can land before the larger shell migration:
+
+1. Refine About positioning with the requested New York digital agency language.
+2. Replace broken Team social placeholders with real public links where values are known.
+3. Document that the LinkedIn URL should be verified before final publishing.
+4. Preserve the shell migration, Risk Radar app upgrade, and subscription workflow as follow-up PRs.
+
+## Confirmed issues from audit
+
+- Menu pages currently inherit `WebLayout` through `BaseLayout` / `MarketingLayout`, so they do not yet match the homepage GS LAB visual shell.
+- `WebLayout.astro` still contains the older top-level `Book Strategy Call` navigation item.
+- `contact.astro` contains duplicate `id="inquiry" name="inquiry"` select controls and should be cleaned in the contact bugfix path.
+- `/risk-radar/` should remain the polished marketing page.
+- `/apps/risk-radar/` should be treated as the interactive app/demo route and upgraded separately.
+- Footer subscribe should use explicit consent and company-level / public firmographic enrichment only.
+
+## Follow-up PR sequence
+
+1. Contact form bugfix: remove duplicate inquiry select, expand allowed inquiry values, and confirm `/api/contact` storage behavior.
+2. Navigation cleanup: rename `Book Strategy Call` to `Intake` or move it into the Contact/Intake CTA flow.
+3. Shell migration: create a shared homepage-style GoldShore shell and migrate menu pages into it.
+4. Risk Radar route cleanup: keep `/risk-radar/` as product page and upgrade `/apps/risk-radar/` as demo app.
+5. Subscription workflow: add footer subscribe, `/api/subscribe`, consent storage, unsubscribe path, and later CRM/Zapier/Google/Meta workflows.
+
+## Notes
+
+- GitHub: `https://github.com/marzton`
+- Website: `https://rmarston.com`
+- LinkedIn: likely value noted in audit, but verify before publishing.


### PR DESCRIPTION
## Summary

This draft PR starts the GoldShore menu page audit updates against `marzton/goldshore-ai` / `apps/gs-web`.

## Changes

- Refines the About page positioning and canonical path.
- Replaces broken Team social placeholders with public links.
- Adds an acknowledgement document covering requested menu-page updates and follow-up order.

## Follow-up items

- Remove the duplicate Contact inquiry select.
- Rename `Book Strategy Call` to `Intake` or move it into the Contact flow.
- Migrate menu pages into the homepage-style shell.
- Clean up Risk Radar marketing/app routes.
- Add the footer subscribe workflow with consent and unsubscribe support.

## Validation

Files were updated through the GitHub connector. Local build validation was not available in this session.