### PR TITLE
Normalize Cloudflare secret names and enforce canonical build token

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -50,7 +50,7 @@ concurrency:
 
 env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN || secrets.CF_WORKERS_BUILDS }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
 
 # ── Shared setup ──────────────────────────────────────────────────────────────
 # Each job repeats the three setup steps (checkout / pnpm / node) because

--- a/.github/workflows/infrastructure-guard.yml
+++ b/.github/workflows/infrastructure-guard.yml
@@ -154,20 +154,20 @@ jobs:
       - name: Verify Cloudflare credentials
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
         run: |
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing: CLOUDFLARE_ACCOUNT_ID" && exit 1)
-          test -n "$CF_WORKERS_BUILDS" || (echo "Missing: CF_WORKERS_BUILDS" && exit 1)
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
 
       - name: Audit live Cloudflare state against manifest
         env:
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           python3 - <<'PY'
           import json, os, urllib.request, urllib.error
 
-          TOKEN = os.environ["CF_WORKERS_BUILDS"]
+          TOKEN = os.environ["CLOUDFLARE_BUILD_API_TOKEN"]
           ACCOUNT = os.environ["CLOUDFLARE_ACCOUNT_ID"]
 
           def cf_get(path):

--- a/.github/workflows/preview-gs-api.yml
+++ b/.github/workflows/preview-gs-api.yml
@@ -49,6 +49,6 @@ jobs:
       - name: Deploy GS API worker preview to Cloudflare
         working-directory: apps/gs-api
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm exec wrangler deploy --env preview --config wrangler.toml

--- a/.github/workflows/setup-preview-dns.yml
+++ b/.github/workflows/setup-preview-dns.yml
@@ -18,15 +18,15 @@ jobs:
 
       - name: Run DNS setup script
         env:
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          test -n "$CF_WORKERS_BUILDS" || (echo "Missing required secret: CF_WORKERS_BUILDS" && exit 1)
+          test -n "$CLOUDFLARE_BUILD_API_TOKEN" || (echo "Missing required secret: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
           test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "Missing required secret: CLOUDFLARE_ACCOUNT_ID" && exit 1)
 
       - name: Configure preview DNS
         env:
-          CF_WORKERS_BUILDS: ${{ secrets.CF_WORKERS_BUILDS }}
+          CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: node scripts/setup-preview-dns.mjs

--- a/docs/ci/cloudflare-secret-matrix.md
+++ b/docs/ci/cloudflare-secret-matrix.md
@@ -1,0 +1,36 @@
+# Cloudflare CI Secret Matrix
+
+This matrix standardizes Cloudflare GitHub Actions secrets across GoldShore repositories while preserving least privilege. Each repository should store only the canonical secret names below unless a platform/security owner explicitly approves an exception.
+
+## Canonical secrets
+
+| Secret | Purpose |
+|---|---|
+| `CLOUDFLARE_BUILD_API_TOKEN` | Repository-scoped Cloudflare token with only the scopes listed for that repository. |
+| `CLOUDFLARE_ACCOUNT_ID` | Target Cloudflare account ID for Wrangler, Pages, and Cloudflare API calls. |
+
+Do not store a second copy of the same token as `CLOUDFLARE_API_TOKEN`. If a legacy workflow or CLI expects `CLOUDFLARE_API_TOKEN`, set the runtime environment variable from the canonical secret during workflow execution:
+
+```yaml
+env:
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+```
+
+## Repository scope matrix
+
+| Repository | Workers Scripts Edit | Workers KV Storage Edit | Pages Edit | D1 Edit | R2 Edit | Zone Read | DNS Edit | Access Apps Edit | Notes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---|
+| `goldshore-ai` | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Platform monorepo deploys Workers, Pages, KV, D1, R2, DNS/routing, and Access policy automation. |
+| `goldshore` | Yes | No | Yes | No | No | Yes | Yes | No | Public web/app repo needs Workers/Pages deploy plus zone/DNS changes for routes and custom domains. |
+| `goldshore-gateway` | Yes | Yes | No | No | No | Yes | Yes | Yes | Gateway deploys Worker code, reads/writes gateway KV, manages route DNS, and may update Access app policies for protected gateway routes. |
+| `goldshore-admin` | No | No | Yes | No | No | Yes | Yes | Yes | Admin is a Pages application protected by Cloudflare Access and may require DNS/custom-domain updates. |
+| `banproof-me` | Yes | No | No | No | No | Yes | Yes | No | Standalone Worker deploy with route/custom-domain DNS management. |
+
+## Least-privilege rules
+
+- Create one Cloudflare API token per repository with only the scopes marked `Yes` above.
+- Avoid a single account-wide super-token in every repository unless platform/security owners explicitly approve it and document the exception.
+- Rotate repository tokens independently so a compromise in one repository does not grant broader Cloudflare access than needed.
+- Keep `CLOUDFLARE_BUILD_API_TOKEN` owned by the service/platform owner responsible for Cloudflare builds; keep `CLOUDFLARE_ACCOUNT_ID` owned by Cloudflare account admins.
+- When new Cloudflare capabilities are added, update this matrix before broadening any repository token.

