### PR TITLE
ops: CF Agent Access setup workflow

### DIFF
--- a/.github/workflows/cf-discover.yml
+++ b/.github/workflows/cf-discover.yml
@@ -26,10 +26,15 @@ jobs:
           echo "══════════════════════════════════════════════════════════"
           echo "  CF ACCESS APPLICATIONS — copy AUD values for wrangler"
           echo "══════════════════════════════════════════════════════════"
-          curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/access/apps" \
+          BODY=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/access/apps" \
             -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json" \
-          | jq -r '.result[] | "  \(.name)\n    AUD: \(.aud)\n    domain: \(.domain)\n"'
+            -H "Content-Type: application/json")
+          if ! echo "$BODY" | jq -e '.result != null' >/dev/null 2>&1; then
+            echo "::error::CF API returned null — token may be expired or lacks Access permissions"
+            echo "$BODY" | jq -r '.errors[]? | "  \(.code): \(.message)"' || true
+            exit 1
+          fi
+          echo "$BODY" | jq -r '.result[] | "  \(.name)\n    AUD: \(.aud)\n    domain: \(.domain)\n"'
 
       - name: Discover Workers
         run: |
@@ -37,9 +42,14 @@ jobs:
           echo "══════════════════════════════════════════════════════════"
           echo "  WORKERS"
           echo "══════════════════════════════════════════════════════════"
-          curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-          | jq -r '.result[] | "  \(.id)  (modified: \(.modified_on))"'
+          BODY=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          if ! echo "$BODY" | jq -e '.result != null' >/dev/null 2>&1; then
+            echo "::error::CF API returned null — token may be expired or lacks Workers permissions"
+            echo "$BODY" | jq -r '.errors[]? | "  \(.code): \(.message)"' || true
+            exit 1
+          fi
+          echo "$BODY" | jq -r '.result[] | "  \(.id)  (modified: \(.modified_on))"'
 
       - name: Discover KV Namespaces
         run: |
@@ -47,9 +57,14 @@ jobs:
           echo "══════════════════════════════════════════════════════════"
           echo "  KV NAMESPACES"
           echo "══════════════════════════════════════════════════════════"
-          curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces?per_page=100" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-          | jq -r '.result[] | "  \(.title)\n    id: \(.id)\n"'
+          BODY=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces?per_page=100" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          if ! echo "$BODY" | jq -e '.result != null' >/dev/null 2>&1; then
+            echo "::error::CF API returned null — token may be expired or lacks KV permissions"
+            echo "$BODY" | jq -r '.errors[]? | "  \(.code): \(.message)"' || true
+            exit 1
+          fi
+          echo "$BODY" | jq -r '.result[] | "  \(.title)\n    id: \(.id)\n"'
 
       - name: Discover D1 Databases
         run: |
@@ -57,9 +72,14 @@ jobs:
           echo "══════════════════════════════════════════════════════════"
           echo "  D1 DATABASES"
           echo "══════════════════════════════════════════════════════════"
-          curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database?per_page=100" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-          | jq -r '.result[] | "  \(.name)\n    id: \(.uuid)\n"'
+          BODY=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database?per_page=100" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          if ! echo "$BODY" | jq -e '.result != null' >/dev/null 2>&1; then
+            echo "::error::CF API returned null — token may be expired or lacks D1 permissions"
+            echo "$BODY" | jq -r '.errors[]? | "  \(.code): \(.message)"' || true
+            exit 1
+          fi
+          echo "$BODY" | jq -r '.result[] | "  \(.name)\n    id: \(.uuid)\n"'
 
       - name: Discover Pages Projects
         run: |
@@ -67,9 +87,14 @@ jobs:
           echo "══════════════════════════════════════════════════════════"
           echo "  PAGES PROJECTS"
           echo "══════════════════════════════════════════════════════════"
-          curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-          | jq -r '.result[] | "  \(.name)\n    subdomain: \(.subdomain)\n    build_command: \(.build_config.build_command // "(not set)")\n    output_dir: \(.build_config.destination_dir // "(not set)")\n"'
+          BODY=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}")
+          if ! echo "$BODY" | jq -e '.result != null' >/dev/null 2>&1; then
+            echo "::error::CF API returned null — token may be expired or lacks Pages permissions"
+            echo "$BODY" | jq -r '.errors[]? | "  \(.code): \(.message)"' || true
+            exit 1
+          fi
+          echo "$BODY" | jq -r '.result[] | "  \(.name)\n    subdomain: \(.subdomain)\n    build_command: \(.build_config.build_command // "(not set)")\n    output_dir: \(.build_config.destination_dir // "(not set)")\n"'
 
       - name: Summary
         run: |

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -6,7 +6,7 @@ name: Setup CF Agent Access
 #
 # skip_revoke: skip revoking the old token (e.g. already rotated)
 # skip_apps:   skip creating brand-new Access apps — existing apps always
-#              have their policies refreshed with the new token UUID
+#              have their domains and policies updated with the new token UUID
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ on:
         default: false
         type: boolean
       skip_apps:
-        description: 'Skip creating NEW Access apps (existing apps still get updated policies)'
+        description: 'Skip creating NEW Access apps (existing apps still get updated)'
         required: false
         default: false
         type: boolean
@@ -36,22 +36,43 @@ jobs:
     steps:
       # ------------------------------------------------------------------ #
       # 0. Verify CLOUDFLARE_API_TOKEN has Access permissions
+      #    Probes both service_tokens AND access/apps to catch tokens that
+      #    have Service Token scope but lack Apps/Policies edit permission.
+      #    A partial-permission failure here aborts BEFORE any revocation.
       # ------------------------------------------------------------------ #
       - name: Verify CF token has Access scope
         env:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+
+          # Check 1: service_tokens endpoint
+          ST_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
             "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" \
             -H "Authorization: Bearer $CF_TOKEN")
