### PR TITLE
Fix reusable-workflow token masking, restore Astro render helper, and normalize docs slugs

### DIFF
--- a/.github/workflows/anthropic-oidc.yml
+++ b/.github/workflows/anthropic-oidc.yml
@@ -89,7 +89,8 @@ jobs:
             TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty' 2>/dev/null || echo "")
 
             if [[ -n "$TOKEN" ]]; then
-              echo "::add-mask::$TOKEN"
+              # Do not mask values promoted to reusable-workflow outputs: GitHub
+              # suppresses masked job outputs as unsafe for downstream jobs.
               echo "api_key=$TOKEN" >> "$GITHUB_OUTPUT"
               echo "base_url=$GATEWAY_BASE" >> "$GITHUB_OUTPUT"
               echo "Issued gateway-scoped token (OIDC exchange succeeded)"
@@ -105,7 +106,8 @@ jobs:
             echo "::error::Neither CF_AI_GATEWAY_ID+OIDC nor ANTHROPIC_API_KEY is configured."
             exit 1
           fi
-          echo "::add-mask::$ANTHROPIC_API_KEY_FALLBACK"
+          # Do not mask values promoted to reusable-workflow outputs: GitHub
+          # suppresses masked job outputs as unsafe for downstream jobs.
           echo "api_key=$ANTHROPIC_API_KEY_FALLBACK" >> "$GITHUB_OUTPUT"
           echo "base_url=https://api.anthropic.com" >> "$GITHUB_OUTPUT"
           echo "Using fallback direct key (base_url=api.anthropic.com)"

--- a/apps/gs-web/src/components/DocsSidebar.astro
+++ b/apps/gs-web/src/components/DocsSidebar.astro
@@ -8,6 +8,10 @@ const pages = await getCollection('docs');
 // Sort by optional "order" key
 pages.sort((a, b) => (a.data.order ?? 999) - (b.data.order ?? 999));
 
+function getDocSlug(id: string) {
+  return id.replace(/\.(md|mdx)$/, '');
+}
+
 function getHref(slug: string) {
   return slug === 'index' ? '/developer/docs' : `/developer/docs/${slug}`;
 }
@@ -23,9 +27,9 @@ function getHref(slug: string) {
     {pages.map((page) => (
       <li>
         <a
-          href={getHref(page.slug)}
-          class={currentSlug === page.slug ? 'active' : ''}
-          aria-current={currentSlug === page.slug ? 'page' : undefined}
+          href={getHref(getDocSlug(page.id))}
+          class={currentSlug === getDocSlug(page.id) ? 'active' : ''}
+          aria-current={currentSlug === getDocSlug(page.id) ? 'page' : undefined}
         >
           {page.data.title}
         </a>

--- a/apps/gs-web/src/layouts/DocsLayout.astro
+++ b/apps/gs-web/src/layouts/DocsLayout.astro
@@ -4,7 +4,7 @@ import DocsSidebar from '../components/DocsSidebar.astro';
 import DocsSearch from '../components/DocsSearch.astro';
 
 const { title, page, canonicalPath, ogTitle, ogDescription } = Astro.props;
-const currentSlug = page ? page.slug : undefined;
+const currentSlug = page ? page.id.replace(/\.(md|mdx)$/, '') : undefined;
 ---
 
 <WebLayout

--- a/apps/gs-web/src/pages/developer/docs/[...slug].astro
+++ b/apps/gs-web/src/pages/developer/docs/[...slug].astro
@@ -1,20 +1,24 @@
 ---
 import DocsLayout from '../../../layouts/DocsLayout.astro';
 import MDXCodeBlock from '../../../components/MDXCodeBlock.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
+
+function getDocSlug(id: string) {
+  return id.replace(/\.(md|mdx)$/, '');
+}
 
 export const prerender = true;
 
 export async function getStaticPaths() {
   const pages = await getCollection('docs');
   return pages.map((p) => ({
-    params: { slug: p.slug },
+    params: { slug: getDocSlug(p.id) },
     props: { page: p }
   }));
 }
 
 const { page } = Astro.props;
-const { Content } = await page.render();
+const { Content } = await render(page);
 ---
 
 <DocsLayout title={`${page.data.title} – GoldShore Docs`} page={page}>


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Ensure reusable workflow outputs (`api_key`/`base_url`) are not masked so downstream callers using `needs.<job>.outputs.api_key` receive values.  
- Restore correct Astro docs rendering to fix the generated docs pages build error caused by using a non-existent `render()` instance.  
- Normalize content entry ids so sidebar/route generation uses stable slugs and the docs sidebar/current-page logic works with the generated content entry shape.

### Description
- Remove `::add-mask::` calls and instead write the gateway token and fallback key directly to `$GITHUB_OUTPUT` in `/.github/workflows/anthropic-oidc.yml` so promoted reusable-workflow outputs are not suppressed.  
- Revert to using Astro's content render helper by importing `render` from `astro:content` and replacing `await page.render()` with `await render(page)` in `apps/gs-web/src/pages/developer/docs/[...slug].astro`.  
- Add a `getDocSlug` helper and switch docs routing/sidebar code to use `page.id` → normalized slug (strip `.md/.mdx`) in `apps/gs-web/src/components/DocsSidebar.astro` and `apps/gs-web/src/layouts/DocsLayout.astro` so generated routes and active state match the content entries.  
- Update affected files and commit the follow-up fixes associated with the original PR changes.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/anthropic-oidc.yml'); puts 'parsed .github/workflows/anthropic-oidc.yml'"` which parsed the workflow file successfully.  
- Ran `pnpm exec wrangler deploy --config apps/gs-api/wrangler.toml --env prod --dry-run` which completed the dry-run and showed production bindings (including `class_name`) as expected.  
- Ran `pnpm --filter @goldshore/gs-web exec astro check` and verified the targeted diagnostics (`page.render()` usage and docs `slug` mapping) are cleared, while the command still reports unrelated existing diagnostics elsewhere in the `gs-web` project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a973e0db48331abe4ffb68cfa081d)