### PR TITLE
Document gs-api route ownership in gateway config

### DIFF
--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -26,6 +26,7 @@ queue = "gs-platform-contact-events-dev"
 # status.goldshore.ai is reserved for gs-status Pages project (MODULE_B2_RUNTIME_WIRING.md)
 # dashboard.goldshore.ai uses custom_domain to auto-provision DNS
 # agent.goldshore.ai/* is gateway-owned and forwarded to gs-agent through the AGENT service binding.
+# api.goldshore.ai/* is owned by gs-api; do not add it here or Wrangler deploys will conflict.
 routes = [
   { pattern = "gw.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Prevent Wrangler deploy conflicts caused by accidental duplicate ownership of the `api.goldshore.ai/*` production route when the deploy-platform job runs a worker matrix.

### Description
- Add a clarifying comment to `apps/gs-gateway/wrangler.toml` noting that `api.goldshore.ai/*` is owned by `gs-api` and must not be added to the gateway config. The change is a single-line documentation update in the production `routes` block.

### Testing
- Ran a repository-wide TOML route-ownership check (`python` + `tomllib` script) that verifies no duplicate production route patterns across `apps/*/wrangler.toml`, and it succeeded.  
- Ran `git diff --check` to validate the change and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a972b39bc8331b1b612b6a2bc0bc6)