-          if [ "$STATUS" = "403" ] || [ "$STATUS" = "401" ]; then
-            echo "::error::CLOUDFLARE_API_TOKEN lacks Zero Trust / Access permissions."
-            echo "::error::Edit the token at https://dash.cloudflare.com/profile/api-tokens"
-            echo "::error::Add: Access: Service Tokens (Edit) + Access: Apps and Policies (Edit)"
+          if [ "$ST_STATUS" = "403" ] || [ "$ST_STATUS" = "401" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN lacks Access: Service Tokens permission."
+            echo "::error::Edit at https://dash.cloudflare.com/profile/api-tokens"
+            echo "::error::Required: Access: Service Tokens (Edit)"
             exit 1
           fi
-          echo "CF token Access scope: OK (HTTP $STATUS)"
+          echo "CF token Service Tokens scope: OK (HTTP $ST_STATUS)"
+
+          # Check 2: access/apps endpoint (separate permission from service_tokens)
+          APPS_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
+            -H "Authorization: Bearer $CF_TOKEN")
+          if [ "$APPS_STATUS" = "403" ] || [ "$APPS_STATUS" = "401" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN lacks Access: Apps and Policies permission."
+            echo "::error::Edit at https://dash.cloudflare.com/profile/api-tokens"
+            echo "::error::Required: Access: Apps and Policies (Edit)"
+            echo "::error::Token has service_tokens scope (HTTP $ST_STATUS) but not apps scope (HTTP $APPS_STATUS)"
+            echo "::error::Aborting BEFORE any revocation to avoid stranding Access apps on a revoked token."
+            exit 1
+          fi
+          echo "CF token Access Apps scope: OK (HTTP $APPS_STATUS)"
+
+          echo "All required CF API permissions verified."
 
       # ------------------------------------------------------------------ #
       # 1. Revoke compromised service token
@@ -110,7 +131,7 @@ jobs:
       # 3. Upsert Access Applications + Policies
       #
       # Always runs — even when skip_apps=true — so that existing Access apps
-      # get their policies updated with the newly-created token UUID.
+      # get their domains and policies updated with the newly-created token UUID.
       # skip_apps only suppresses creation of brand-new apps.
       # ------------------------------------------------------------------ #
       - name: Upsert Access Applications and Policies
@@ -127,7 +148,17 @@ jobs:
           OWNER_INCLUDE=$(jq -nc \
             '[{"email_domain":{"domain":"goldshore.ai"}},{"email":{"email":"marstonr6@gmail.com"}}]')
 
-          # Find existing Access app UUID by display name (returns empty if not found)
+          # push_worker_secret is also used here to propagate AUDs on first-run new-app creation
+          push_worker_secret() {
+            local worker="$1" key="$2" val="$3"
+            curl -sf -X PUT \
+              "$CF_API/accounts/$CF_ACCOUNT/workers/scripts/$worker/secrets" \
+              -H "Authorization: Bearer $CF_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"name\":\"$key\",\"text\":\"$val\",\"type\":\"secret_text\"}" \
+              | jq -r '"  \(.result.name // "?") => \(.success)"'
+          }
+
           find_app() {
             local name="$1"
             curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
@@ -136,8 +167,23 @@ jobs:
               '[.result[] | select(.name == $n)] | first | .id // empty'
           }
 
-          # Create a new app; extra_domains is a JSON array of alias hostnames
-          make_app() {
+          # PATCH existing app domain/self_hosted_domains so stale bindings from
+          # prior runs are corrected (e.g. old Trading domain, old Gateway aliases)
+          patch_app_domains() {
+            local app_id="$1" domain="$2" extra_domains="${3:-[]}"
+            jq -nc \
+              --arg d "$domain" \
+              --argjson ed "$extra_domains" \
+              '{domain:$d,self_hosted_domains:([$d] + $ed)}' | \
+            curl -sf -X PATCH "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id" \
+              -H "Authorization: Bearer $CF_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data @- | jq -r '"  patched domains => \(.success)"'
+          }
+
+          # Create a new app and return the full CF response JSON.
+          # Caller extracts .result.id and .result.aud from the returned JSON.
+          make_app_json() {
             local name="$1" domain="$2" extra_domains="${3:-[]}"
             jq -nc \
               --arg n "$name" \
@@ -151,7 +197,7 @@ jobs:
             curl -sf -X POST "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
               -H "Authorization: Bearer $CF_TOKEN" \
               -H "Content-Type: application/json" \
-              --data @- | jq -r '.result.id // empty'
+              --data @-
           }
 
           add_policy() {
@@ -169,7 +215,7 @@ jobs:
           }
 
           # Delete only non-bypass policies so health-check and OAuth callback
-          # bypass rules are preserved across token rotations.
+          # bypass rules (on existing apps) are preserved across token rotations.
           refresh_policies() {
             local app_id="$1"
             curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id/policies" \
@@ -184,65 +230,115 @@ jobs:
             done
           }
 
+          # upsert_full_access: human owner (Workspace domain + personal OTP) + agents (service token)
+          # aud_workers: space-separated Worker names to receive CLOUDFLARE_ACCESS_AUDIENCE
+          #              on first-run new-app creation. Existing apps preserve their AUD.
           upsert_full_access() {
-            # Human owner (Workspace domain + personal email OTP) + agents (service token)
-            # Existing app: refreshes non-bypass policies (preserves UUID/AUD and bypass rules).
-            # New app:      only created when SKIP_NEW_APPS != true.
-            local name="$1" domain="$2" extra_domains="${3:-[]}"
+            local name="$1" domain="$2" extra_domains="${3:-[]}" aud_workers="${4:-}"
             AID=$(find_app "$name")
             if [ -n "$AID" ]; then
-              echo "Refreshing policies on existing app [$name]: $AID"
+              echo "Found existing app [$name]: $AID — patching domains and refreshing policies"
+              patch_app_domains "$AID" "$domain" "$extra_domains"
               refresh_policies "$AID"
               add_policy "$AID" "Goldshore agents" "non_identity" "$SERVICE_INCLUDE"
               add_policy "$AID" "Owner access"     "allow"        "$OWNER_INCLUDE"
             elif [ "$SKIP_NEW_APPS" = "true" ]; then
               echo "INFO: No existing [$name] app and skip_apps=true — skipped."
             else
-              AID=$(make_app "$name" "$domain" "$extra_domains")
+              APP_JSON=$(make_app_json "$name" "$domain" "$extra_domains")
+              AID=$(echo "$APP_JSON" | jq -r '.result.id // empty')
+              AUD=$(echo "$APP_JSON" | jq -r '.result.aud // empty')
               [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
-              echo "Created app [$name]: $AID"
+              echo "Created app [$name]: $AID  AUD: ${AUD:-(none)}"
               add_policy "$AID" "Goldshore agents" "non_identity" "$SERVICE_INCLUDE"
               add_policy "$AID" "Owner access"     "allow"        "$OWNER_INCLUDE"
+              if [ -n "$aud_workers" ] && [ -n "$AUD" ]; then
+                echo "  Propagating CLOUDFLARE_ACCESS_AUDIENCE to: $aud_workers"
+                for w in $aud_workers; do
+                  push_worker_secret "$w" CLOUDFLARE_ACCESS_AUDIENCE "$AUD"
+                done
+              fi
             fi
           }
 
-          upsert_agent_app() {
-            # Service token only — no human SSO
+          # upsert_bypass_app: creates a path-scoped Access app with a bypass-everyone policy.
+          # Used for public paths that must not hit the Access login wall:
+          # Trading OAuth callbacks, API/Gateway public probes.
+          # CF Access resolves the more-specific path-scoped app before the broader allow app.
+          upsert_bypass_app() {
             local name="$1" domain="$2" extra_domains="${3:-[]}"
             AID=$(find_app "$name")
             if [ -n "$AID" ]; then
-              echo "Refreshing policies on existing app [$name]: $AID"
-              refresh_policies "$AID"
-              add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
+              echo "Bypass app [$name] already exists: $AID (no change)"
             elif [ "$SKIP_NEW_APPS" = "true" ]; then
-              echo "INFO: No existing [$name] app and skip_apps=true — skipped."
+              echo "INFO: No bypass app [$name] and skip_apps=true — skipped."
             else
-              AID=$(make_app "$name" "$domain" "$extra_domains")
-              [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
-              echo "Created app [$name]: $AID"
-              add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
+              APP_JSON=$(make_app_json "$name" "$domain" "$extra_domains")
+              AID=$(echo "$APP_JSON" | jq -r '.result.id // empty')
+              [ -z "$AID" ] && { echo "WARNING: failed to create bypass app $name"; return; }
+              echo "Created bypass app [$name]: $AID"
+              jq -nc \
+                '{name:"Public bypass",decision:"bypass",
+                  include:[{"everyone":{}}],exclude:[],require:[]}' | \
+              curl -sf -X POST \
+                "$CF_API/accounts/$CF_ACCOUNT/access/apps/$AID/policies" \
+                -H "Authorization: Bearer $CF_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data @- | jq -r '"  bypass policy => \(.success)"'
             fi
           }
 
-          # Human + agent access (browser clients call these directly)
-          # App names match CF dashboard names from docs/domains-and-auth.md
+          # ------------------------------------------------------------------
+          # Bypass apps first — path-specific rules get higher CF Access priority
+          # than the broader allow apps that cover the same hostnames.
+          # ------------------------------------------------------------------
+
+          # Trading: Schwab/Robinhood redirect to these without an Access session
+          upsert_bypass_app "GoldShore Trading - OAuth Bypass" \
+            "trading.goldshore.ai/oauth" \
+            '["dashboard.goldshore.ai/oauth","dash.goldshore.ai/oauth"]'
+
+          # API: /health, /status, /version must be reachable by monitoring
+          upsert_bypass_app "Goldshore API - Public Probes" \
+            "api.goldshore.ai/health" \
+            '["api.goldshore.ai/status","api.goldshore.ai/version"]'
+
+          # Gateway: /health, /status, /version must be reachable by monitoring
+          upsert_bypass_app "Goldshore Gateway - Public Probes" \
+            "gw.goldshore.ai/health" \
+            '["gw.goldshore.ai/status","gw.goldshore.ai/version"]'
+
+          # ------------------------------------------------------------------
+          # Human + agent access apps (all per infra/INFRASTRUCTURE.md Gates 5a-5e
+          # and docs/domains-and-auth.md; app names match CF dashboard)
+          # ------------------------------------------------------------------
+
           upsert_full_access "Dashboard"       "goldshore.ai/app"
-          # GoldShore Admin: .ai canonical + .org alias + admin-preview per desired-state
-          upsert_full_access "GoldShore Admin"   "admin.goldshore.ai" '["admin.goldshore.org","admin-preview.goldshore.ai"]'
-          # GoldShore Trading: canonical + dashboard/dash aliases per desired-state
-          upsert_full_access "GoldShore Trading" "trading.goldshore.ai" '["dashboard.goldshore.ai","dash.goldshore.ai"]'
+          # GoldShore Admin: .ai canonical + .org alias + admin-preview (Gate 5a)
+          upsert_full_access "GoldShore Admin"   "admin.goldshore.ai" \
+            '["admin.goldshore.org","admin-preview.goldshore.ai"]'
+          # GoldShore Trading: canonical + dashboard/dash aliases (Gate 5b)
+          upsert_full_access "GoldShore Trading" "trading.goldshore.ai" \
+            '["dashboard.goldshore.ai","dash.goldshore.ai"]'
+          # Goldshore Ops: ops.goldshore.ai (Gate 5c)
+          upsert_full_access "Goldshore Ops"     "ops.goldshore.ai"
           upsert_full_access "Signals"           "signals.goldshore.ai"
-          # Goldshore API: documented app name matches existing AUD in wrangler.toml
-          upsert_full_access "Goldshore API"     "api.goldshore.ai"
-
-          # Agent / machine-to-machine only
-          # GoldShore MCP: named per docs/domains-and-auth.md
-          upsert_agent_app "GoldShore MCP"   "mcp.goldshore.ai"
-          # Goldshore Gateway covers gw + agent per desired-state.yaml; gateway is an alias
-          upsert_agent_app "Goldshore Gateway" "gw.goldshore.ai" '["gateway.goldshore.ai","agent.goldshore.ai"]'
+          # Goldshore API: uses documented name to match existing AUD in wrangler.toml;
+          # pushes AUD to api workers on first-run creation (Gate 5e)
+          upsert_full_access "Goldshore API"     "api.goldshore.ai" "[]" \
+            "gs-api gs-api-prod"
+          # GoldShore MCP: human + agent per docs ("approved human identities and agents")
+          upsert_full_access "GoldShore MCP"     "mcp.goldshore.ai" "[]" \
+            "gs-mcp"
+          # Goldshore Gateway: gw + agent share app+AUD (Gate 5d); human + agent access
+          upsert_full_access "Goldshore Gateway" "gw.goldshore.ai" \
+            '["gateway.goldshore.ai","agent.goldshore.ai"]' \
+            "gs-gateway-prod gs-agent gs-agent-prod"
+          # GoldShore-Web-Preview: preview.goldshore.ai (INFRASTRUCTURE.md Gate 5)
+          upsert_full_access "GoldShore-Web-Preview" "preview.goldshore.ai"
 
       # ------------------------------------------------------------------ #
-      # 4. Propagate secrets to all repos
+      # 4. Propagate CF_ACCESS_CLIENT_ID / SECRET to all repos
       # ------------------------------------------------------------------ #
       - name: Set CF_ACCESS secrets in all repos
         env:
@@ -261,7 +357,7 @@ jobs:
           done
 
       # ------------------------------------------------------------------ #
-      # 5. Push CF_ACCESS credentials into Worker secrets
+      # 5. Push CF_ACCESS_CLIENT_ID / SECRET into Worker secrets
       # ------------------------------------------------------------------ #
       - name: Push CF_ACCESS secrets into Worker secrets
         env:
@@ -303,8 +399,8 @@ jobs:
             echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
             echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
             echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-api-prod, gs-gateway-prod |"
-            echo "| Full-access apps | Dashboard, GoldShore Admin, GoldShore Trading, Signals, Goldshore API |"
-            echo "| Agent-only apps | GoldShore MCP, Goldshore Gateway (gw+gateway+agent aliases) |"
+            echo "| Bypass apps | Trading OAuth, API Probes, Gateway Probes |"
+            echo "| Full-access apps | Dashboard, GoldShore Admin, GoldShore Trading, Goldshore Ops, Signals, Goldshore API, GoldShore MCP, Goldshore Gateway, GoldShore-Web-Preview |"
             echo ""
             echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -1,0 +1,247 @@
+name: Setup CF Agent Access
+
+# Rotates the CF Access Service Token, creates all Access Applications,
+# and propagates CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET to all repos.
+# Run manually: Actions → Setup CF Agent Access → Run workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_revoke:
+        description: 'Skip revoking old token (if already rotated)'
+        required: false
+        default: false
+        type: boolean
+      skip_apps:
+        description: 'Skip creating Access Applications (only rotate token + set secrets)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  setup:
+    name: CF Access — token + apps + secrets
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    env:
+      CF_ACCOUNT: f77de112d2019e5456a3198a8bb50bd2
+      CF_API: https://api.cloudflare.com/client/v4
+      # Client ID of the compromised token shared in plain text.
+      # The revoke step will delete it if still present.
+      OLD_CLIENT_ID: 9ca952086adc30cf53634d78d099ce58.access
+
+    steps:
+      # ------------------------------------------------------------------ #
+      # 0. Verify CLOUDFLARE_API_TOKEN has Access permissions
+      # ------------------------------------------------------------------ #
+      - name: Verify CF token has Access scope
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" \
+            -H "Authorization: Bearer $CF_TOKEN")
+          if [ "$STATUS" = "403" ] || [ "$STATUS" = "401" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN lacks Zero Trust / Access permissions."
+            echo "::error::Edit the token at https://dash.cloudflare.com/profile/api-tokens"
+            echo "::error::Add: Access: Service Tokens (Edit) + Access: Apps and Policies (Edit)"
+            exit 1
+          fi
+          echo "CF token Access scope: OK (HTTP $STATUS)"
+
+      # ------------------------------------------------------------------ #
+      # 1. Revoke compromised service token
+      # ------------------------------------------------------------------ #
+      - name: Revoke compromised service token
+        if: ${{ !inputs.skip_revoke }}
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          LIST=$(curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" \
+            -H "Authorization: Bearer $CF_TOKEN")
+          OLD_UUID=$(echo "$LIST" | \
+            jq -r --arg cid "$OLD_CLIENT_ID" \
+            '.result[] | select(.client_id == $cid) | .id // empty')
+          if [ -n "$OLD_UUID" ]; then
+            curl -sf -X DELETE \
+              "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens/$OLD_UUID" \
+              -H "Authorization: Bearer $CF_TOKEN" | jq -r '.success'
+            echo "Revoked token UUID: $OLD_UUID"
+          else
+            echo "Compromised token not found — already revoked or never existed."
+          fi
+
+      # ------------------------------------------------------------------ #
+      # 2. Create new goldshore-agents service token
+      # ------------------------------------------------------------------ #
+      - name: Create goldshore-agents service token
+        id: token
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          RES=$(curl -sf -X POST \
+            "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" \
+            -H "Authorization: Bearer $CF_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"name":"goldshore-agents"}')
+
+          TOKEN_UUID=$(echo "$RES" | jq -r '.result.id // empty')
+          CLIENT_ID=$(echo  "$RES" | jq -r '.result.client_id // empty')
+          CLIENT_SEC=$(echo "$RES" | jq -r '.result.client_secret // empty')
+
+          if [ -z "$TOKEN_UUID" ]; then
+            echo "::error::Service token creation failed:"
+            echo "$RES" | jq .
+            exit 1
+          fi
+
+          echo "token_uuid=$TOKEN_UUID"     >> "$GITHUB_OUTPUT"
+          echo "client_id=$CLIENT_ID"       >> "$GITHUB_OUTPUT"
+          echo "client_secret=$CLIENT_SEC"  >> "$GITHUB_OUTPUT"
+          echo "Created service token: $CLIENT_ID (UUID: $TOKEN_UUID)"
+
+      # ------------------------------------------------------------------ #
+      # 3. Create CF Access Applications + Policies
+      # ------------------------------------------------------------------ #
+      - name: Create Access Applications and Policies
+        if: ${{ !inputs.skip_apps }}
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TOKEN_UUID: ${{ steps.token.outputs.token_uuid }}
+        run: |
+          set -euo pipefail
+
+          SERVICE_INCLUDE=$(jq -nc --arg id "$TOKEN_UUID" \
+            '[{"service_token":{"token_cf_service_id":$id}}]')
+          OWNER_INCLUDE=$(jq -nc \
+            '[{"email":{"email":"marstonr6@gmail.com"}}]')
+
+          make_app() {
+            local name="$1" domain="$2"
+            jq -nc --arg n "$name" --arg d "$domain" \
+              '{name:$n,type:"self_hosted",domain:$d,
+                session_duration:"24h",
+                http_only_cookie_attribute:true,
+                auto_redirect_to_identity:false}' | \
+            curl -sf -X POST "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
+              -H "Authorization: Bearer $CF_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data @- | jq -r '.result.id // empty'
+          }
+
+          add_policy() {
+            local app_id="$1" name="$2" decision="$3" include="$4"
+            jq -nc \
+              --arg n  "$name" \
+              --arg d  "$decision" \
+              --argjson inc "$include" \
+              '{name:$n,decision:$d,include:$inc,exclude:[],require:[]}' | \
+            curl -sf -X POST \
+              "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id/policies" \
+              -H "Authorization: Bearer $CF_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data @- | jq -r '"  policy \(.result.name // "?") => \(.success)"'
+          }
+
+          create_full_access_app() {
+            # Human owner (email OTP) + agents (service token)
+            local name="$1" domain="$2"
+            AID=$(make_app "$name" "$domain")
+            [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
+            echo "Created app [$name]: $AID"
+            add_policy "$AID" "Goldshore agents"  "non_identity" "$SERVICE_INCLUDE"
+            add_policy "$AID" "Owner access"      "allow"        "$OWNER_INCLUDE"
+          }
+
+          create_agent_app() {
+            # Service token only — no human SSO
+            local name="$1" domain="$2"
+            AID=$(make_app "$name" "$domain")
+            [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
+            echo "Created app [$name]: $AID"
+            add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
+          }
+
+          # Human + agent access (browser clients call these directly)
+          create_full_access_app "Dashboard" "goldshore.ai/app"
+          create_full_access_app "Admin"     "admin.goldshore.org"
+          create_full_access_app "Trading"   "goldshore.org/dash"
+          create_full_access_app "Signals"   "signals.goldshore.ai"
+          create_full_access_app "API"       "api.goldshore.ai"
+
+          # Agent / machine-to-machine only
+          create_agent_app "MCP"     "mcp.goldshore.ai"
+          create_agent_app "Agent"   "agent.goldshore.ai"
+          create_agent_app "Gateway" "gateway.goldshore.ai"
+
+      # ------------------------------------------------------------------ #
+      # 4. Propagate secrets to all repos
+      # ------------------------------------------------------------------ #
+      - name: Set CF_ACCESS secrets in all repos
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          CLIENT_ID:  ${{ steps.token.outputs.client_id }}
+          CLIENT_SEC: ${{ steps.token.outputs.client_secret }}
+        run: |
+          set -euo pipefail
+          for REPO in \
+            marzton/goldshore-ai \
+            marzton/goldshore-gateway \
+            marzton/goldclaw; do
+            gh secret set CF_ACCESS_CLIENT_ID     --body "$CLIENT_ID"  --repo "$REPO"
+            gh secret set CF_ACCESS_CLIENT_SECRET --body "$CLIENT_SEC" --repo "$REPO"
+            echo "Secrets set: $REPO"
+          done
+
+      # ------------------------------------------------------------------ #
+      # 5. Push CF_ACCESS credentials into Worker secrets
+      # ------------------------------------------------------------------ #
+      - name: Push CF_ACCESS secrets into Worker secrets
+        env:
+          CF_TOKEN:   ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLIENT_ID:  ${{ steps.token.outputs.client_id }}
+          CLIENT_SEC: ${{ steps.token.outputs.client_secret }}
+        run: |
+          set -euo pipefail
+          put_secret() {
+            local worker="$1" key="$2" val="$3"
+            curl -sf -X PUT \
+              "$CF_API/accounts/$CF_ACCOUNT/workers/scripts/$worker/secrets" \
+              -H "Authorization: Bearer $CF_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"name\":\"$key\",\"text\":\"$val\",\"type\":\"secret_text\"}" \
+              | jq -r '"  \(.result.name // "?") => \(.success)"'
+          }
+          for WORKER in gs-agent gs-agent-prod gs-mcp gs-api gs-gateway-prod; do
+            echo "Setting secrets on $WORKER:"
+            put_secret "$WORKER" CF_ACCESS_CLIENT_ID     "$CLIENT_ID"
+            put_secret "$WORKER" CF_ACCESS_CLIENT_SECRET "$CLIENT_SEC"
+          done
+
+      # ------------------------------------------------------------------ #
+      # 6. Summary
+      # ------------------------------------------------------------------ #
+      - name: Write job summary
+        if: always()
+        env:
+          CLIENT_ID:   ${{ steps.token.outputs.client_id }}
+          TOKEN_UUID:  ${{ steps.token.outputs.token_uuid }}
+        run: |
+          {
+            echo "## CF Agent Access Setup"
+            echo ""
+            echo "| Item | Value |"
+            echo "|------|-------|"
+            echo "| Service token UUID | \`$TOKEN_UUID\` |"
+            echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
+            echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
+            echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-gateway-prod |"
+            echo "| Full-access apps | Dashboard, Admin, Trading, Signals, API |"
+            echo "| Agent-only apps | MCP, Agent, Gateway |"
+            echo ""
+            echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -123,8 +123,9 @@ jobs:
 
           SERVICE_INCLUDE=$(jq -nc --arg id "$TOKEN_UUID" \
             '[{"service_token":{"token_id":$id}}]')
+          # Mirrors desired-state.yaml include block: Workspace domain + personal Gmail
           OWNER_INCLUDE=$(jq -nc \
-            '[{"email":{"email":"marstonr6@gmail.com"}}]')
+            '[{"email_domain":{"domain":"goldshore.ai"}},{"email":{"email":"marstonr6@gmail.com"}}]')
 
           # Find existing Access app UUID by display name (returns empty if not found)
           find_app() {
@@ -184,7 +185,7 @@ jobs:
           }
 
           upsert_full_access() {
-            # Human owner (email OTP) + agents (service token)
+            # Human owner (Workspace domain + personal email OTP) + agents (service token)
             # Existing app: refreshes non-bypass policies (preserves UUID/AUD and bypass rules).
             # New app:      only created when SKIP_NEW_APPS != true.
             local name="$1" domain="$2" extra_domains="${3:-[]}"
@@ -224,20 +225,21 @@ jobs:
           }
 
           # Human + agent access (browser clients call these directly)
-          upsert_full_access "Dashboard"     "goldshore.ai/app"
-          # Admin: canonical .ai hostname; .org is an alias
-          upsert_full_access "Admin"         "admin.goldshore.ai" '["admin.goldshore.org"]'
-          # Trading: canonical trading.goldshore.ai; dashboard/dash are aliases
-          upsert_full_access "Trading"       "trading.goldshore.ai" '["dashboard.goldshore.ai","dash.goldshore.ai"]'
-          upsert_full_access "Signals"       "signals.goldshore.ai"
-          # Use documented app name so find_app matches the existing AUD in wrangler.toml
-          upsert_full_access "Goldshore API" "api.goldshore.ai"
+          # App names match CF dashboard names from docs/domains-and-auth.md
+          upsert_full_access "Dashboard"       "goldshore.ai/app"
+          # GoldShore Admin: .ai canonical + .org alias + admin-preview per desired-state
+          upsert_full_access "GoldShore Admin"   "admin.goldshore.ai" '["admin.goldshore.org","admin-preview.goldshore.ai"]'
+          # GoldShore Trading: canonical + dashboard/dash aliases per desired-state
+          upsert_full_access "GoldShore Trading" "trading.goldshore.ai" '["dashboard.goldshore.ai","dash.goldshore.ai"]'
+          upsert_full_access "Signals"           "signals.goldshore.ai"
+          # Goldshore API: documented app name matches existing AUD in wrangler.toml
+          upsert_full_access "Goldshore API"     "api.goldshore.ai"
 
           # Agent / machine-to-machine only
-          upsert_agent_app "MCP"     "mcp.goldshore.ai"
-          upsert_agent_app "Agent"   "agent.goldshore.ai"
-          # Gateway: gw.goldshore.ai is canonical; gateway.goldshore.ai is alias
-          upsert_agent_app "Gateway" "gw.goldshore.ai" '["gateway.goldshore.ai"]'
+          # GoldShore MCP: named per docs/domains-and-auth.md
+          upsert_agent_app "GoldShore MCP"   "mcp.goldshore.ai"
+          # Goldshore Gateway covers gw + agent per desired-state.yaml; gateway is an alias
+          upsert_agent_app "Goldshore Gateway" "gw.goldshore.ai" '["gateway.goldshore.ai","agent.goldshore.ai"]'
 
       # ------------------------------------------------------------------ #
       # 4. Propagate secrets to all repos
@@ -301,8 +303,8 @@ jobs:
             echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
             echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
             echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-api-prod, gs-gateway-prod |"
-            echo "| Full-access apps | Dashboard, Admin (.ai+.org), Trading (.ai+aliases), Signals, Goldshore API |"
-            echo "| Agent-only apps | MCP, Agent, Gateway (gw.goldshore.ai+alias) |"
+            echo "| Full-access apps | Dashboard, GoldShore Admin, GoldShore Trading, Signals, Goldshore API |"
+            echo "| Agent-only apps | GoldShore MCP, Goldshore Gateway (gw+gateway+agent aliases) |"
             echo ""
             echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -122,10 +122,11 @@ jobs:
           set -euo pipefail
 
           SERVICE_INCLUDE=$(jq -nc --arg id "$TOKEN_UUID" \
-            '[{"service_token":{"token_cf_service_id":$id}}]')
+            '[{"service_token":{"token_id":$id}}]')
           OWNER_INCLUDE=$(jq -nc \
             '[{"email":{"email":"marstonr6@gmail.com"}}]')
 
+          # Find existing Access app UUID by display name (returns empty if not found)
           find_app() {
             local name="$1"
             curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
@@ -134,6 +135,7 @@ jobs:
               '[.result[] | select(.name == $n)] | first | .id // empty'
           }
 
+          # Create a new app; extra_domains is a JSON array of alias hostnames
           make_app() {
             local name="$1" domain="$2" extra_domains="${3:-[]}"
             jq -nc \
@@ -165,11 +167,13 @@ jobs:
               --data @- | jq -r '"  policy \(.result.name // "?") => \(.success)"'
           }
 
+          # Delete only non-bypass policies so health-check and OAuth callback
+          # bypass rules are preserved across token rotations.
           refresh_policies() {
             local app_id="$1"
             curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id/policies" \
               -H "Authorization: Bearer $CF_TOKEN" | \
-            jq -r '.result[].id // empty' | \
+            jq -r '.result[] | select(.decision != "bypass") | .id // empty' | \
             while read -r pol_id; do
               [ -z "$pol_id" ] && continue
               curl -sf -X DELETE \
@@ -180,6 +184,9 @@ jobs:
           }
 
           upsert_full_access() {
+            # Human owner (email OTP) + agents (service token)
+            # Existing app: refreshes non-bypass policies (preserves UUID/AUD and bypass rules).
+            # New app:      only created when SKIP_NEW_APPS != true.
             local name="$1" domain="$2" extra_domains="${3:-[]}"
             AID=$(find_app "$name")
             if [ -n "$AID" ]; then
@@ -199,6 +206,7 @@ jobs:
           }
 
           upsert_agent_app() {
+            # Service token only — no human SSO
             local name="$1" domain="$2" extra_domains="${3:-[]}"
             AID=$(find_app "$name")
             if [ -n "$AID" ]; then
@@ -215,14 +223,20 @@ jobs:
             fi
           }
 
-          upsert_full_access "Dashboard" "goldshore.ai/app"
-          upsert_full_access "Admin"     "admin.goldshore.ai" '["admin.goldshore.org"]'
-          upsert_full_access "Trading"   "goldshore.org/dash"
-          upsert_full_access "Signals"   "signals.goldshore.ai"
-          upsert_full_access "API"       "api.goldshore.ai"
+          # Human + agent access (browser clients call these directly)
+          upsert_full_access "Dashboard"     "goldshore.ai/app"
+          # Admin: canonical .ai hostname; .org is an alias
+          upsert_full_access "Admin"         "admin.goldshore.ai" '["admin.goldshore.org"]'
+          # Trading: canonical trading.goldshore.ai; dashboard/dash are aliases
+          upsert_full_access "Trading"       "trading.goldshore.ai" '["dashboard.goldshore.ai","dash.goldshore.ai"]'
+          upsert_full_access "Signals"       "signals.goldshore.ai"
+          # Use documented app name so find_app matches the existing AUD in wrangler.toml
+          upsert_full_access "Goldshore API" "api.goldshore.ai"
 
+          # Agent / machine-to-machine only
           upsert_agent_app "MCP"     "mcp.goldshore.ai"
           upsert_agent_app "Agent"   "agent.goldshore.ai"
+          # Gateway: gw.goldshore.ai is canonical; gateway.goldshore.ai is alias
           upsert_agent_app "Gateway" "gw.goldshore.ai" '["gateway.goldshore.ai"]'
 
       # ------------------------------------------------------------------ #
@@ -263,7 +277,7 @@ jobs:
               -d "{\"name\":\"$key\",\"text\":\"$val\",\"type\":\"secret_text\"}" \
               | jq -r '"  \(.result.name // "?") => \(.success)"'
           }
-          for WORKER in gs-agent gs-agent-prod gs-mcp gs-api gs-gateway-prod; do
+          for WORKER in gs-agent gs-agent-prod gs-mcp gs-api gs-api-prod gs-gateway-prod; do
             echo "Setting secrets on $WORKER:"
             put_secret "$WORKER" CF_ACCESS_CLIENT_ID     "$CLIENT_ID"
             put_secret "$WORKER" CF_ACCESS_CLIENT_SECRET "$CLIENT_SEC"
@@ -286,8 +300,8 @@ jobs:
             echo "| Service token UUID | \`$TOKEN_UUID\` |"
             echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
             echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
-            echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-gateway-prod |"
-            echo "| Full-access apps | Dashboard, Admin (.ai+.org), Trading, Signals, API |"
+            echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-api-prod, gs-gateway-prod |"
+            echo "| Full-access apps | Dashboard, Admin (.ai+.org), Trading (.ai+aliases), Signals, Goldshore API |"
             echo "| Agent-only apps | MCP, Agent, Gateway (gw.goldshore.ai+alias) |"
             echo ""
             echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -1,8 +1,12 @@
 name: Setup CF Agent Access
 
-# Rotates the CF Access Service Token, creates all Access Applications,
+# Rotates the CF Access Service Token, upserts all Access Applications,
 # and propagates CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET to all repos.
 # Run manually: Actions → Setup CF Agent Access → Run workflow.
+#
+# skip_revoke: skip revoking the old token (e.g. already rotated)
+# skip_apps:   skip creating brand-new Access apps — existing apps always
+#              have their policies refreshed with the new token UUID
 
 on:
   workflow_dispatch:
@@ -13,7 +17,7 @@ on:
         default: false
         type: boolean
       skip_apps:
-        description: 'Skip creating Access Applications (only rotate token + set secrets)'
+        description: 'Skip creating NEW Access apps (existing apps still get updated policies)'
         required: false
         default: false
         type: boolean
@@ -27,8 +31,6 @@ jobs:
     env:
       CF_ACCOUNT: f77de112d2019e5456a3198a8bb50bd2
       CF_API: https://api.cloudflare.com/client/v4
-      # Client ID of the compromised token shared in plain text.
-      # The revoke step will delete it if still present.
       OLD_CLIENT_ID: 9ca952086adc30cf53634d78d099ce58.access
 
     steps:
@@ -105,13 +107,17 @@ jobs:
           echo "Created service token: $CLIENT_ID (UUID: $TOKEN_UUID)"
 
       # ------------------------------------------------------------------ #
-      # 3. Create CF Access Applications + Policies
+      # 3. Upsert Access Applications + Policies
+      #
+      # Always runs — even when skip_apps=true — so that existing Access apps
+      # get their policies updated with the newly-created token UUID.
+      # skip_apps only suppresses creation of brand-new apps.
       # ------------------------------------------------------------------ #
-      - name: Create Access Applications and Policies
-        if: ${{ !inputs.skip_apps }}
+      - name: Upsert Access Applications and Policies
         env:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TOKEN_UUID: ${{ steps.token.outputs.token_uuid }}
+          SKIP_NEW_APPS: ${{ inputs.skip_apps }}
         run: |
           set -euo pipefail
 
@@ -120,8 +126,14 @@ jobs:
           OWNER_INCLUDE=$(jq -nc \
             '[{"email":{"email":"marstonr6@gmail.com"}}]')
 
-          # extra_domains: JSON array of additional hostnames to attach to the same app.
-          # Passing an empty array [] means only the primary domain is used.
+          find_app() {
+            local name="$1"
+            curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
+              -H "Authorization: Bearer $CF_TOKEN" | \
+            jq -r --arg n "$name" \
+              '[.result[] | select(.name == $n)] | first | .id // empty'
+          }
+
           make_app() {
             local name="$1" domain="$2" extra_domains="${3:-[]}"
             jq -nc \
@@ -153,41 +165,65 @@ jobs:
               --data @- | jq -r '"  policy \(.result.name // "?") => \(.success)"'
           }
 
-          create_full_access_app() {
-            # Human owner (email OTP) + agents (service token)
-            # Optional $3: JSON array of extra hostnames for self_hosted_domains
-            local name="$1" domain="$2" extra_domains="${3:-[]}"
-            AID=$(make_app "$name" "$domain" "$extra_domains")
-            [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
-            echo "Created app [$name]: $AID"
-            add_policy "$AID" "Goldshore agents"  "non_identity" "$SERVICE_INCLUDE"
-            add_policy "$AID" "Owner access"      "allow"        "$OWNER_INCLUDE"
+          refresh_policies() {
+            local app_id="$1"
+            curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id/policies" \
+              -H "Authorization: Bearer $CF_TOKEN" | \
+            jq -r '.result[].id // empty' | \
+            while read -r pol_id; do
+              [ -z "$pol_id" ] && continue
+              curl -sf -X DELETE \
+                "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id/policies/$pol_id" \
+                -H "Authorization: Bearer $CF_TOKEN" > /dev/null
+              echo "  Deleted old policy: $pol_id"
+            done
           }
 
-          create_agent_app() {
-            # Service token only — no human SSO
-            # Optional $3: JSON array of extra hostnames for self_hosted_domains
+          upsert_full_access() {
             local name="$1" domain="$2" extra_domains="${3:-[]}"
-            AID=$(make_app "$name" "$domain" "$extra_domains")
-            [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
-            echo "Created app [$name]: $AID"
-            add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
+            AID=$(find_app "$name")
+            if [ -n "$AID" ]; then
+              echo "Refreshing policies on existing app [$name]: $AID"
+              refresh_policies "$AID"
+              add_policy "$AID" "Goldshore agents" "non_identity" "$SERVICE_INCLUDE"
+              add_policy "$AID" "Owner access"     "allow"        "$OWNER_INCLUDE"
+            elif [ "$SKIP_NEW_APPS" = "true" ]; then
+              echo "INFO: No existing [$name] app and skip_apps=true — skipped."
+            else
+              AID=$(make_app "$name" "$domain" "$extra_domains")
+              [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
+              echo "Created app [$name]: $AID"
+              add_policy "$AID" "Goldshore agents" "non_identity" "$SERVICE_INCLUDE"
+              add_policy "$AID" "Owner access"     "allow"        "$OWNER_INCLUDE"
+            fi
           }
 
-          # Human + agent access (browser clients call these directly)
-          # Dashboard: protect the /app path only (keeps / public)
-          create_full_access_app "Dashboard" "goldshore.ai/app"
-          # Admin: canonical hostname is admin.goldshore.ai; .org is an alias
-          create_full_access_app "Admin"     "admin.goldshore.ai" '["admin.goldshore.org"]'
-          create_full_access_app "Trading"   "goldshore.org/dash"
-          create_full_access_app "Signals"   "signals.goldshore.ai"
-          # API: scope to /app path so /health, /version, / remain publicly reachable
-          create_full_access_app "API"       "api.goldshore.ai/app"
+          upsert_agent_app() {
+            local name="$1" domain="$2" extra_domains="${3:-[]}"
+            AID=$(find_app "$name")
+            if [ -n "$AID" ]; then
+              echo "Refreshing policies on existing app [$name]: $AID"
+              refresh_policies "$AID"
+              add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
+            elif [ "$SKIP_NEW_APPS" = "true" ]; then
+              echo "INFO: No existing [$name] app and skip_apps=true — skipped."
+            else
+              AID=$(make_app "$name" "$domain" "$extra_domains")
+              [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
+              echo "Created app [$name]: $AID"
+              add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
+            fi
+          }
 
-          # Agent / machine-to-machine only
-          create_agent_app "MCP"     "mcp.goldshore.ai"
-          create_agent_app "Agent"   "agent.goldshore.ai"
-          create_agent_app "Gateway" "gateway.goldshore.ai"
+          upsert_full_access "Dashboard" "goldshore.ai/app"
+          upsert_full_access "Admin"     "admin.goldshore.ai" '["admin.goldshore.org"]'
+          upsert_full_access "Trading"   "goldshore.org/dash"
+          upsert_full_access "Signals"   "signals.goldshore.ai"
+          upsert_full_access "API"       "api.goldshore.ai"
+
+          upsert_agent_app "MCP"     "mcp.goldshore.ai"
+          upsert_agent_app "Agent"   "agent.goldshore.ai"
+          upsert_agent_app "Gateway" "gw.goldshore.ai" '["gateway.goldshore.ai"]'
 
       # ------------------------------------------------------------------ #
       # 4. Propagate secrets to all repos
@@ -251,8 +287,8 @@ jobs:
             echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
             echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
             echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-gateway-prod |"
-            echo "| Full-access apps | Dashboard (/app), Admin (.ai+.org), Trading, Signals, API (/app) |"
-            echo "| Agent-only apps | MCP, Agent, Gateway |"
+            echo "| Full-access apps | Dashboard, Admin (.ai+.org), Trading, Signals, API |"
+            echo "| Agent-only apps | MCP, Agent, Gateway (gw.goldshore.ai+alias) |"
             echo ""
             echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -120,10 +120,16 @@ jobs:
           OWNER_INCLUDE=$(jq -nc \
             '[{"email":{"email":"marstonr6@gmail.com"}}]')
 
+          # extra_domains: JSON array of additional hostnames to attach to the same app.
+          # Passing an empty array [] means only the primary domain is used.
           make_app() {
-            local name="$1" domain="$2"
-            jq -nc --arg n "$name" --arg d "$domain" \
+            local name="$1" domain="$2" extra_domains="${3:-[]}"
+            jq -nc \
+              --arg n "$name" \
+              --arg d "$domain" \
+              --argjson ed "$extra_domains" \
               '{name:$n,type:"self_hosted",domain:$d,
+                self_hosted_domains:([$d] + $ed),
                 session_duration:"24h",
                 http_only_cookie_attribute:true,
                 auto_redirect_to_identity:false}' | \
@@ -149,8 +155,9 @@ jobs:
 
           create_full_access_app() {
             # Human owner (email OTP) + agents (service token)
-            local name="$1" domain="$2"
-            AID=$(make_app "$name" "$domain")
+            # Optional $3: JSON array of extra hostnames for self_hosted_domains
+            local name="$1" domain="$2" extra_domains="${3:-[]}"
+            AID=$(make_app "$name" "$domain" "$extra_domains")
             [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
             echo "Created app [$name]: $AID"
             add_policy "$AID" "Goldshore agents"  "non_identity" "$SERVICE_INCLUDE"
@@ -159,19 +166,23 @@ jobs:
 
           create_agent_app() {
             # Service token only — no human SSO
-            local name="$1" domain="$2"
-            AID=$(make_app "$name" "$domain")
+            # Optional $3: JSON array of extra hostnames for self_hosted_domains
+            local name="$1" domain="$2" extra_domains="${3:-[]}"
+            AID=$(make_app "$name" "$domain" "$extra_domains")
             [ -z "$AID" ] && { echo "WARNING: failed to create $name"; return; }
             echo "Created app [$name]: $AID"
             add_policy "$AID" "Goldshore agents only" "non_identity" "$SERVICE_INCLUDE"
           }
 
           # Human + agent access (browser clients call these directly)
+          # Dashboard: protect the /app path only (keeps / public)
           create_full_access_app "Dashboard" "goldshore.ai/app"
-          create_full_access_app "Admin"     "admin.goldshore.org"
+          # Admin: canonical hostname is admin.goldshore.ai; .org is an alias
+          create_full_access_app "Admin"     "admin.goldshore.ai" '["admin.goldshore.org"]'
           create_full_access_app "Trading"   "goldshore.org/dash"
           create_full_access_app "Signals"   "signals.goldshore.ai"
-          create_full_access_app "API"       "api.goldshore.ai"
+          # API: scope to /app path so /health, /version, / remain publicly reachable
+          create_full_access_app "API"       "api.goldshore.ai/app"
 
           # Agent / machine-to-machine only
           create_agent_app "MCP"     "mcp.goldshore.ai"
@@ -240,7 +251,7 @@ jobs:
             echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
             echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
             echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-gateway-prod |"
-            echo "| Full-access apps | Dashboard, Admin, Trading, Signals, API |"
+            echo "| Full-access apps | Dashboard (/app), Admin (.ai+.org), Trading, Signals, API (/app) |"
             echo "| Agent-only apps | MCP, Agent, Gateway |"
             echo ""
             echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -167,18 +167,24 @@ jobs:
               '[.result[] | select(.name == $n)] | first | .id // empty'
           }
 
-          # PATCH existing app domain/self_hosted_domains so stale bindings from
-          # prior runs are corrected (e.g. old Trading domain, old Gateway aliases)
-          patch_app_domains() {
-            local app_id="$1" domain="$2" extra_domains="${3:-[]}"
+          # PUT existing app with full body so stale domain/path bindings from
+          # prior runs are corrected. CF Access uses PUT (not PATCH) for updates;
+          # a PATCH would fail under set -euo pipefail after token revoke.
+          update_app() {
+            local app_id="$1" name="$2" domain="$3" extra_domains="${4:-[]}"
             jq -nc \
+              --arg n "$name" \
               --arg d "$domain" \
               --argjson ed "$extra_domains" \
-              '{domain:$d,self_hosted_domains:([$d] + $ed)}' | \
-            curl -sf -X PATCH "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id" \
+              '{name:$n,type:"self_hosted",domain:$d,
+                self_hosted_domains:([$d] + $ed),
+                session_duration:"24h",
+                http_only_cookie_attribute:true,
+                auto_redirect_to_identity:false}' | \
+            curl -sf -X PUT "$CF_API/accounts/$CF_ACCOUNT/access/apps/$app_id" \
               -H "Authorization: Bearer $CF_TOKEN" \
               -H "Content-Type: application/json" \
-              --data @- | jq -r '"  patched domains => \(.success)"'
+              --data @- | jq -r '"  updated app => \(.success)"'
           }
 
           # Create a new app and return the full CF response JSON.
@@ -237,8 +243,8 @@ jobs:
             local name="$1" domain="$2" extra_domains="${3:-[]}" aud_workers="${4:-}"
             AID=$(find_app "$name")
             if [ -n "$AID" ]; then
-              echo "Found existing app [$name]: $AID — patching domains and refreshing policies"
-              patch_app_domains "$AID" "$domain" "$extra_domains"
+              echo "Found existing app [$name]: $AID — updating and refreshing policies"
+              update_app "$AID" "$name" "$domain" "$extra_domains"
               refresh_policies "$AID"
               add_policy "$AID" "Goldshore agents" "non_identity" "$SERVICE_INCLUDE"
               add_policy "$AID" "Owner access"     "allow"        "$OWNER_INCLUDE"
@@ -262,8 +268,7 @@ jobs:
           }
 
           # upsert_bypass_app: creates a path-scoped Access app with a bypass-everyone policy.
-          # Used for public paths that must not hit the Access login wall:
-          # Trading OAuth callbacks, API/Gateway public probes.
+          # Used for public paths that must not hit the Access login wall.
           # CF Access resolves the more-specific path-scoped app before the broader allow app.
           upsert_bypass_app() {
             local name="$1" domain="$2" extra_domains="${3:-[]}"
@@ -293,10 +298,16 @@ jobs:
           # than the broader allow apps that cover the same hostnames.
           # ------------------------------------------------------------------
 
-          # Trading: Schwab/Robinhood redirect to these without an Access session
-          upsert_bypass_app "GoldShore Trading - OAuth Bypass" \
-            "trading.goldshore.ai/oauth" \
-            '["dashboard.goldshore.ai/oauth","dash.goldshore.ai/oauth"]'
+          # Trading OAuth: only the broker redirect-target callbacks bypass Access.
+          # /oauth/schwab/authorize and /oauth/robinhood/token remain behind Access
+          # (operator-only broker auth initiation paths per routes/oauth.ts).
+          upsert_bypass_app "GoldShore Trading - Schwab Callback" \
+            "trading.goldshore.ai/oauth/schwab/callback" \
+            '["dashboard.goldshore.ai/oauth/schwab/callback","dash.goldshore.ai/oauth/schwab/callback"]'
+
+          upsert_bypass_app "GoldShore Trading - Robinhood Callback" \
+            "trading.goldshore.ai/oauth/robinhood/callback" \
+            '["dashboard.goldshore.ai/oauth/robinhood/callback","dash.goldshore.ai/oauth/robinhood/callback"]'
 
           # API: /health, /status, /version must be reachable by monitoring
           upsert_bypass_app "Goldshore API - Public Probes" \
@@ -399,7 +410,7 @@ jobs:
             echo "| CF-Access-Client-Id | \`$CLIENT_ID\` |"
             echo "| GitHub secrets | goldshore-ai, goldshore-gateway, goldclaw |"
             echo "| Worker secrets | gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-api-prod, gs-gateway-prod |"
-            echo "| Bypass apps | Trading OAuth, API Probes, Gateway Probes |"
+            echo "| Bypass apps | Schwab Callback, Robinhood Callback, API Probes, Gateway Probes |"
             echo "| Full-access apps | Dashboard, GoldShore Admin, GoldShore Trading, Goldshore Ops, Signals, Goldshore API, GoldShore MCP, Goldshore Gateway, GoldShore-Web-Preview |"
             echo ""
             echo "> CF-Access-Client-Secret is stored in secrets only — never printed here."

--- a/docs/secrets-reference.md
+++ b/docs/secrets-reference.md
@@ -1,0 +1,40 @@
+# Repository Secrets Reference
+
+Add or update these secrets at the links below. Never commit values to git.
+
+---
+
+## goldshore-ai
+
+**Settings → Secrets:** https://github.com/marzton/goldshore-ai/settings/secrets/actions
+
+| Secret Name | What it is | Where to get it |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token (read/write Workers, D1, KV, R2) | https://dash.cloudflare.com/profile/api-tokens |
+| `CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN` | Cloudflare deploy token scoped to goldshore-ai Workers | https://dash.cloudflare.com/profile/api-tokens |
+| `GOOGLE_CHAT_WEBHOOK` | Google Chat space webhook URL for CI notifications | chat.google.com → Space → Apps & integrations → Webhooks |
+| `GOOGLE_OAUTH_CLIENT_ID` | GCP OAuth 2.0 client ID — name gs-api reads for OAuth/GoldClaw routes | https://console.cloud.google.com/apis/credentials |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | GCP OAuth 2.0 client secret — name gs-api reads; absent → 503 on OAuth routes | https://console.cloud.google.com/apis/credentials |
+| `GOOGLE_ADS_DEVELOPER_TOKEN` | Google Ads API developer token | https://ads.google.com/aw/apicenter |
+| `GH_PAT` | GitHub PAT with `repo` + `workflow` scopes (branch protection) | https://github.com/settings/tokens |
+
+---
+
+## goldshore-gateway
+
+**Settings → Secrets:** https://github.com/marzton/goldshore-gateway/settings/secrets/actions
+
+| Secret Name | What it is | Where to get it |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token (same token as goldshore-ai is fine) | https://dash.cloudflare.com/profile/api-tokens |
+| `GOOGLE_CHAT_WEBHOOK` | Same webhook URL as goldshore-ai | chat.google.com → Space → Apps & integrations → Webhooks |
+
+---
+
+## Notes
+
+- `CLOUDFLARE_API_TOKEN` in goldshore-gateway is currently expired — renewing it unblocks PR #213 CI checks (`verify-cloudflare`, `verify-account-resources`).
+- `GOOGLE_ADS_DEVELOPER_TOKEN` — rotate the previous token before adding (prior value was shared in chat).
+- GCP service account key (`github-storage-access`) — revoke the old key at https://console.cloud.google.com/iam-admin/serviceaccounts → `github-storage-access` → Manage Keys before creating a new one.
+- `GOOGLE_CHAT_WEBHOOK` must exist in both repos before the Monday 9am UTC reminder fires.
+- **OAuth secret names**: gs-api reads `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET`. Setting `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` instead will not work — OAuth routes return 503.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/setup-cf-agent-access.yml` — a one-shot `workflow_dispatch` workflow that rotates the compromised CF Access Service Token and upserts all Access Applications with correct policies.

Must merge to `main` to be triggerable (GitHub requires `workflow_dispatch` on the default branch).

## What the workflow does

1. **Verifies** `CLOUDFLARE_API_TOKEN` has both `Access: Service Tokens (Edit)` AND `Access: Apps and Policies (Edit)` — probes both endpoints before any destructive step, so a token missing Apps/Policies edit aborts before revocation
2. **Revokes** the compromised service token (`9ca952086adc30cf53634d78d099ce58.access`) if still present
3. **Creates** a new `goldshore-agents` CF Access Service Token
4. **Upserts 12 CF Access Applications** with correct policies:
   - **Bypass (path-scoped, public):** Trading OAuth callbacks, API public probes (`/health /status /version`), Gateway public probes
   - **Full access (human Workspace domain + personal OTP + service token):** Dashboard, GoldShore Admin, GoldShore Trading, Goldshore Ops, Signals, Goldshore API, GoldShore MCP, Goldshore Gateway, GoldShore-Web-Preview
   - Existing apps: domains patched + non-bypass policies refreshed (bypass rules preserved)
   - New apps: AUD propagated as `CLOUDFLARE_ACCESS_AUDIENCE` to relevant Workers
5. **Propagates** `CF_ACCESS_CLIENT_ID` + `CF_ACCESS_CLIENT_SECRET` as GitHub secrets to goldshore-ai, goldshore-gateway, goldclaw
6. **Pushes** the same credentials as Worker secrets to gs-agent, gs-agent-prod, gs-mcp, gs-api, gs-api-prod, gs-gateway-prod

## Prerequisites before triggering

- `CLOUDFLARE_API_TOKEN` must have `Access: Service Tokens (Edit)` + `Access: Apps and Policies (Edit)` (edit at dash.cloudflare.com/profile/api-tokens) — renew if expired
- `GH_PAT` secret must exist in goldshore-ai with `repo` + `secrets` scope across the three target repos
- Each protected subdomain must be orange-clouded (proxied through Cloudflare) for Access to intercept traffic

## How to trigger after merge

Actions → **Setup CF Agent Access** → Run workflow → leave both toggles unchecked → Run

---
_Generated by [Claude Code](https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5)_