### PR TITLE
Route gs-admin API through API_SERVICE binding and declare gs-control route deps

### DIFF
--- a/apps/gs-admin/src/env.d.ts
+++ b/apps/gs-admin/src/env.d.ts
@@ -15,7 +15,8 @@ declare global {
           CLOUDFLARE_TEAM_DOMAIN?: string;
           ADMIN_DEV_ROLE?: string;
           GS_API_SERVICE_TOKEN?: string;
-          [key: string]: string | undefined;
+          API_SERVICE?: Fetcher;
+          [key: string]: string | Fetcher | undefined;
         };
       };
     }

--- a/apps/gs-admin/src/lib/gs-api.ts
+++ b/apps/gs-admin/src/lib/gs-api.ts
@@ -1,10 +1,15 @@
 type GsApiEnv = {
   API_ORIGIN?: string;
+  GS_API_URL?: string;
   GS_API_SERVICE_TOKEN?: string;
+  API_SERVICE?: Fetcher;
 };
 
+const DEFAULT_API_ORIGIN = 'https://api.goldshore.ai';
+const SERVICE_BINDING_ORIGIN = 'https://gs-api';
+
 export function getGsApiBaseUrl(env: GsApiEnv) {
-  return env.API_ORIGIN || 'https://api.goldshore.ai';
+  return env.API_ORIGIN || env.GS_API_URL || DEFAULT_API_ORIGIN;
 }
 
 export function buildGsApiHeaders(env: GsApiEnv) {
@@ -17,4 +22,23 @@ export function buildGsApiHeaders(env: GsApiEnv) {
   }
 
   return headers;
+}
+
+export function fetchGsApi(env: GsApiEnv, path: string, init: RequestInit = {}) {
+  const headers = {
+    ...buildGsApiHeaders(env),
+    ...Object.fromEntries(new Headers(init.headers).entries()),
+  };
+
+  if (env.API_SERVICE && !env.API_ORIGIN && !env.GS_API_URL) {
+    return env.API_SERVICE.fetch(new Request(new URL(path, SERVICE_BINDING_ORIGIN), {
+      ...init,
+      headers,
+    }));
+  }
+
+  return fetch(new URL(path, getGsApiBaseUrl(env)), {
+    ...init,
+    headers,
+  });
 }

--- a/apps/gs-admin/src/pages/api/gs-api/config.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/config.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { normalizeApiRuntimeConfig } from '@goldshore/schema';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 const buildErrorResponse = (status: number, message: string) =>
@@ -18,9 +18,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     return buildErrorResponse(access.status, access.error ?? 'Unknown error');
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env as any)}/system/config`, {
-    headers: buildGsApiHeaders(env)
-  });
+  const response = await fetchGsApi(env, '/system/config');
 
   const payload = await response.json().catch(() => null);
 
@@ -46,9 +44,8 @@ export const PUT: APIRoute = async ({ request, locals }) => {
     return buildErrorResponse(400, 'Invalid configuration payload.');
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env as any)}/system/config`, {
+  const response = await fetchGsApi(env, '/system/config', {
     method: 'PUT',
-    headers: buildGsApiHeaders(env),
     body: JSON.stringify(body)
   });
 

--- a/apps/gs-admin/src/pages/api/gs-api/dns-sync-status.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/dns-sync-status.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -14,9 +14,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env)}/internal/dns-sync-status`, {
-    headers: buildGsApiHeaders(env),
-  });
+  const response = await fetchGsApi(env, '/internal/dns-sync-status');
 
   const payload = await response.json().catch(() => null);
 

--- a/apps/gs-admin/src/pages/api/gs-api/health.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/health.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -14,9 +14,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env)}/health`, {
-    headers: buildGsApiHeaders(env)
-  });
+  const response = await fetchGsApi(env, '/health');
 
   const payload = await response.json().catch(() => null);
 

--- a/apps/gs-admin/src/pages/api/gs-api/inbox-status.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/inbox-status.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -14,9 +14,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env)}/internal/inbox-status`, {
-    headers: buildGsApiHeaders(env)
-  });
+  const response = await fetchGsApi(env, '/internal/inbox-status');
 
   const payload = await response.json().catch(() => null);
 

--- a/apps/gs-admin/src/pages/api/gs-api/status.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/status.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { ServiceStatusSchema } from '@goldshore/schema';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -15,9 +15,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env)}/system/status`, {
-    headers: buildGsApiHeaders(env)
-  });
+  const response = await fetchGsApi(env, '/system/status');
 
   const payload = await response.json().catch(() => null);
   const parsedStatus = ServiceStatusSchema.safeParse(payload);

