### PR TITLE
Align api.goldshore.ai route with Goldshore API Access audience

### DIFF
--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -7,6 +7,7 @@ workers_dev = false
 
 [env.prod]
 routes = [
+  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 

--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -28,7 +28,6 @@ queue = "gs-platform-contact-events-dev"
 routes = [
   { pattern = "gw.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "dashboard.goldshore.ai", custom_domain = true }
 ]
 

--- a/infra/INFRASTRUCTURE.md
+++ b/infra/INFRASTRUCTURE.md
@@ -96,7 +96,7 @@
 | `www.goldshore.ai` | `gs-www-redirect` | 1 (public) | 308 → goldshore.ai |
 | `dashboard.goldshore.ai` | `gs-gateway` | 1 (public) | 308 → admin.goldshore.ai |
 | `gw.goldshore.ai` | `gs-gateway` | 2 (auth) | Fail closed |
-| `api.goldshore.ai` | `gs-gateway` → `gs-api` | 2 (auth) | Fail closed; /health /version /status public |
+| `api.goldshore.ai` | `gs-api` | 2 (auth) | Fail closed; /health /version /status public; route must stay on the API Worker while it validates the API Access AUD |
 | `agent.goldshore.ai` | `gs-gateway` → `gs-agent` | 2 (auth) | Fail closed |
 | `trading.goldshore.ai` | `gs-trading` | 3 (admin) | Fail closed |
 | `ops.goldshore.ai` | `gs-control` | 3 (admin) | Fail closed |


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Prevent tokens minted for the `Goldshore API` audience from being presented to the `gs-gateway` route owner, which would cause audience validation failures for protected API paths. 
- Ensure the route owner for `api.goldshore.ai` is the same Worker that validates the preserved API Access AUD so protected requests are accepted.

### Description
- Move the production `api.goldshore.ai/*` route out of `gs-gateway` and into `gs-api` by updating `apps/gs-gateway/wrangler.toml` and `apps/gs-api/wrangler.toml`. 
- Update `infra/INFRASTRUCTURE.md` to document that `api.goldshore.ai` must remain on the API Worker while it validates the API Access audience. 
- Leave the `Goldshore API` Access application and its audience value intact in `infra/Cloudflare/desired-state.yaml` so the API AUD is preserved.

### Testing
- Ran `git diff --check` which completed successfully. 
- Parsed `apps/gs-api/wrangler.toml` and `apps/gs-gateway/wrangler.toml` with `tomllib` which succeeded. 
- Parsed `infra/Cloudflare/desired-state.yaml` with `ruby -e 'require "yaml"; YAML.load_file(...)'` which succeeded and confirmed the `Goldshore API` policy and `audience` value remain present. 
- Executed a Node guard script that verified `gs-api` claims `api.goldshore.ai`, `gs-gateway` no longer claims it, and the desired-state API Access app/audience are present, and the script passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a972dec3c83319b1f769667b048f2)