### PR TITLE
Consolidate gs-api Wrangler environments

### DIFF
--- a/apps/gs-api/package.json
+++ b/apps/gs-api/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "tsx src/dev.ts",
     "dev:wrangler": "wrangler dev src/index.ts --ip 0.0.0.0",
-    "deploy": "wrangler deploy --env prod",
-    "build": "wrangler deploy --env prod --dry-run --outdir=dist",
+    "deploy": "wrangler deploy --env production",
+    "build": "wrangler deploy --env production --dry-run --outdir=dist",
     "test": "tsx --test src/routes/*.test.ts",
     "test:gateway": "node test-gateway.js"
   },

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -9,126 +9,6 @@ workers_dev = false
 # Production environment
 # ══════════════════════════════════════════════════════════════════════════════
 
-[env.prod]
-routes = [
-  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
-]
-
-[env.prod.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
-GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
-
-# ── KV ──────────────────────────────────────────────────────────────────────────────────────
-[[env.prod.kv_namespaces]]
-binding = "KV"
-id = "e0b8b807191346c3b0afc25fe716d2cd"
-
-[[env.prod.kv_namespaces]]
-binding = "CONTROL_LOGS"
-id = "a52e94cb331c4e3db08f2aa507e6df09"
-
-# ── R2 ──────────────────────────────────────────────────────────────────────────────────────
-[[env.prod.r2_buckets]]
-binding = "GS_ASSETS"
-bucket_name = "gs-assets"
-
-[[env.prod.r2_buckets]]
-binding = "TELEMETRY"
-bucket_name = "gs-telemetry-storage"
-
-# ── D1 ──────────────────────────────────────────────────────────────────────────────────────
-[[env.prod.d1_databases]]
-binding = "DB"
-database_name = "goldshore"
-database_id = "gs_db_001"
-
-[[env.prod.d1_databases]]
-binding = "PLATFORM_DB"
-database_name = "gs_platform_db"
-database_id = "9703574e-adb7-481e-8d98-96f8ce5f8a90"
-
-[[env.prod.d1_databases]]
-binding = "AUDIT_DB"
-database_name = "gs_audit_db"
-database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
-
-[[env.prod.d1_databases]]
-binding = "SIGNALS_DB"
-database_name = "gs_signals_db"
-database_id = "76af4653-7f44-417b-b46e-250143d906fd"
-
-[[env.prod.d1_databases]]
-binding = "JOBS_DB"
-database_name = "gs_jobs_db"
-database_id = "750c469c-788d-49e8-9254-77231cffd70f"
-
-# ── AI ──────────────────────────────────────────────────────────────────────────────────────
-[env.prod.ai]
-binding = "AI"
-
-# ── Durable Objects ──────────────────────────────────────────────────────────────────────
-[[env.prod.durable_objects.bindings]]
-name = "AUTH_SESSION"
-class_name = "AuthSession"
-
-# ── Services ──────────────────────────────────────────────────────────────────────────────────────
-[[env.prod.services]]
-binding = "AGENT"
-service = "gs-agent"
-environment = "prod"
-
-[[env.prod.services]]
-binding = "GS_MAIL"
-service = "gs-mail"
-environment = "prod"
-
-[[env.prod.services]]
-binding = "GS_WEB PROD"
-service = "gs-web-prod"
-environment = "prod"
-
-[[env.prod.services]]
-binding = "GOLDSHORE_AI"
-service = "goldshore-ai"
-environment = "prod"
-
-# ── Queues (producers) ───────────────────────────────────────────────────────────
-[[env.prod.queues.producers]]
-binding = "JOBS_QUEUE"
-queue = "goldshore-jobs"
-
-[[env.prod.queues.producers]]
-binding = "EVENTS_QUEUE"
-queue = "gs-events"
-
-[[env.prod.queues.producers]]
-binding = "MAIL_JOBS_QUEUE"
-queue = "gs-mail-jobs"
-
-[[env.prod.queues.producers]]
-binding = "DEAD_LETTER_QUEUE"
-queue = "gs-mail-dead-letter"
-
-# ── Workflows ────────────────────────────────────────────────────────────────────────────────────────
-[[env.prod.workflows]]
-binding = "GS_SIGNALS"
-name = "signals-evaluator"
-class_name = "SignalsEvaluator"
-script_name = "gs-signals-prod"
-
-# ── Secrets Store ───────────────────────────────────────────────────────────────────────────────────
-[[env.prod.secrets_store.bindings]]
-binding = "SECRETS"
-store_id = "b9824d3280c54573a24137c7e7143b33"
-
-# ══════════════════════════════════════════════════════════════════════════════
-# Production (named 'production') environment
-# ══════════════════════════════════════════════════════════════════════════════
-
 [env.production]
 routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
@@ -140,51 +20,111 @@ ENV = "production"
 CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
 CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
 CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
-# ══════════════════════════════════════════════════════════════════════════════
-
-[env.preview]
-workers_dev = true
-
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
 
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
-# ══════════════════════════════════════════════════════════════════════════════
+# ── KV ──────────────────────────────────────────────────────────────────────────────────────
+[[env.production.kv_namespaces]]
+binding = "KV"
+id = "e0b8b807191346c3b0afc25fe716d2cd"
 
-[env.preview]
-workers_dev = true
+[[env.production.kv_namespaces]]
+binding = "CONTROL_LOGS"
+id = "a52e94cb331c4e3db08f2aa507e6df09"
 
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
-GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
+# ── R2 ──────────────────────────────────────────────────────────────────────────────────────
+[[env.production.r2_buckets]]
+binding = "GS_ASSETS"
+bucket_name = "gs-assets"
 
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
-# ══════════════════════════════════════════════════════════════════════════════
+[[env.production.r2_buckets]]
+binding = "TELEMETRY"
+bucket_name = "gs-telemetry-storage"
 
-[env.preview]
-workers_dev = true
+# ── D1 ──────────────────────────────────────────────────────────────────────────────────────
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "goldshore"
+database_id = "gs_db_001"
 
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
-GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
+[[env.production.d1_databases]]
+binding = "PLATFORM_DB"
+database_name = "gs_platform_db"
+database_id = "9703574e-adb7-481e-8d98-96f8ce5f8a90"
+
+[[env.production.d1_databases]]
+binding = "AUDIT_DB"
+database_name = "gs_audit_db"
+database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
+
+[[env.production.d1_databases]]
+binding = "SIGNALS_DB"
+database_name = "gs_signals_db"
+database_id = "76af4653-7f44-417b-b46e-250143d906fd"
+
+[[env.production.d1_databases]]
+binding = "JOBS_DB"
+database_name = "gs_jobs_db"
+database_id = "750c469c-788d-49e8-9254-77231cffd70f"
+
+# ── AI ──────────────────────────────────────────────────────────────────────────────────────
+[env.production.ai]
+binding = "AI"
+
+# ── Durable Objects ──────────────────────────────────────────────────────────────────────
+[[env.production.durable_objects.bindings]]
+name = "AUTH_SESSION"
+class_name = "AuthSession"
+
+# ── Services ──────────────────────────────────────────────────────────────────────────────────────
+[[env.production.services]]
+binding = "AGENT"
+service = "gs-agent"
+environment = "prod"
+
+[[env.production.services]]
+binding = "GS_MAIL"
+service = "gs-mail"
+environment = "prod"
+
+[[env.production.services]]
+binding = "GS_WEB PROD"
+service = "gs-web-prod"
+environment = "prod"
+
+[[env.production.services]]
+binding = "GOLDSHORE_AI"
+service = "goldshore-ai"
+environment = "prod"
+
+# ── Queues (producers) ───────────────────────────────────────────────────────────
+[[env.production.queues.producers]]
+binding = "JOBS_QUEUE"
+queue = "goldshore-jobs"
+
+[[env.production.queues.producers]]
+binding = "EVENTS_QUEUE"
+queue = "gs-events"
+
+[[env.production.queues.producers]]
+binding = "MAIL_JOBS_QUEUE"
+queue = "gs-mail-jobs"
+
+[[env.production.queues.producers]]
+binding = "DEAD_LETTER_QUEUE"
+queue = "gs-mail-dead-letter"
+
+# ── Workflows ────────────────────────────────────────────────────────────────────────────────────────
+[[env.production.workflows]]
+binding = "GS_SIGNALS"
+name = "signals-evaluator"
+class_name = "SignalsEvaluator"
+script_name = "gs-signals-prod"
+
+# ── Secrets Store ───────────────────────────────────────────────────────────────────────────────────
+[[env.production.secrets_store.bindings]]
+binding = "SECRETS"
+store_id = "b9824d3280c54573a24137c7e7143b33"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Preview environment — deploys to workers.dev (no zone route needed)
@@ -197,6 +137,7 @@ workers_dev = true
 ENV = "preview"
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 
+# ── KV ──────────────────────────────────────────────────────────────────────────────────────
 [[env.preview.kv_namespaces]]
 binding = "KV"
 id = "d4d20cee39094b999dea3f7e5f4c533a"
@@ -205,6 +146,7 @@ id = "d4d20cee39094b999dea3f7e5f4c533a"
 binding = "CONTROL_LOGS"
 id = "09e43cb8bd4749fdaaed0dc9d4ff2284"
 
+# ── R2 ──────────────────────────────────────────────────────────────────────────────────────
 [[env.preview.r2_buckets]]
 binding = "GS_ASSETS"
 bucket_name = "gs-assets-preview"
@@ -213,6 +155,7 @@ bucket_name = "gs-assets-preview"
 binding = "TELEMETRY"
 bucket_name = "gs-telemetry-storage"
 
+# ── D1 ──────────────────────────────────────────────────────────────────────────────────────
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
@@ -233,13 +176,16 @@ binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
 
+# ── AI ──────────────────────────────────────────────────────────────────────────────────────
 [env.preview.ai]
 binding = "AI"
 
+# ── Durable Objects ──────────────────────────────────────────────────────────────────────
 [[env.preview.durable_objects.bindings]]
 name = "AUTH_SESSION"
 class_name = "AuthSession"
 
+# ── Services ──────────────────────────────────────────────────────────────────────────────────────
 [[env.preview.services]]
 binding = "AGENT"
 service = "gs-agent"
@@ -256,6 +202,7 @@ service = "gs-web"
 binding = "API_SERVICE"
 service = "gs-api"
 
+# ── Queues (producers) ───────────────────────────────────────────────────────────
 [[env.preview.queues.producers]]
 binding = "JOBS_QUEUE"
 queue = "goldshore-jobs"
@@ -272,11 +219,6 @@ queue = "gs-mail-jobs"
 [[env.preview.secrets_store.bindings]]
 binding = "SECRETS"
 store_id = "b9824d3280c54573a24137c7e7143b33"
-# Temporarily disabled: Wrangler 4.105.0 warns this preview env field is unexpected.
-# Re-enable only after confirming current Wrangler config schema supports env.preview.secrets_store.
-# [[env.preview.secrets_store.bindings]]
-# binding = "SECRETS"
-# store_id = "b9824d3280c54573a24137c7e7143b33"
 
 # ── Durable Object migrations ───────────────────────────────────────────────────────────────────
 [[migrations]]


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Remove duplicated `env.prod` / `env.production` / `env.preview` blocks and provide one canonical `production` and one canonical `preview` environment in `apps/gs-api/wrangler.toml` to reduce confusion and drift. 
- Ensure all runtime bindings required by the API (KV, R2, D1, AI, Durable Objects, queues, workflows, and secrets) are present and canonicalized for both production and preview environments. 

### Description
- Consolidated duplicate environment sections into a single `[env.production]` and a single `[env.preview]` in `apps/gs-api/wrangler.toml`, converting previous `prod` aliases to `production`. 
- Normalized all per-environment bindings under `env.production.*` and `env.preview.*` (including `kv_namespaces`, `r2_buckets`, `d1_databases`, `ai`, `durable_objects`, `queues.producers`, `workflows`, and `secrets_store`) and added the `CONTROL_SYNC_TOKEN` var to the canonical production vars. 
- Preserved the requested bindings: `KV`, `CONTROL_LOGS`, `GS_ASSETS`, `TELEMETRY`, `PLATFORM_DB`, `AUDIT_DB`, `SIGNALS_DB`, `JOBS_DB`, `AI`, `AUTH_SESSION`, queue producers, workflow binding (`GS_SIGNALS`), and `SECRETS`. 
- Updated `apps/gs-api/package.json` scripts to use `--env production` for `deploy` and `build` instead of the removed `prod` alias. 

### Testing
- Ran a TOML parse and binding verification with `python`/`tomllib` which confirmed both `production` and `preview` envs include the expected bindings and queues and completed successfully. 
- Executed `pnpm --filter @goldshore/gs-api build` (which runs `wrangler deploy --env production --dry-run`) and the dry-run succeeded but Wrangler emitted a warning that `env.*.secrets_store` is an unexpected field in the current Wrangler schema. 
- Executed a preview dry-run via `pnpm --filter @goldshore/gs-api exec wrangler deploy --env preview --dry-run` which succeeded and produced the same `secrets_store` warning for `env.preview`. 
- Ran `pnpm check:wrangler-placeholders` and `git diff --check` which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52752ed37083319ff7bc094b2a881c)