### PR TITLE
Fix branch protection workflow token

### DIFF
--- a/.github/workflows/enforce-branch-protection.yml
+++ b/.github/workflows/enforce-branch-protection.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  administration: write
 
 jobs:
   protect-main:
@@ -23,7 +22,7 @@ jobs:
           node-version: 22
       - name: Apply branch protection
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PROTECTED_BRANCH: main
         run: node scripts/configure-branch-protection.mjs

--- a/scripts/configure-branch-protection.mjs
+++ b/scripts/configure-branch-protection.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 
-const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+const token = process.env.GH_TOKEN;
 const repoSlug = process.env.GITHUB_REPOSITORY;
 const branch = process.env.PROTECTED_BRANCH || 'main';
 
-if (!token) throw new Error('Missing GH_TOKEN or GITHUB_TOKEN');
+if (!token) {
+  throw new Error(
+    'Missing GH_TOKEN. Configure the GH_PAT repository secret with branch administration access.',
+  );
+}
 if (!repoSlug || !repoSlug.includes('/')) throw new Error('Missing GITHUB_REPOSITORY (owner/repo)');
 
 const [owner, repo] = repoSlug.split('/');


### PR DESCRIPTION
Merge Strategy: Merge Commit

## Summary
- remove unsupported workflow permission from enforce-branch-protection
- require GH_PAT for branch protection updates instead of falling back to GITHUB_TOKEN
- keep failure mode explicit if the admin PAT secret is missing

## Verification
- node --check scripts/configure-branch-protection.mjs
- YAML parse for .github/workflows/enforce-branch-protection.yml
- git diff --check
- npx actionlint .github/workflows/enforce-branch-protection.yml could not run because npm could not determine an executable for that package