--- a/scripts/check-cloudflare-token-policy.sh
+++ b/scripts/check-cloudflare-token-policy.sh
@@ -11,8 +11,8 @@ if rg -n 'CLOUDFLARE_(BUILD_)?API_TOKEN:\s*\$\{\{[^}]*\|\|[^}]*\}\}' "$workflows
 fi
 
 echo "Checking canonical deploy token wiring..."
-if ! rg -n 'CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CF_WORKERS_BUILDS\s*\}\}' "$workflows_dir/deploy-platform.yml" >/dev/null; then
-  echo "❌ deploy-platform.yml must set CLOUDFLARE_API_TOKEN from secrets.CF_WORKERS_BUILDS"
+if ! rg -n 'CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CLOUDFLARE_BUILD_API_TOKEN\s*\}\}' "$workflows_dir/deploy-platform.yml" >/dev/null; then
+  echo "❌ deploy-platform.yml must set CLOUDFLARE_API_TOKEN from secrets.CLOUDFLARE_BUILD_API_TOKEN"
   exit 1
 fi
 


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Standardize Cloudflare GitHub Actions secrets across repos to a single canonical name and preserve least-privilege token scopes.  
- Replace ad-hoc fallbacks and legacy token names (`CF_WORKERS_BUILDS`, `CLOUDFLARE_API_TOKEN`) with `CLOUDFLARE_BUILD_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.  
- Ensure CI/workflows and infra checks enforce the canonical secret and provide runtime mapping for legacy tooling when needed.  

### Description
- Add `docs/ci/cloudflare-secret-matrix.md` documenting canonical secrets, per-repo scope matrix, runtime mapping guidance for legacy consumers, and least-privilege rules.  
- Update workflows to use the canonical secret by changing `.github/workflows/deploy-platform.yml`, `.github/workflows/preview-gs-api.yml`, `.github/workflows/setup-preview-dns.yml`, and `.github/workflows/infrastructure-guard.yml` to reference `CLOUDFLARE_BUILD_API_TOKEN` (and set `CLOUDFLARE_API_TOKEN` from it at runtime where required).  
- Replace occurrences of `CF_WORKERS_BUILDS` and remove fallback expressions so `CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}` is enforced.  
- Update `scripts/check-cloudflare-token-policy.sh` to reject fallback secret expressions and verify the deploy wiring uses `secrets.CLOUDFLARE_BUILD_API_TOKEN`.  

### Testing
- Ran `bash scripts/check-cloudflare-token-policy.sh` and it passed with `✅ Cloudflare token policy checks passed.`.  
- Ran `git diff --check` which produced no whitespace or diff errors.  
- Attempted YAML parsing via Python but `PyYAML` was not installed in the environment so that additional parse check was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45cb10be8c83319bc9c679a067577a)