### PR TITLE
docs: align CI token policy

### DIFF
--- a/docs/ci/INFRA_SYNC_RUNBOOK.md
+++ b/docs/ci/INFRA_SYNC_RUNBOOK.md
@@ -4,6 +4,8 @@ Use `.github/workflows/maintenance.yml` to run Cloudflare infrastructure reconci
 
 For incident triage and guardrail verification, inspect and run `.github/workflows/cloudflare-infra-guard.yml` (the canonical replacement for the retired Cloudflare Pages guard workflow path).
 
+For ownership and canonical Cloudflare infrastructure context, cross-reference `policy/REPO_OWNERSHIP.md` and `infra/Cloudflare/README.md`.
+
 ## Trigger model
 
 - **Manual (`workflow_dispatch`):** the only trigger; recommended for urgent reconciliation, post-incident verification, or post-rotation validation.
@@ -20,14 +22,12 @@ Run `Maintenance: Cloudflare Infra Reconcile` manually when:
 
 Set these repository secrets before enabling the workflow:
 
-- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_BUILD_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
 - `CLOUDFLARE_KV_NAMESPACE_API_ID`
 - `CLOUDFLARE_KV_NAMESPACE_GATEWAY_ID`
 
-Optional for token rotation without downtime:
-
-- `CLOUDFLARE_BUILD_API_TOKEN` (if set, workflows prefer this token and fall back to `CLOUDFLARE_API_TOKEN`)
+Active deploy and reconciliation workflows use `CLOUDFLARE_BUILD_API_TOKEN` as the single Cloudflare deploy token. Some workflow steps may still export runtime environment variable `CLOUDFLARE_API_TOKEN` from `secrets.CLOUDFLARE_BUILD_API_TOKEN` when Wrangler or scripts expect that variable name; do not create or rotate `CLOUDFLARE_API_TOKEN` as a separate deploy credential.
 
 Do not store Cloudflare credentials or namespace IDs in tracked workflow files or scripts.
 
@@ -51,22 +51,22 @@ For each Worker/Pages project involved in the deploy chain:
 
 Rotate the GitHub Actions secrets in the same maintenance window so preview and production jobs consume the same credential set:
 
-- Update `CLOUDFLARE_API_TOKEN` if the base deploy token changed.
-- Update `CLOUDFLARE_BUILD_API_TOKEN` if you are using the dedicated build-token override path.
+- Update `CLOUDFLARE_BUILD_API_TOKEN` when the active deploy token changes.
 - Confirm `CLOUDFLARE_ACCOUNT_ID` is still the correct target account.
+- Do not rotate `CLOUDFLARE_API_TOKEN` as a separate deploy token; if a job needs that runtime variable name, map it from `secrets.CLOUDFLARE_BUILD_API_TOKEN`.
 
 #### Workflow-to-secret map
 
 | Workflow | Purpose | Secrets consumed in repo | Rotation note |
 | --- | --- | --- | --- |