--- a/apps/gs-admin/src/pages/api/gs-api/sync-runs.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/sync-runs.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -14,9 +14,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env)}/internal/sync-runs/summary`, {
-    headers: buildGsApiHeaders(env),
-  });
+  const response = await fetchGsApi(env, '/internal/sync-runs/summary');
 
   const payload = await response.json().catch(() => ({ success: false, runs: [] }));
 

--- a/apps/gs-admin/src/pages/api/gs-api/version.ts
+++ b/apps/gs-admin/src/pages/api/gs-api/version.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { requireAdminAccess } from '../../../lib/access';
-import { getGsApiBaseUrl, buildGsApiHeaders } from '../../../lib/gs-api';
+import { fetchGsApi } from '../../../lib/gs-api';
 import { getServerEnv } from '../../../lib/server-env';
 
 export const GET: APIRoute = async ({ request, locals }) => {
@@ -14,9 +14,7 @@ export const GET: APIRoute = async ({ request, locals }) => {
     });
   }
 
-  const response = await fetch(`${getGsApiBaseUrl(env)}/system/version`, {
-    headers: buildGsApiHeaders(env)
-  });
+  const response = await fetchGsApi(env, '/system/version');
 
   const payload = await response.json().catch(() => null);
 

--- a/apps/gs-control/package.json
+++ b/apps/gs-control/package.json
@@ -10,7 +10,10 @@
   },
   "dependencies": {
     "@goldshore/auth": "workspace:*",
-    "hono": "^4.12.16"
+    "@goldshore/utils": "workspace:*",
+    "@hono/zod-validator": "^0.8.0",
+    "hono": "^4.12.16",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260511.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,9 +213,18 @@ importers:
       '@goldshore/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@goldshore/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      '@hono/zod-validator':
+        specifier: ^0.8.0
+        version: 0.8.0(hono@4.12.25)(zod@4.4.3)
       hono:
         specifier: ^4.12.16
         version: 4.12.25
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260511.1
@@ -940,6 +949,12 @@ packages:
     peerDependencies:
       hono: '>=3.9.0'
       zod: ^3.19.1
+
+  '@hono/zod-validator@0.8.0':
+    resolution: {integrity: sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==}
+    peerDependencies:
+      hono: '>=4.10.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4869,6 +4884,11 @@ snapshots:
     dependencies:
       hono: 4.12.25
       zod: 3.25.76
+
+  '@hono/zod-validator@0.8.0(hono@4.12.25)(zod@4.4.3)':
+    dependencies:
+      hono: 4.12.25
+      zod: 4.4.3
 
   '@humanfs/core@0.19.2':
     dependencies:


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Prevent gs-admin admin widgets from hitting the public `api.goldshore.ai` host (and being rejected by gateway) when the `API_SERVICE` worker binding is available. 
- Ensure `apps/gs-control` declares runtime dependencies used by its Cloudflare routes so `pnpm` frozen installs and per-package builds can resolve modules.

### Description
- Add a service-binding-aware helper `fetchGsApi(env, path, init)` that prefers the `API_SERVICE` binding when neither `API_ORIGIN` nor `GS_API_URL` is configured, while preserving `X-Goldshore-Service-Token` headers via `buildGsApiHeaders`; update `getGsApiBaseUrl` to respect `GS_API_URL` and keep the public fallback. (`apps/gs-admin/src/lib/gs-api.ts`).
- Update all gs-admin proxy endpoints to use `fetchGsApi` instead of building public URLs and manually attaching headers. (multiple files under `apps/gs-admin/src/pages/api/gs-api/`).
- Add the `API_SERVICE?: Fetcher` typing to the gs-admin runtime environment. (`apps/gs-admin/src/env.d.ts`).
- Declare `@goldshore/utils`, `@hono/zod-validator`, and `zod` in `apps/gs-control/package.json` and update `pnpm-lock.yaml` importer entries so frozen installs link those packages for `@goldshore/gs-control`.

### Testing
- Ran `pnpm install --frozen-lockfile --offline` which completed successfully against the updated lockfile. (success)
- Ran a Wrangler dry-run for the control worker with `pnpm exec wrangler deploy --config apps/gs-control/wrangler.toml --env prod --dry-run --outdir=apps/gs-control/dist` which produced a successful dry-run and listed expected bindings. (success)
- Attempting `pnpm --filter @goldshore/gs-control build` without passing an explicit config still fails due to Wrangler resolving the repository root `wrangler.jsonc` instead of the app `wrangler.toml`, so per-app builds should pass an explicit `--config` flag; this is a tooling caveat rather than a dependency resolution failure. (warning)
- Running `pnpm --filter @goldshore/gs-admin check` surfaced the existing Astro/Tailwind peer mismatch (Tailwind 4 vs `@astrojs/tailwind` expectations) unrelated to these changes. (warning)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51beb31e148331a356d19bc6146d80)