### PR TITLE
Revamp header branding and styles; add DM Mono font

### DIFF
--- a/apps/gs-web/src/layouts/WebLayout.astro
+++ b/apps/gs-web/src/layouts/WebLayout.astro
@@ -58,7 +58,7 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700;800&family=DM+Mono:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
     <link rel="manifest" href="/site.webmanifest"/>
@@ -68,8 +68,10 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
     <div class="gs-page-shell">
       <header class="header" data-menu-open="false">
         <div class="header__inner">
-          <a href="/" class="gs-logo-link" aria-label="Gold Shore home">
-            <Logo class="gs-logo gs-logo--lockup" title="Gold Shore" variant="lockup" />
+          <a href="/" class="header-brand" aria-label="Gold Shore home">
+            <span class="header-brand__coords">40°42′45″N<br />74°00′21″W</span>
+            <span class="header-brand__mark">GS·LAB·v2.84</span>
+            <span class="header-brand__lockup"><strong>Gold Shore Labs</strong><em>GoldShore</em></span>
           </a>
 
           <nav class="desktop-nav" aria-label="Primary navigation">
@@ -100,12 +102,9 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
         <nav id={mobileNavId} class="menu-panel" aria-label="Mobile navigation">
           <div class="menu-panel__inner">
             <div class="menu-panel__header">
-              <a href="/" class="gs-logo-link gs-logo-link--mobile" aria-label="GoldShore home">
-                <Logo class="gs-logo" title="GoldShore" />
-                <div class="brand-lockup">
-                  <strong>GoldShore</strong>
-                  <span>Institutional AI systems</span>
-                </div>
+              <a href="/" class="header-brand header-brand--mobile" aria-label="GoldShore home">
+                <span class="header-brand__mark">GS·LAB</span>
+                <span class="header-brand__lockup"><strong>Gold Shore Labs</strong><em>Institutional AI systems</em></span>
               </a>
               <button class="menu-close" type="button" aria-label="Close navigation">×</button>
             </div>
@@ -260,65 +259,81 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
         position: sticky;
         top: 0;
         z-index: 1100;
-        padding-inline: clamp(1rem, 3vw, 2rem);
-        backdrop-filter: blur(16px);
-        -webkit-backdrop-filter: blur(16px);
-        background: rgba(5, 5, 7, 0.82);
+        padding: 1rem clamp(1rem, 3vw, 3rem);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        background: rgba(6, 6, 10, 0.88);
         border-bottom: 1px solid rgba(255, 255, 255, 0.06);
       }
 
       .header__inner {
-        width: min(100%, var(--gs-max-width));
-        min-height: 5rem;
+        width: min(100%, 1440px);
         margin: 0 auto;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        gap: 1rem;
+        gap: 2rem;
       }
 
-      .gs-logo-link {
-        display: inline-flex;
+      .header-brand {
+        display: flex;
         align-items: center;
-        gap: 0.8rem;
+        gap: 1rem;
+        color: var(--gs-text);
         text-decoration: none;
+        min-width: 0;
       }
 
-      .gs-logo {
-        width: clamp(24px, 3vw, 36px);
-        height: auto;
-        color: var(--gs-primary);
-        flex-shrink: 0;
-      }
-
-      .gs-logo--lockup {
-        width: clamp(220px, 24vw, 320px);
-      }
-
-      .gs-logo--footer {
-        width: 28px;
-      }
-
-      .brand-lockup {
-        display: grid;
-        gap: 0.1rem;
-      }
-
-      .brand-lockup strong {
-        font-size: 0.98rem;
-        letter-spacing: 0.14em;
-        text-transform: uppercase;
-      }
-
-      .brand-lockup span {
+      .header-brand__coords {
         color: var(--gs-text-dim);
-        font-size: 0.77rem;
-        letter-spacing: 0.06em;
+        font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.52rem;
+        letter-spacing: 0.09em;
+        line-height: 1.35;
         text-transform: uppercase;
       }
 
-      .brand-lockup--footer span {
-        max-width: 28ch;
+      .header-brand__mark {
+        flex-shrink: 0;
+        padding: 0.48rem 0.64rem;
+        border: 1px solid rgba(217, 106, 50, 0.28);
+        color: var(--gs-primary);
+        font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.62rem;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+      }
+
+      .header-brand__lockup {
+        display: block;
+        min-width: 0;
+      }
+
+      .header-brand__lockup strong {
+        display: block;
+        color: var(--gs-text);
+        font-family: 'Space Grotesk', 'Inter', system-ui, sans-serif;
+        font-size: 0.9rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        line-height: 1.2;
+        text-transform: uppercase;
+        white-space: nowrap;
+      }
+
+      .header-brand__lockup em {
+        display: block;
+        color: var(--gs-text-dim);
+        font-family: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 0.65rem;
+        font-style: normal;
+        letter-spacing: 0.09em;
+        line-height: 1.35;
+        text-transform: uppercase;
+      }
+
+      .header-brand--mobile {
+        flex: 1;
       }
 
       .desktop-nav {
@@ -607,10 +622,6 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
         .menu-button {
           display: inline-grid;
         }
-
-        .gs-logo--lockup {
-          width: clamp(190px, 44vw, 260px);
-        }
       }
 
       @media (max-width: 720px) {
@@ -618,8 +629,16 @@ const shouldRenderCspMeta = !Astro.locals.securityPolicySource;
           padding-inline: 0.8rem;
         }
 
-        .brand-lockup span {
-          font-size: 0.72rem;
+        .header-brand__coords {
+          display: none;
+        }
+
+        .header-brand__lockup strong {
+          font-size: 0.78rem;
+        }
+
+        .header-brand__lockup em {
+          font-size: 0.58rem;
         }
 
         .menu-panel__header {


### PR DESCRIPTION
### Motivation
- Refresh the site header/brand presentation with a textual lockup and metadata in place of the previous `Logo` component to support expanded branding needs.
- Include a monospace font for coordinate and microcopy treatment to improve legibility and visual hierarchy.
- Improve header layout, spacing, and backdrop behavior to better match updated design and responsive constraints.

### Description
- Add `DM Mono` to the Google Fonts import and keep existing `Space Grotesk` and `Inter` families by updating the fonts `<link>` href.
- Replace usages of the `Logo` component with a new `.header-brand` markup containing `header-brand__coords`, `header-brand__mark`, and `header-brand__lockup` elements for desktop and mobile variants.
- Update mobile header markup to use `.header-brand--mobile` and adjust copy to include the institutional descriptor previously shown in the lockup.
- Adjust CSS for the header including padding, backdrop blur, background color, header inner width, spacing, and add styles for the new `.header-brand*` classes and responsive tweaks while removing the old `.gs-logo*` and `.brand-lockup` rules.

### Testing
- Ran a production build via `pnpm build` and the build completed successfully.
- Ran linting via `pnpm lint` and no lint errors were reported.
- Ran the unit/integration test suite via `pnpm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a442fb068c88331be79c1006fba789a)