### PR TITLE
Forward Access credentials from admin proxy and restrict integration mutations to system:integrations:manage

### DIFF
--- a/apps/gs-admin/src/pages/api/integrations/manage.test.ts
+++ b/apps/gs-admin/src/pages/api/integrations/manage.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildGsApiAccessHeaders } from './manage';
+
+test('buildGsApiAccessHeaders forwards Cloudflare Access assertion and cookie', () => {
+  const request = new Request('https://admin.goldshore.ai/api/integrations/manage', {
+    headers: {
+      'CF-Access-Jwt-Assertion': 'verified-access-token',
+      Cookie: 'CF_Authorization=verified-access-cookie; session=admin',
+    },
+  });
+
+  const headers = buildGsApiAccessHeaders(request);
+
+  assert.equal(headers.get('Content-Type'), 'application/json');
+  assert.equal(headers.get('CF-Access-Jwt-Assertion'), 'verified-access-token');
+  assert.equal(headers.get('Cookie'), 'CF_Authorization=verified-access-cookie; session=admin');
+});

--- a/apps/gs-admin/src/pages/api/integrations/manage.ts
+++ b/apps/gs-admin/src/pages/api/integrations/manage.ts
@@ -1,15 +1,29 @@
 import type { APIRoute } from 'astro';
 
+const ACCESS_ASSERTION_HEADER = 'CF-Access-Jwt-Assertion';
+const ACCESS_COOKIE_HEADER = 'Cookie';
+
+export const buildGsApiAccessHeaders = (request: Request): Headers => {
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  const accessAssertion = request.headers.get(ACCESS_ASSERTION_HEADER);
+  if (accessAssertion) {
+    headers.set(ACCESS_ASSERTION_HEADER, accessAssertion);
+  }
+
+  const accessCookie = request.headers.get(ACCESS_COOKIE_HEADER);
+  if (accessCookie) {
+    headers.set(ACCESS_COOKIE_HEADER, accessCookie);
+  }
+
+  return headers;
+};
+
 export const GET: APIRoute = async ({ url, request }) => {
   try {
     const gsApiUrl = import.meta.env.PUBLIC_GS_API_URL || 'https://api.goldshore.ai';
     const action = url.searchParams.get('action') || 'list';
 
-    const headers: HeadersInit = { 'Content-Type': 'application/json' };
-    const cfJwt = request.headers.get('CF-Access-Jwt-Assertion');
-    if (cfJwt) {
-      headers['CF-Access-Jwt-Assertion'] = cfJwt;
-    }
+    const headers = buildGsApiAccessHeaders(request);
 
     const response = await fetch(`${gsApiUrl}/integrations?action=${encodeURIComponent(action)}`, {
       method: 'GET',
@@ -35,11 +49,7 @@ export const POST: APIRoute = async ({ request }) => {
     const body = await request.json();
     const gsApiUrl = import.meta.env.PUBLIC_GS_API_URL || 'https://api.goldshore.ai';
 
-    const headers: HeadersInit = { 'Content-Type': 'application/json' };
-    const cfJwt = request.headers.get('CF-Access-Jwt-Assertion');
-    if (cfJwt) {
-      headers['CF-Access-Jwt-Assertion'] = cfJwt;
-    }
+    const headers = buildGsApiAccessHeaders(request);
 
     const response = await fetch(`${gsApiUrl}/integrations`, {
       method: 'POST',

--- a/apps/gs-api/src/routes/integrations.test.ts
+++ b/apps/gs-api/src/routes/integrations.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import integrations from './integrations';
+import type { Env, Variables } from '../types';
+
+const mockKV = {
+  put: mock.fn(async () => {}),
+  get: mock.fn(async () => null),
+  delete: mock.fn(async () => {}),
+  list: mock.fn(async () => ({ keys: [] })),
+};
+
+const createTestApp = (claims: any = null) => {
+  const app = new Hono<{ Bindings: Env; Variables: Variables }>();
+
+  app.use('*', async (c, next) => {
+    c.set('accessClaims', claims);
+    c.env = { KV: mockKV } as any;
+    await next();
+  });
+
+  app.route('/integrations', integrations);
+  return app;
+};
+
+describe('Integration management API security', () => {
+  it('rejects integration mutations without integration management permission', async () => {
+    const app = createTestApp({ roles: ['viewer'], email: 'viewer@example.com' });
+
+    const res = await app.request('/integrations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'delete', config: { name: 'facebook' } }),
+    });
+
+    assert.equal(res.status, 403);
+  });
+});

--- a/apps/gs-api/src/routes/integrations.ts
+++ b/apps/gs-api/src/routes/integrations.ts
@@ -38,7 +38,7 @@ integrations.get("/", async (c) => {
 
       case "sync": {
         const session = buildAdminSession(c.get("accessClaims"));
-        if (!hasAdminPermission(session.permissions, "system:write")) {
+        if (!hasAdminPermission(session.permissions, "system:integrations:manage")) {
           return c.json({ error: "Forbidden" }, 403);
         }
         const results = await registry.syncAll();
@@ -59,8 +59,8 @@ integrations.get("/", async (c) => {
   }
 });
 
-// POST /integrations - Create or delete integrations (requires system:write permission)
-integrations.post("/", requirePermission("system:write"), async (c) => {
+// POST /integrations - Create or delete integrations (requires system:integrations:manage permission)
+integrations.post("/", requirePermission("system:integrations:manage"), async (c) => {
   const kv = c.env.KV;
 
   if (!kv) {


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Admin integration proxy calls to the terminal `gs-api` `/integrations` handler were not forwarding Cloudflare Access credentials, causing authenticated requests from the dashboard to be rejected with 401s.  
- Integration mutation and sync endpoints were gated by the broad `system:write` permission instead of the dedicated integration management permission, allowing principals with Access but without integration privileges to modify stored credentials.

### Description
- Added `buildGsApiAccessHeaders(request)` to `apps/gs-admin/src/pages/api/integrations/manage.ts` to forward `CF-Access-Jwt-Assertion` and the `Cookie` header along with `Content-Type` for both GET and POST proxy requests.  
- Replaced the coarse `system:write` checks with the dedicated `system:integrations:manage` guard in `apps/gs-api/src/routes/integrations.ts` for the `sync` action and the POST mutation route.  
- Added regression tests: `apps/gs-admin/src/pages/api/integrations/manage.test.ts` to assert header forwarding, and `apps/gs-api/src/routes/integrations.test.ts` to assert that mutation attempts without `system:integrations:manage` fail.  
- Updated handler comments and small error paths to match the stricter permission model and forwarding behavior.

### Testing
- Ran `pnpm --filter @goldshore/gs-api test` which executed the `gs-api` test suite and all tests passed (`56` tests, `0` failures).  
- Ran the new admin test with `pnpm exec tsx --test apps/gs-admin/src/pages/api/integrations/manage.test.ts` and it passed (`1` test, `0` failures).  
- Both added regression tests pass locally and verify header forwarding and permission denial as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51c158f5b88331b5bf4c392db68785)