### PR TITLE
Pin Tailwind v3 override to prevent @astrojs/tailwind resolving v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
       "postal-mime": "2.7.3",
       "wrangler": "^4.63.0",
       "typescript": "^5.4.2",
-      "esbuild": "0.25.12"
+      "esbuild": "0.25.12",
+      "tailwindcss": "3.4.19"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   wrangler: ^4.63.0
   typescript: ^5.4.2
   esbuild: 0.25.12
+  tailwindcss: 3.4.19
 
 importers:
 
@@ -69,7 +70,7 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       tailwindcss:
-        specifier: ^3.4.17
+        specifier: 3.4.19
         version: 3.4.19
       tsx:
         specifier: ^4.21.0
@@ -140,7 +141,7 @@ importers:
         specifier: ^4.20260421.1
         version: 4.20260610.1
       tailwindcss:
-        specifier: ^3.4.17
+        specifier: 3.4.19
         version: 3.4.19
       typescript:
         specifier: ^5.4.2
@@ -372,7 +373,7 @@ importers:
         specifier: ^1.59.1
         version: 1.60.0
       tailwindcss:
-        specifier: ^3.4.17
+        specifier: 3.4.19
         version: 3.4.19
       typescript:
         specifier: ^5.4.2
@@ -540,7 +541,7 @@ packages:
     resolution: {integrity: sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg==}
     peerDependencies:
       astro: ^3.0.0 || ^4.0.0 || ^5.0.0
-      tailwindcss: ^3.0.24
+      tailwindcss: 3.4.19
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Prevent `@astrojs/tailwind` from resolving Tailwind v4 which breaks `gs-admin`/`gs-web` builds on clean frozen installs. 
- Confirm the production `gs-api` deploy uses the app-local Wrangler config and should not be changed.

### Description
- Add a root `pnpm` override for `tailwindcss` pinned to `3.4.19` in `package.json`. 
- Refresh `pnpm-lock.yaml` so lockfile entries and importer/devDependency entries record `tailwindcss` `3.4.19`. 
- No change required to the `gs-api` workflow or package scripts because the production deploy already invokes `wrangler` with `--config wrangler.toml --env prod`, which was confirmed.

### Testing
- Ran `pnpm install --frozen-lockfile`, which completed successfully. 
- Ran `pnpm --filter @goldshore/gs-api build` (dry-run deploy) and it completed successfully with Wrangler output. 
- Ran `pnpm --filter @goldshore/gs-admin build`, which progressed past Tailwind resolution but failed later due to Wrangler rejecting an `ASSETS` binding name (this confirms Tailwind was pinned but surfaces a separate Cloudflare config issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51ce76b1f88331a6d4577074167ae3)