### PR TITLE
feat(gs-web): cross-site UX alignment — logo, nav, fonts, team, contact form

### DIFF
--- a/apps/gs-web/src/layouts/GoldShoreShell.astro
+++ b/apps/gs-web/src/layouts/GoldShoreShell.astro
@@ -7,6 +7,8 @@ const navLinks = [
   { href: '/services/', label: 'Services' },
   { href: '/developer/', label: 'Developer' },
   { href: '/about/', label: 'About' },
+  { href: '/team/', label: 'Team' },
+  { href: '/contact/', label: 'Contact' },
 ];
 
 const footerColumns = [
@@ -17,6 +19,7 @@ const footerColumns = [
       { href: '/platform/financial-signals', label: 'Financial Signals' },
       { href: '/platform/workflow-engine', label: 'Workflow Engine' },
       { href: '/platform/sentinel', label: 'Sentinel' },
+      { href: '/platform/ai-oracle', label: 'AI Oracle' },
     ],
   },
   {
@@ -26,6 +29,7 @@ const footerColumns = [
       { href: '/services/ai-implementation', label: 'AI Implementation' },
       { href: '/services/systems-integration', label: 'Systems Integration' },
       { href: '/services/design-dev', label: 'Design & Development' },
+      { href: '/services/consulting', label: 'Enterprise Consulting' },
     ],
   },
   {
@@ -34,6 +38,7 @@ const footerColumns = [
       { href: '/about/', label: 'About' },
       { href: '/team/', label: 'Team' },
       { href: '/developer/', label: 'Developer Hub' },
+      { href: '/status/', label: 'Status' },
       { href: '/contact/', label: 'Contact' },
     ],
   },

--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -89,15 +89,6 @@ export const prerender = true;
       </div>
 
       <div class="gs-input-group">
-        <label for="inquiry">Inquiry type</label>
-        <select id="inquiry" name="inquiry" autocomplete="off">
-          <option value="general">General inquiry</option>
-          <option value="strategy-call">Strategy call</option>
-          <option value="project-scope">Project scoping</option>
-          <option value="support">Support</option>
-        </select>
-      </div>
-      <div class="gs-input-group">
         <label for="message">Project brief</label>
         <p id="message-help" class="field-help">
           Share a short summary of your goals, timeline, and budget. We read

