### PR TITLE
Trim platform deploy dispatcher

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -1,23 +1,10 @@
 name: Deploy Cloudflare apps
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "infra/Cloudflare/**"
-      - "scripts/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "turbo.json"
-      - ".github/workflows/deploy-platform.yml"
   workflow_dispatch:
     inputs:
       target:
-        description: "App/service to deploy (or 'all')"
+        description: "Canonical app to deploy (or 'all')"
         required: true
         default: "all"
         type: choice
@@ -26,15 +13,6 @@ on:
           - gs-web
           - gs-admin
           - gs-api
-          - gs-gateway
-          - gs-control
-          - gs-mail
-          - gs-agent
-          - gs-trading
-          - banproof-me
-          - gs-www-redirect
-          - gs-core-worker
-          - armsway-com
       environment:
         description: "Cloudflare environment"
         required: true
@@ -52,10 +30,9 @@ env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
 
-# ── Shared setup ──────────────────────────────────────────────────────────────
-# Each job repeats the three setup steps (checkout / pnpm / node) because
-# GitHub Actions has no reusable step blocks. Jobs run in parallel so the
-# repeated setup is cheaper than serialising through a setup job.
+# Manual canonical deploy dispatcher. Normal pushes are handled by the
+# app-specific deploy workflows; this avoids duplicate deploys and Cloudflare
+# API rate-limit spikes.
 
 jobs:
 
@@ -110,25 +87,12 @@ jobs:
       - name: Deploy to Cloudflare Pages
         run: pnpm exec wrangler pages deploy apps/gs-admin/dist --project-name=gs-admin --branch=${{ github.ref_name }}
 
-  # ── Workers (matrix) ────────────────────────────────────────────────────────
-  # Canonical worker app paths: apps/gs-api, apps/gs-gateway, apps/gs-agent,
-  # apps/gs-control, apps/gs-mail, apps/banproof-me, apps/gs-trading,
-  # apps/gs-www-redirect, apps/gs-core-worker, apps/armsway-com
-  #
-  # wrangler deploy auto-creates the worker if it doesn't exist and updates it
-  # if it does. Route/custom-domain binding is declared in each wrangler.toml
-  # and applied on every deploy — no manual DNS setup needed for custom_domain=true.
-  #
-  # Workers with route-based patterns (zone_name) require a proxied DNS record
-  # to already exist for the zone. Those records are managed in desired-state.yaml
-  # and applied by infra/Cloudflare/deploy.ts (or manually via CF Dashboard).
+  # ── Canonical Worker ────────────────────────────────────────────────────────
   deploy-workers:
     name: Deploy ${{ matrix.app }}
-    # matrix.app cannot be used in a job-level if; filter per-target inside steps instead
     if: >
-      github.event_name == 'push' ||
       inputs.target == 'all' ||
-      contains(fromJSON('["gs-gateway","gs-api","gs-agent","gs-control","gs-trading","gs-mail","banproof-me","gs-www-redirect","gs-core-worker","armsway-com"]'), inputs.target)
+      inputs.target == 'gs-api'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,26 +100,8 @@ jobs:
       fail-fast: false   # one broken worker does not cancel the others
       matrix:
         include:
-          - app: gs-gateway
-            filter: "@goldshore/gs-gateway"
           - app: gs-api
             filter: "@goldshore/gs-api"
-          - app: gs-agent
-            filter: "@goldshore/gs-agent"
-          - app: gs-control
-            filter: "@goldshore/gs-control"
-          - app: gs-trading
-            filter: "@goldshore/gs-trading"
-          - app: gs-mail
-            filter: "@goldshore/gs-mail"
-          - app: banproof-me
-            filter: "@goldshore/banproof-me"
-          - app: gs-www-redirect
-            filter: "@goldshore/gs-www-redirect"
-          - app: gs-core-worker
-            filter: "@goldshore/gs-core-worker"
-          - app: armsway-com
-            filter: "@goldshore/armsway-com"
     steps:
       - name: Skip if not targeted
         if: github.event_name == 'workflow_dispatch' && inputs.target != 'all' && inputs.target != matrix.app
@@ -180,6 +126,8 @@ jobs:
       - name: Deploy ${{ matrix.app }}
         if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.app
         working-directory: apps/${{ matrix.app }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_GS_CONTROL }}
         run: |
           ENV=${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'prod' }}
           pnpm exec wrangler deploy --env $ENV
@@ -190,26 +138,11 @@ jobs:
           sleep 3
           # Check worker health endpoint based on app
           case "${{ matrix.app }}" in
-            banproof-me)
-              HEALTH_URL="https://banproof.me/health"
-              ;;
             gs-web)
               HEALTH_URL="https://goldshore.ai/health"
               ;;
             gs-api)
               HEALTH_URL="https://api.goldshore.ai/health"
-              ;;
-            gs-gateway)
-              HEALTH_URL="https://gw.goldshore.ai/health"
-              ;;
-            gs-control)
-              HEALTH_URL="https://ops.goldshore.ai/health"
-              ;;
-            gs-mail)
-              HEALTH_URL="https://mail.goldshore.ai/health"
-              ;;
-            armsway-com)
-              HEALTH_URL="https://armsway.com/health"
               ;;
             *)
               echo "Skipping health check for ${{ matrix.app }}"


### PR DESCRIPTION
Merge Strategy: Squash

## Summary
- make deploy-platform manual-only so main pushes use app-specific deploy workflows
- remove legacy worker targets from the dispatcher
- keep manual gs-api deploys on the gs-control Cloudflare token

## Verification
- YAML parse for .github/workflows/deploy-platform.yml
- legacy target search returns no matches
- git diff --check
- all PR checks passed