### PR TITLE
fix: harden CF Access setup workflow

### DIFF
--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -85,6 +85,59 @@ jobs:
           echo "All required CF API permissions verified."
 
       # ------------------------------------------------------------------ #
+      # 0a. When skip_apps=true, verify required apps exist before rotating
+      #     or revoking any service token. Policy refreshes still run later;
+      #     this guard only prevents issuing credentials that cannot be
+      #     attached to every required Access app.
+      # ------------------------------------------------------------------ #
+      - name: Preflight existing Access apps when app creation is skipped
+        if: ${{ inputs.skip_apps }}
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          INCLUDE_SSH_LAPTOP: ${{ inputs.include_ssh_laptop }}
+          INCLUDE_MCP_PORTAL: ${{ inputs.include_mcp_portal }}
+        run: |
+          set -euo pipefail
+
+          APPS=$(curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
+            -H "Authorization: Bearer $CF_TOKEN")
+
+          require_app() {
+            local name="$1" domain="${2:-}"
+            local id
+            id=$(echo "$APPS" | jq -r --arg n "$name" --arg d "$domain" \
+              '[.result[] | select(.name == $n or ($d != "" and ((.domain == $d) or ((.self_hosted_domains // []) | index($d)))))] | first | .id // empty')
+            if [ -z "$id" ]; then
+              echo "::error::skip_apps=true but required Access app is missing: $name ($domain)."
+              return 1
+            fi
+            echo "Preflight found Access app [$name]: $id"
+          }
+
+          require_app "GoldShore Trading - Schwab Callback" "trading.goldshore.ai/oauth/schwab/callback"
+          require_app "GoldShore Trading - Robinhood Callback" "trading.goldshore.ai/oauth/robinhood/callback"
+          require_app "Goldshore API - Public Probes" "api.goldshore.ai/health"
+          require_app "Goldshore Gateway - Public Probes" "gw.goldshore.ai/health"
+          require_app "Dashboard" "goldshore.ai/app"
+          require_app "GoldShore Admin" "admin.goldshore.ai"
+          require_app "GoldShore Trading" "trading.goldshore.ai"
+          require_app "Goldshore Ops" "ops.goldshore.ai"
+          require_app "Signals" "signals.goldshore.ai"
+          require_app "Goldshore API" "api.goldshore.ai"
+          require_app "GoldShore MCP" "mcp.goldshore.ai"
+          require_app "Goldshore Gateway" "gw.goldshore.ai"
+          require_app "GoldShore-Web-Preview" "preview.goldshore.ai"
+
+          if [ "$INCLUDE_SSH_LAPTOP" = "true" ]; then
+            require_app "Temp HP Laptop SSH" "ssh-laptop.goldshore.ai"
+          fi
+          if [ "$INCLUDE_MCP_PORTAL" = "true" ]; then
+            require_app "Goldshore MCP Portal" "mcp.goldshore.ai"
+          fi
+
+          echo "skip_apps preflight passed; token rotation can safely proceed to policy refresh."
+
+      # ------------------------------------------------------------------ #
       # 1. Revoke compromised service token
       # ------------------------------------------------------------------ #
       - name: Revoke compromised service token
@@ -454,7 +507,12 @@ jobs:
           # because browser-based admin routes call api.goldshore.ai with
           # credentials: 'include' and need a human Cloudflare Access session.
           # Service-token-only access is limited to machine-only/path-scoped apps.
-          upsert_full_access "Goldshore API"     "api.goldshore.ai" "[]" \
+          # Keep this app on the full api.goldshore.ai host and list every
+          # protected route family served by gs-api so Access issues one AUD for
+          # browser calls to /goldclaw, /admin, /users, /ai, /v1, etc. The public
+          # probes above remain path-scoped bypass apps.
+          API_PROTECTED_DOMAINS='["api.goldshore.ai/goldclaw","api.goldshore.ai/admin","api.goldshore.ai/users","api.goldshore.ai/ai","api.goldshore.ai/v1"]'
+          upsert_full_access "Goldshore API"     "api.goldshore.ai" "$API_PROTECTED_DOMAINS" \
             "gs-api gs-api-prod"
           # GoldShore MCP: human + agent per docs ("approved human identities and agents")
           upsert_full_access "GoldShore MCP"     "mcp.goldshore.ai" "[]" \
@@ -469,6 +527,8 @@ jobs:
           if [ "$MISSING_REQUIRED_APPS" -ne 0 ]; then
             echo "::error::One or more required Access apps were missing while skip_apps=true. Policies were not updated for those apps, so new credentials were not propagated."
             exit 1
+          fi
+
           # ------------------------------------------------------------------
           # Gated apps (workflow_dispatch inputs)
           # ------------------------------------------------------------------


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Prevent accidental rotation of Cloudflare Access credentials that cannot be trusted by existing apps when `skip_apps=true`.
- Ensure browser calls to `gs-api` routes receive an Access JWT with the correct AUD by keeping the API Access app scoped to the full `api.goldshore.ai` host and including protected route families.
- Fix a missing shell guard so the workflow remains syntactically valid and continues into optional app handling.

### Description
- Add a preflight step (`Preflight existing Access apps when app creation is skipped`) that runs when `skip_apps=true` and verifies all required Access apps exist before any token revocation/rotation proceeds, failing early if any are missing.
- Keep the Goldshore API Access app on the full `api.goldshore.ai` host and pass an explicit `API_PROTECTED_DOMAINS` list that includes `api.goldshore.ai/goldclaw`, `api.goldshore.ai/admin`, `api.goldshore.ai/users`, `api.goldshore.ai/ai`, and `api.goldshore.ai/v1` so the produced AUD is propagated to `gs-api` workers.
- Restore the missing `fi` after the required-app check so the script flow into gated optional-app logic is syntactically correct.
- File modified: `.github/workflows/setup-cf-agent-access.yml`.

### Testing
- Loaded the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/setup-cf-agent-access.yml")'` which succeeded.
- Ran Python content assertions that check the presence of the skip-apps preflight and the `api.goldshore.ai/goldclaw` protected-domain entry, which passed.
- Performed local diffs and basic line-number inspections to confirm the inserted blocks and the restored `fi` (commit created and file updated), all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51ce8f65548331a41281de479c4889)