--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -44,10 +44,8 @@ const marquee   = ['Risk Intelligence','Financial Signal Analysis','Workflow Aut
 <canvas id="starfield" aria-hidden="true"></canvas>
 
 <header class="topbar">
-  <a class="brand" href="/">
-    <span class="coords">40°42′45″N<br />74°00′21″W</span>
-    <span class="mark">GS·LAB·v2.84</span>
-    <span><strong>Gold Shore Labs</strong><em>GoldShore</em></span>
+  <a class="brand" href="/" aria-label="GoldShore home">
+    <span class="brand-wordmark">GOLDSHORE</span>
   </a>
   <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
     <span></span><span></span><span></span>

--- a/apps/gs-web/src/pages/team.astro
+++ b/apps/gs-web/src/pages/team.astro
@@ -22,8 +22,12 @@ export const prerender = true;
       </div>
 
       <div class="card">
-        <h3>Systems</h3>
-        <p>Infrastructure, execution, observability.</p>
+        <h3>Nicholas B.</h3>
+        <p>Systems architecture, infrastructure engineering, and operational reliability.</p>
+        <div class="social-links">
+          <a href="#" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+          <a href="#" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </div>
       </div>
 
       <div class="card">

--- a/apps/gs-web/src/styles/global.css
+++ b/apps/gs-web/src/styles/global.css
@@ -5,9 +5,9 @@
 
 :root {
   --font-sans:
-    'Space Grotesk', 'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
+    'DM Sans', 'Inter', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica,
     Arial, 'Apple Color Emoji', 'Segoe UI Emoji';
-  --gs-bg: #050507;
+  --gs-bg: #06060a;
   --gs-surface: rgba(14, 16, 20, 0.84);
   --gs-surface-strong: rgba(20, 23, 29, 0.94);
   --gs-border: rgba(255, 120, 54, 0.14);
@@ -28,8 +28,8 @@
   --gs-radius-lg: 32px;
   --gs-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
   --gs-max-width: 1200px;
-  --gs-font-display: 'Space Grotesk', 'Inter', system-ui, sans-serif;
-  --gs-font-body: 'Inter', system-ui, sans-serif;
+  --gs-font-display: 'Syne', 'DM Sans', system-ui, sans-serif;
+  --gs-font-body: 'DM Sans', 'Inter', system-ui, sans-serif;
 }
 
 html {

--- a/apps/gs-web/src/styles/home-theme.css
+++ b/apps/gs-web/src/styles/home-theme.css
@@ -92,47 +92,16 @@ main { display: grid; gap: 1px; position: relative; z-index: 1; }
 .brand {
   display: flex;
   align-items: center;
-  gap: 1rem;
   text-decoration: none;
 }
 
-.coords {
-  font-family: var(--font-mono);
-  font-size: 0.52rem;
-  color: var(--t3);
-  line-height: 1.35;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.mark {
-  font-family: var(--font-mono);
-  padding: 0.48rem 0.64rem;
-  border: 1px solid var(--ox-border);
-  color: var(--ox);
-  font-size: 0.62rem;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.brand strong {
-  display: block;
+.brand-wordmark {
   font-family: var(--font-display);
-  font-size: 0.9rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: 1.15rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--t1);
-}
-
-.brand em {
-  display: block;
-  font-family: var(--font-mono);
-  color: var(--t3);
-  font-style: normal;
-  font-size: 0.65rem;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
 }
 
 .topbar nav {


### PR DESCRIPTION
## Summary

- **Logo**: Home page header simplified to clean `GOLDSHORE` wordmark (bold white, uppercase, Syne 800) — matches footer `<h2>GoldShore</h2>` style; removed legacy coords/mark/brand-em markup
- **Nav alignment**: `GoldShoreShell.astro` nav now includes Team and Contact links, matching the home page topbar
- **Footer completeness**: Added missing entries — AI Oracle (Platform column), Enterprise Consulting (Services column), Status (Company column)
- **Font consistency**: `global.css` CSS variables updated to use Syne/DM Sans/DM Mono (matching `home-theme.css`); previously used Space Grotesk/Inter causing visual mismatch on sub-pages
- **Contact form**: Removed duplicate `<select id="inquiry" name="inquiry">` block that caused duplicate field rendering
- **Team page**: Added Nicholas B. card (systems architecture, infrastructure engineering) between Robert M. and the Risk placeholder

## Files changed

| File | Change |
|------|--------|
| `apps/gs-web/src/layouts/GoldShoreShell.astro` | Added Team + Contact nav links; footer AI Oracle, Enterprise Consulting, Status |
| `apps/gs-web/src/pages/contact.astro` | Removed duplicate inquiry select field |
| `apps/gs-web/src/pages/index.astro` | Logo: `coords/mark/brand-em` → `brand-wordmark` span |
| `apps/gs-web/src/pages/team.astro` | Added Nicholas B. card |
| `apps/gs-web/src/styles/global.css` | Font vars: Space Grotesk/Inter → Syne/DM Sans; `--gs-bg` aligned to `#06060a` |
| `apps/gs-web/src/styles/home-theme.css` | Old brand CSS removed; `.brand-wordmark` added |

## Test plan

- [ ] Home page logo renders as bold white GOLDSHORE wordmark (no coordinates, no monospace mark)
- [ ] Sub-pages (team, contact, risk-radar, platform, services) use Syne headings, DM Sans body — visually match home page
- [ ] Nav on sub-pages shows Team and Contact links
- [ ] Footer on sub-pages shows AI Oracle, Enterprise Consulting, Status
- [ ] Contact form has single inquiry dropdown (not duplicated)
- [ ] Team page shows Robert M., Nicholas B., and Risk placeholder
- [ ] Mobile layout at 375px — nav, columns, footer stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5

---
_Generated by [Claude Code](https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5)_