### PR TITLE
Rename prod gs-web service binding to GS_WEB and add env types

### DIFF
--- a/apps/gs-api/src/index.ts
+++ b/apps/gs-api/src/index.ts
@@ -52,6 +52,7 @@ type Env = {
   MAIL_BLOCKED_SENDERS?: string;
   MAIL_ALLOWED_RECIPIENTS?: string;
   AGENT?: Fetcher;
+  GS_WEB?: Fetcher;
   API_ORIGIN?: string;
   ENV?: string;
   DEV_AUTH_BYPASS?: string;

--- a/apps/gs-api/src/types.ts
+++ b/apps/gs-api/src/types.ts
@@ -35,6 +35,7 @@ export type Env = {
   MAIL_BLOCKED_SENDERS?: string;
   MAIL_ALLOWED_RECIPIENTS?: string;
   AGENT?: Fetcher;
+  GS_WEB?: Fetcher;
   API_ORIGIN?: string;
   ADMIN_URL?: string;
   ENV?: string;

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -87,7 +87,7 @@ service = "gs-mail"
 environment = "prod"
 
 [[env.prod.services]]
-binding = "GS_WEB PROD"
+binding = "GS_WEB"
 service = "gs-web-prod"
 environment = "prod"
 
@@ -134,49 +134,6 @@ routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
-
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
-# ══════════════════════════════════════════════════════════════════════════════
-
-[env.preview]
-workers_dev = true
-
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
-GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
-
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
-# ══════════════════════════════════════════════════════════════════════════════
-
-[env.preview]
-workers_dev = true
-
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
-GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
-
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
-# ══════════════════════════════════════════════════════════════════════════════
-
-[env.preview]
-workers_dev = true
 
 [env.production.vars]
 ENV = "production"


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- The production service binding used an invalid identifier (`GS_WEB PROD`) which broke Wrangler parsing and was inconsistent with preview.
- The runtime needs a matching canonical binding name so runtime `Fetcher` access is available for both prod and preview.
- Duplicate `env.production.vars` / `env.preview` table declarations caused a TOML redefinition error during `wrangler` dry-run.

### Description
- Rename the production `gs-web` service binding from `GS_WEB PROD` to `GS_WEB` in `apps/gs-api/wrangler.toml` so it matches preview and uses a valid canonical identifier.
- Add `GS_WEB?: Fetcher;` to the `Env` type in `apps/gs-api/src/types.ts` and the runtime `Env` in `apps/gs-api/src/index.ts` to expose the binding in TypeScript.
- Clean up duplicate `env.production.vars` / `env.preview` table blocks in `apps/gs-api/wrangler.toml` so the file is a valid TOML document for Wrangler.

### Testing
- Ran `pnpm --filter @goldshore/gs-api test` and all tests passed (60 passed, 0 failed).
- Ran `pnpm --filter @goldshore/gs-api build` (Wrangler dry-run) and the configuration parsed successfully showing the expected bindings without the previous TOML redefinition error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52752c315883319c398f3b358bd705)