-| `.github/workflows/deploy-gs-api.yml` | `main` → production deploy for `gs-api` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Keep the build-token override aligned with preview so both environments rotate together. |
-| `.github/workflows/preview-gs-api.yml` | PR preview deploy for `gs-api` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Uses the same build-token fallback as production; rotate both together. |
-| `.github/workflows/deploy-gs-gateway.yml` | `main` → production deploy for `gs-gateway` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Keep the production gateway token aligned with preview because both now use the same fallback chain. |
-| `.github/workflows/preview-gs-gateway.yml` | PR preview deploy for `gs-gateway` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Prefer updating both token secrets during rotation so fallback behavior is deterministic. |
-| `.github/workflows/deploy-gs-control.yml` | `main` → production deploy for `gs-control` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Active production deploy; rotate the override token in the same window as the other worker deploys. |
-| `.github/workflows/preview-gs-agent.yml` | PR preview deploy for `gs-agent` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Include when agent preview retries share the same maintenance window. |
-| `.github/workflows/deploy-gs-agent.yml` | `main` → production deploy for `gs-agent` | `CLOUDFLARE_BUILD_API_TOKEN` **or** `CLOUDFLARE_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Active production deploy; keep it in sync with the preview workflow because both use the same fallback token model. |
-| `.github/workflows/maintenance.yml` | manual infra reconciliation after rotation | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `GS_KV_NAMESPACE_ID` | Run after secret updates to confirm the repo can still reconcile Cloudflare state. |
+| `.github/workflows/deploy-gs-api.yml` | `main` → production deploy for `gs-api` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Rotate the single build token with preview so both environments stay aligned. |
+| `.github/workflows/preview-gs-api.yml` | PR preview deploy for `gs-api` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Uses the same single build token as production; rotate both together. |
+| `.github/workflows/deploy-gs-gateway.yml` | `main` → production deploy for `gs-gateway` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Keep the production gateway token aligned with preview because both use the same build token. |
+| `.github/workflows/preview-gs-gateway.yml` | PR preview deploy for `gs-gateway` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Update the single build token during rotation so behavior is deterministic. |
+| `.github/workflows/deploy-gs-control.yml` | `main` → production deploy for `gs-control` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Active production deploy; rotate the single build token in the same window as the other worker deploys. |
+| `.github/workflows/preview-gs-agent.yml` | PR preview deploy for `gs-agent` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Include when agent preview retries share the same maintenance window. |
+| `.github/workflows/deploy-gs-agent.yml` | `main` → production deploy for `gs-agent` | `CLOUDFLARE_BUILD_API_TOKEN`, plus `CLOUDFLARE_ACCOUNT_ID` | Active production deploy; keep it in sync with the preview workflow because both use the same build token model. |
+| `.github/workflows/maintenance.yml` | manual infra reconciliation after rotation | `CLOUDFLARE_BUILD_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `GS_KV_NAMESPACE_ID` | Run after secret updates to confirm the repo can still reconcile Cloudflare state; steps may expose `CLOUDFLARE_API_TOKEN` from the build-token secret for Wrangler/script compatibility. |
 
 ### 3. Reconcile preview worker environments and service names in Cloudflare
 
@@ -97,4 +97,4 @@ After Cloudflare and GitHub secrets are updated:
 1. Rerun the failed preview jobs first so branch environments recover quickly.
 2. Rerun the related production deploy jobs if they were blocked by the same token issue.
 3. Manually run `.github/workflows/maintenance.yml` to confirm the new secret set can still reconcile infra state.
-4. Record which token secret path was used (`CLOUDFLARE_API_TOKEN` only vs. `CLOUDFLARE_BUILD_API_TOKEN` override) so the next rotation stays consistent.
+4. Record that the `CLOUDFLARE_BUILD_API_TOKEN` path was used so the next rotation stays consistent.


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Align the infra sync runbook with the current single-token Cloudflare deployment policy so workflows consistently use the build token.
- Remove legacy guidance that suggested rotating `CLOUDFLARE_API_TOKEN` as a separate deploy credential to avoid operational confusion.
- Ensure runtime compatibility by noting that `CLOUDFLARE_API_TOKEN` may still be populated from `secrets.CLOUDFLARE_BUILD_API_TOKEN` when tools expect that variable name.
- Surface ownership context by cross-referencing `policy/REPO_OWNERSHIP.md` and `infra/Cloudflare/README.md` for canonical infra information.

### Description
- Updated `docs/ci/INFRA_SYNC_RUNBOOK.md` to document `CLOUDFLARE_BUILD_API_TOKEN` as the single active Cloudflare deploy token and to remove fallback/legacy references to `CLOUDFLARE_API_TOKEN`.
- Rewrote the "Required GitHub Secrets" and rotation checklist to instruct updating only `CLOUDFLARE_BUILD_API_TOKEN` and to map `CLOUDFLARE_API_TOKEN` from the build-token secret only when needed by Wrangler/scripts.
- Edited the workflow-to-secret table so each workflow now lists `CLOUDFLARE_BUILD_API_TOKEN` (and `CLOUDFLARE_ACCOUNT_ID`) instead of a build-token fallback pair.
- Added a cross-reference note to `policy/REPO_OWNERSHIP.md` and `infra/Cloudflare/README.md` for ownership and canonical Cloudflare context.

### Testing
- Ran `git diff --check` to validate the working tree had no whitespace or diff issues and it passed.
- Ran a targeted search with `rg` to confirm legacy `CLOUDFLARE_API_TOKEN` fallback text was removed or replaced and the expected `CLOUDFLARE_BUILD_API_TOKEN` references appear, and the search returned the expected matches.
- Committed the updated `docs/ci/INFRA_SYNC_RUNBOOK.md` file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45cb14b6108331bec035b4dba8f4e5)