### PR TITLE
Consolidate Cloudflare bindings, switch gs-api env to `prod`, and use per-secret INTEGRATION_MASTER_KEY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,13 +117,15 @@ For Claude/Codex assistance with Google API integration: provide the API name, s
 
 `apps/gs-api/wrangler.toml` is the canonical config for `gs-api` bindings. Cross-check any future binding edits against the registry in [`infra/Cloudflare/BINDINGS_MAP.md`](infra/Cloudflare/BINDINGS_MAP.md) before changing this summary.
 
-- KV: `KV` (`e0b8b807191346c3b0afc25fe716d2cd` in `prod`; `d4d20cee39094b999dea3f7e5f4c533a` in `preview`), `CONTROL_LOGS` (`a52e94cb331c4e3db08f2aa507e6df09` in `prod`; `09e43cb8bd4749fdaaed0dc9d4ff2284` in `preview`). Legacy historical aliases only: `GS_CONFIG`, `KV_SESSIONS`.
-- D1: `DB` (`goldshore` / `gs_db_001`), `PLATFORM_DB` (`9703574e-adb7-481e-8d98-96f8ce5f8a90`), `AUDIT_DB` (`1ae71d76-188f-481b-91d9-db2d39013f68`), `SIGNALS_DB` (`76af4653-7f44-417b-b46e-250143d906fd`), `JOBS_DB` (`750c469c-788d-49e8-9254-77231cffd70f`). Legacy historical alias only: `GS_AUDIT_DB` → `AUDIT_DB`.
-- R2: `GS_ASSETS` (`gs-assets` in `prod`; `gs-assets-preview` in `preview`), `TELEMETRY` (`gs-telemetry-storage`).
+- Environment names: `prod` and `preview`. `production` is a historical alias and should not be used in `apps/gs-api/wrangler.toml` or package scripts.
+- KV: `KV` (`e0b8b807191346c3b0afc25fe716d2cd` in `prod`; `d4d20cee39094b999dea3f7e5f4c533a` in `preview`), `CONTROL_LOGS` (`a52e94cb331c4e3db08f2aa507e6df09` in `prod`; `09e43cb8bd4749fdaaed0dc9d4ff2284` in `preview`), and `RISK_RADAR_CACHE`. Legacy historical aliases only: `GS_CONFIG`, `KV_SESSIONS`.
+- D1: `PLATFORM_DB` (`9703574e-adb7-481e-8d98-96f8ce5f8a90`), `AUDIT_DB` (`1ae71d76-188f-481b-91d9-db2d39013f68`), `SIGNALS_DB` (`76af4653-7f44-417b-b46e-250143d906fd`), `RISK_RADAR_DB`, and `JOBS_DB` (`750c469c-788d-49e8-9254-77231cffd70f`). Legacy historical aliases only: `DB` and `GS_AUDIT_DB`.
+- R2: `GS_ASSETS` (`gs-assets` in `prod`; `gs-assets-preview` in `preview`), `TELEMETRY` (`gs-telemetry-storage`), and `RISK_RADAR_R2`.
 - AI and Durable Objects: `AI`; `AUTH_SESSION` (`AuthSession`).
-- Queues: `JOBS_QUEUE` (`goldshore-jobs`), `EVENTS_QUEUE` (`gs-events`), `MAIL_JOBS_QUEUE` (`gs-mail-jobs`), `DEAD_LETTER_QUEUE` (`gs-mail-dead-letter`).
-- Services and workflows: `AGENT` → `gs-agent`/`prod`, `GS_MAIL` → `gs-mail`/`prod`, `GS_WEB PROD` → `gs-web-prod`/`prod`, `GOLDSHORE_AI` → `goldshore-ai`/`prod`, workflow `GS_SIGNALS` → `signals-evaluator`.
-- Secrets Store: `SECRETS` (`b9824d3280c54573a24137c7e7143b33`).
+- Queues: `JOBS_QUEUE` (`goldshore-jobs`), `EVENTS_QUEUE` (`gs-events`), `MAIL_JOBS_QUEUE` (`gs-mail-jobs`), `DEAD_LETTER_QUEUE` (`gs-mail-dead-letter`). `gs-api` also consumes the consolidated backend queues in `prod`.
+- Workflows: `GS_SIGNALS` → `signals-evaluator`.
+- Secrets Store: `INTEGRATION_MASTER_KEY` is bound as a per-secret Secrets Store binding from store `b9824d3280c54573a24137c7e7143b33`. Do not use the historical `SECRETS.get(...)` store-object shape in Wrangler config.
+- Unclear/live Cloudflare note: if the dashboard still shows legacy service bindings such as `AGENT`, `GS_MAIL`, `GS_WEB PROD`, `API_SERVICE`, or `GOLDSHORE_AI`, treat them as stale until a human confirms a live dependency; do not re-add them to repo-managed `gs-api` config without updating this file and `docs/WORKER_CONFIGURATION.md`.
 
 ---
 

--- a/apps/gs-api/package.json
+++ b/apps/gs-api/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "tsx src/dev.ts",
     "dev:wrangler": "wrangler dev src/index.ts --ip 0.0.0.0",
-    "deploy": "wrangler deploy --env production",
-    "build": "wrangler deploy --env production --dry-run --outdir=dist",
+    "deploy": "wrangler deploy --env prod",
+    "build": "wrangler deploy --env prod --dry-run --outdir=dist",
     "test": "tsx --test src/routes/*.test.ts",
     "test:gateway": "node test-gateway.js"
   },

--- a/apps/gs-api/src/index.ts
+++ b/apps/gs-api/src/index.ts
@@ -59,8 +59,6 @@ type Env = {
   FORWARD_TO?: string;
   MAIL_BLOCKED_SENDERS?: string;
   MAIL_ALLOWED_RECIPIENTS?: string;
-  AGENT?: Fetcher;
-  GS_WEB?: Fetcher;
   API_ORIGIN?: string;
   ENV?: string;
   DEV_AUTH_BYPASS?: string;

--- a/apps/gs-api/src/lib/encryption.ts
+++ b/apps/gs-api/src/lib/encryption.ts
@@ -1,7 +1,7 @@
 /**
  * Encryption utilities for secure credential storage
  * Uses Web Crypto API (SubtleCrypto) with AES-256-GCM
- * Master key sourced from Cloudflare Secrets Store
+ * Master key sourced from a Cloudflare Secrets Store secret binding
  */
 
 const ALGORITHM = 'AES-GCM';
@@ -10,19 +10,15 @@ const IV_LENGTH = 16; // 128 bits
 const TAG_LENGTH = 128; // 128 bits
 
 /**
- * Retrieve and import the master encryption key from Cloudflare Secrets Store
+ * Retrieve and import the master encryption key from a Secrets Store binding.
  */
 export async function getMasterKey(env: any): Promise<CryptoKey> {
-  if (!env.SECRETS) {
-    throw new Error('SECRETS store not configured in Cloudflare bindings');
+  const masterKeySecret = env.INTEGRATION_MASTER_KEY;
+  if (!masterKeySecret) {
+    throw new Error('INTEGRATION_MASTER_KEY secret binding is not configured');
   }
 
   try {
-    const masterKeySecret = await env.SECRETS.get('INTEGRATION_MASTER_KEY');
-    if (!masterKeySecret) {
-      throw new Error('INTEGRATION_MASTER_KEY not found in Secrets Store');
-    }
-
     const keyData = new TextEncoder().encode(masterKeySecret);
     return await crypto.subtle.importKey(
       'raw',

--- a/apps/gs-api/src/types.ts
+++ b/apps/gs-api/src/types.ts
@@ -11,7 +11,7 @@ export type Env = {
   RISK_RADAR_R2?: R2Bucket;
   AUTH_SESSION?: DurableObjectNamespace;
   AI: Ai;
-  SECRETS: SecretsStore;
+  INTEGRATION_MASTER_KEY?: string;
   JOBS_QUEUE?: Queue;
   EVENTS_QUEUE?: Queue;
   MAIL_JOBS_QUEUE?: Queue;
@@ -41,8 +41,6 @@ export type Env = {
   FORWARD_TO?: string;
   MAIL_BLOCKED_SENDERS?: string;
   MAIL_ALLOWED_RECIPIENTS?: string;
-  AGENT?: Fetcher;
-  GS_WEB?: Fetcher;
   API_ORIGIN?: string;
   ADMIN_URL?: string;
   ENV?: string;

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -7,9 +7,10 @@ workers_dev = false
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Production environment
+# Canonical environment name is "prod". Use `wrangler deploy --env prod`.
 # ══════════════════════════════════════════════════════════════════════════════
 
-[env.production]
+[env.prod]
 routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },
@@ -21,7 +22,7 @@ routes = [
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 
-[env.production.vars]
+[env.prod.vars]
 ENV = "production"
 CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
 CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
@@ -29,12 +30,12 @@ CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
 
-# ── KV ──────────────────────────────────────────────────────────────────────────────────────
-[[env.production.kv_namespaces]]
+# ── KV ───────────────────────────────────────────────────────────────────────
+[[env.prod.kv_namespaces]]
 binding = "KV"
 id = "e0b8b807191346c3b0afc25fe716d2cd"
 
-[[env.production.kv_namespaces]]
+[[env.prod.kv_namespaces]]
 binding = "CONTROL_LOGS"
 id = "a52e94cb331c4e3db08f2aa507e6df09"
 
@@ -42,12 +43,12 @@ id = "a52e94cb331c4e3db08f2aa507e6df09"
 binding = "RISK_RADAR_CACHE"
 id = "0e67c3fe3d2b3231e7d4dba704e7dcd6"
 
-# ── R2 ──────────────────────────────────────────────────────────────────────────────────────
-[[env.production.r2_buckets]]
+# ── R2 ───────────────────────────────────────────────────────────────────────
+[[env.prod.r2_buckets]]
 binding = "GS_ASSETS"
 bucket_name = "gs-assets"
 
-[[env.production.r2_buckets]]
+[[env.prod.r2_buckets]]
 binding = "TELEMETRY"
 bucket_name = "gs-telemetry-storage"
 
@@ -55,23 +56,18 @@ bucket_name = "gs-telemetry-storage"
 binding = "RISK_RADAR_R2"
 bucket_name = "gs-risk-radar-raw"
 
-# ── D1 ──────────────────────────────────────────────────────────────────────────────────────
-[[env.production.d1_databases]]
-binding = "DB"
-database_name = "goldshore"
-database_id = "gs_db_001"
-
-[[env.production.d1_databases]]
+# ── D1 ───────────────────────────────────────────────────────────────────────
+[[env.prod.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
 database_id = "9703574e-adb7-481e-8d98-96f8ce5f8a90"
 
-[[env.production.d1_databases]]
+[[env.prod.d1_databases]]
 binding = "AUDIT_DB"
 database_name = "gs_audit_db"
 database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
 
-[[env.production.d1_databases]]
+[[env.prod.d1_databases]]
 binding = "SIGNALS_DB"
 database_name = "gs_signals_db"
 database_id = "76af4653-7f44-417b-b46e-250143d906fd"
@@ -86,46 +82,29 @@ binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
 
-# ── AI ──────────────────────────────────────────────────────────────────────────────────────
-[env.production.ai]
+# ── AI ───────────────────────────────────────────────────────────────────────
+[env.prod.ai]
 binding = "AI"
 
-# ── Durable Objects ──────────────────────────────────────────────────────────────────────
-[[env.production.durable_objects.bindings]]
+# ── Durable Objects ──────────────────────────────────────────────────────────
+[[env.prod.durable_objects.bindings]]
 name = "AUTH_SESSION"
 class_name = "AuthSession"
 
-# ── Services ──────────────────────────────────────────────────────────────────────────────────────
-[[env.production.services]]
-binding = "AGENT"
-service = "gs-agent"
-environment = "prod"
-
-[[env.production.services]]
-binding = "GS_MAIL"
-service = "gs-mail"
-environment = "prod"
-
-[[env.production.services]]
-binding = "GS_WEB PROD"
-service = "gs-web-prod"
-environment = "prod"
-
-
-# ── Queues (producers) ───────────────────────────────────────────────────────────
-[[env.production.queues.producers]]
+# ── Queues ───────────────────────────────────────────────────────────────────
+[[env.prod.queues.producers]]
 binding = "JOBS_QUEUE"
 queue = "goldshore-jobs"
 
-[[env.production.queues.producers]]
+[[env.prod.queues.producers]]
 binding = "EVENTS_QUEUE"
 queue = "gs-events"
 
-[[env.production.queues.producers]]
+[[env.prod.queues.producers]]
 binding = "MAIL_JOBS_QUEUE"
 queue = "gs-mail-jobs"
 
-[[env.production.queues.producers]]
+[[env.prod.queues.producers]]
 binding = "DEAD_LETTER_QUEUE"
 queue = "gs-mail-dead-letter"
 
@@ -138,48 +117,36 @@ queue = "gs-mail-jobs"
 [[env.prod.queues.consumers]]
 queue = "gs-events"
 
-# ── Workflows ────────────────────────────────────────────────────────────────────────────────────────
-[[env.production.workflows]]
+# ── Workflows ────────────────────────────────────────────────────────────────
+[[env.prod.workflows]]
 binding = "GS_SIGNALS"
 name = "signals-evaluator"
 class_name = "SignalsEvaluator"
 script_name = "gs-signals-prod"
 
-# ── Secrets Store ───────────────────────────────────────────────────────────────────────────────────
-[[env.production.secrets_store.bindings]]
-binding = "SECRETS"
+# ── Secrets Store ────────────────────────────────────────────────────────────
+# Secrets Store bindings are per secret, not a store object. The runtime reads
+# env.INTEGRATION_MASTER_KEY directly.
+[[env.prod.secrets_store_secrets]]
+binding = "INTEGRATION_MASTER_KEY"
 store_id = "b9824d3280c54573a24137c7e7143b33"
+secret_name = "INTEGRATION_MASTER_KEY"
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Production (named 'production') environment
-# ══════════════════════════════════════════════════════════════════════════════
-
-[env.production]
-routes = [
-  { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
-]
-
-[env.production.vars]
-ENV = "production"
-CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
-CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
-GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
-GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
-
-# ══════════════════════════════════════════════════════════════════════════════
-# Preview environment — deploys to workers.dev (no zone route needed)
+# Preview environment
 # ══════════════════════════════════════════════════════════════════════════════
 
 [env.preview]
 workers_dev = true
+routes = [
+  { pattern = "api-preview.goldshore.ai/*", zone_name = "goldshore.ai" }
+]
 
 [env.preview.vars]
 ENV = "preview"
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 
-# ── KV ──────────────────────────────────────────────────────────────────────────────────────
+# ── KV ───────────────────────────────────────────────────────────────────────
 [[env.preview.kv_namespaces]]
 binding = "KV"
 id = "d4d20cee39094b999dea3f7e5f4c533a"
@@ -188,7 +155,11 @@ id = "d4d20cee39094b999dea3f7e5f4c533a"
 binding = "CONTROL_LOGS"
 id = "09e43cb8bd4749fdaaed0dc9d4ff2284"
 
-# ── R2 ──────────────────────────────────────────────────────────────────────────────────────
+[[env.preview.kv_namespaces]]
+binding = "RISK_RADAR_CACHE"
+id = "a2315c0e83f27b610c3dfdd30eb0a9ea"
+
+# ── R2 ───────────────────────────────────────────────────────────────────────
 [[env.preview.r2_buckets]]
 binding = "GS_ASSETS"
 bucket_name = "gs-assets-preview"
@@ -197,7 +168,11 @@ bucket_name = "gs-assets-preview"
 binding = "TELEMETRY"
 bucket_name = "gs-telemetry-storage"
 
-# ── D1 ──────────────────────────────────────────────────────────────────────────────────────
+[[env.preview.r2_buckets]]
+binding = "RISK_RADAR_R2"
+bucket_name = "gs-risk-radar-raw-preview"
+
+# ── D1 ───────────────────────────────────────────────────────────────────────
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
@@ -223,30 +198,16 @@ binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
 
-# ── AI ──────────────────────────────────────────────────────────────────────────────────────
+# ── AI ───────────────────────────────────────────────────────────────────────
 [env.preview.ai]
 binding = "AI"
 
-# ── Durable Objects ──────────────────────────────────────────────────────────────────────
+# ── Durable Objects ──────────────────────────────────────────────────────────
 [[env.preview.durable_objects.bindings]]
 name = "AUTH_SESSION"
 class_name = "AuthSession"
 
-# ── Services ──────────────────────────────────────────────────────────────────────────────────────
-[[env.preview.services]]
-binding = "AGENT"
-service = "gs-agent"
-
-
-[[env.preview.services]]
-binding = "GS_WEB"
-service = "gs-web"
-
-[[env.preview.services]]
-binding = "API_SERVICE"
-service = "gs-api"
-
-# ── Queues (producers) ───────────────────────────────────────────────────────────
+# ── Queues ───────────────────────────────────────────────────────────────────
 [[env.preview.queues.producers]]
 binding = "JOBS_QUEUE"
 queue = "goldshore-jobs"
@@ -263,12 +224,15 @@ queue = "gs-mail-jobs"
 binding = "DEAD_LETTER_QUEUE"
 queue = "gs-mail-dead-letter"
 
-# ── Secrets Store ───────────────────────────────────────────────────────────────────
-[[env.preview.secrets_store.bindings]]
-binding = "SECRETS"
+# ── Secrets Store ────────────────────────────────────────────────────────────
+# Secrets Store bindings are per secret, not a store object. The runtime reads
+# env.INTEGRATION_MASTER_KEY directly.
+[[env.preview.secrets_store_secrets]]
+binding = "INTEGRATION_MASTER_KEY"
 store_id = "b9824d3280c54573a24137c7e7143b33"
+secret_name = "INTEGRATION_MASTER_KEY"
 
-# ── Durable Object migrations ───────────────────────────────────────────────────────────────────
+# ── Durable Object migrations ────────────────────────────────────────────────
 [[migrations]]
 tag = "v1-auth-session"
 new_sqlite_classes = ["AuthSession"]

--- a/apps/gs-control/wrangler.toml
+++ b/apps/gs-control/wrangler.toml
@@ -6,9 +6,9 @@ compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 
 [env.prod]
-routes = [
-  { pattern = "ops.goldshore.ai/*", zone_name = "goldshore.ai" }
-]
+# Consolidated into gs-api. Keep this legacy config route-free to prevent
+# hostname ownership collisions during validation and deployment.
+routes = []
 
 [env.prod.vars]
 ENV = "production"
@@ -38,9 +38,9 @@ service = "gs-gateway"
 environment = "prod"
 
 [env.preview]
-routes = [
-  { pattern = "ops-preview.goldshore.ai/*", zone_name = "goldshore.ai" }
-]
+# Consolidated into gs-api. Preview control traffic should route through gs-api
+# once a preview hostname is explicitly approved.
+routes = []
 
 [env.preview.vars]
 ENV = "preview"

--- a/apps/gs-gateway/wrangler.toml
+++ b/apps/gs-gateway/wrangler.toml
@@ -22,12 +22,7 @@ binding = "CONTACT_EVENTS_QUEUE"
 queue = "gs-platform-contact-events-dev"
 
 [env.prod]
-# www.goldshore.ai is owned by gs-www-redirect Worker
-# status.goldshore.ai is reserved for gs-status Pages project (MODULE_B2_RUNTIME_WIRING.md)
-# dashboard.goldshore.ai uses custom_domain to auto-provision DNS
-# agent.goldshore.ai/* is gateway-owned and forwarded to gs-agent through the AGENT service binding.
-# api.goldshore.ai/* is owned by gs-api; do not add it here or Wrangler deploys will conflict.
-routes = [
-  { pattern = "gw.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" }
-]
+# Legacy gateway routes are consolidated into gs-api or external live-state
+# cleanup. Keep this repo-managed placeholder route-free to prevent hostname
+# ownership collisions. Do not re-add agent.goldshore.ai here without an ADR.
+routes = []

--- a/apps/gs-trading/wrangler.toml
+++ b/apps/gs-trading/wrangler.toml
@@ -20,9 +20,9 @@ ENV = "development"
 # ---- Production environment --------------------------------------------------
 [env.prod]
 name = "gs-trading-prod"
-routes = [
-  { pattern = "trading.goldshore.ai/*", zone_name = "goldshore.ai" },
-]
+# Consolidated into gs-api trading routes. Keep this legacy config route-free
+# to prevent hostname ownership collisions during validation and deployment.
+routes = []
 
 # kv_namespaces is NOT inherited by named environments in Wrangler — must be re-declared.
 [[env.prod.kv_namespaces]]

--- a/docs/WORKER_CONFIGURATION.md
+++ b/docs/WORKER_CONFIGURATION.md
@@ -13,17 +13,17 @@ Do not add new app workers or deploy workflows for retired services. All backend
 ## `gs-api` (`apps/gs-api`)
 
 - **Wrangler:** `apps/gs-api/wrangler.toml`
-- **Production routes:** `api.goldshore.ai/*`, `api.goldshore.org/*`
-- **Preview:** `workers_dev = true`
+- **Production routes:** `api.goldshore.ai/*`, `api.goldshore.org/*`, plus consolidated backend hostnames `agent.goldshore.ai/*`, `mail.goldshore.ai/*`, `ops.goldshore.ai/*`, `trading.goldshore.ai/*`, `dashboard.goldshore.ai/*`, and `dash.goldshore.ai/*`
+- **Preview:** `workers_dev = true`; preview API route `api-preview.goldshore.ai/*`
 - **Canonical bindings:**
-  - KV: `KV`, `CONTROL_LOGS`
-  - D1: `PLATFORM_DB`, `AUDIT_DB`, `SIGNALS_DB`, `JOBS_DB`
-  - R2: `GS_ASSETS`, `TELEMETRY`
+  - KV: `KV`, `CONTROL_LOGS`, `RISK_RADAR_CACHE`
+  - D1: `PLATFORM_DB`, `AUDIT_DB`, `SIGNALS_DB`, `RISK_RADAR_DB`, `JOBS_DB`
+  - R2: `GS_ASSETS`, `TELEMETRY`, `RISK_RADAR_R2`
   - AI: `AI`
   - Durable Object: `AUTH_SESSION`
-  - Queues produced: `JOBS_QUEUE`, `EVENTS_QUEUE`, `MAIL_JOBS_QUEUE`, `DEAD_LETTER_QUEUE`
-  - Secrets Store: `SECRETS`
-- **Retired aliases:** `DB`, `ASSETS`, `TELEMETRY_DB`, `AGENT`, `GS_MAIL`, `GS_WEB`, `API_SERVICE`, and `GOLDSHORE_AI` must not be used as `gs-api` bindings.
+  - Queues produced: `JOBS_QUEUE`, `EVENTS_QUEUE`, `MAIL_JOBS_QUEUE`, `DEAD_LETTER_QUEUE`; `gs-api` is also the production consumer for consolidated backend queues
+  - Secrets Store: `INTEGRATION_MASTER_KEY` per-secret binding
+- **Retired aliases/service bindings:** `DB`, `ASSETS`, `TELEMETRY_DB`, `SECRETS`, `AGENT`, `GS_MAIL`, `GS_WEB`, `GS_WEB PROD`, `API_SERVICE`, and `GOLDSHORE_AI` must not be used as `gs-api` bindings. If Cloudflare still shows any of these in the dashboard, treat them as live-state cleanup candidates until a human confirms otherwise.
 
 ## `gs-web` (`apps/gs-web`)
 

--- a/infra/Cloudflare/BINDINGS_MAP.md
+++ b/infra/Cloudflare/BINDINGS_MAP.md
@@ -64,6 +64,13 @@
 - Code: `apps/gs-api`
 - Routes:
   - `api.goldshore.ai/*`
+  - `api.goldshore.org/*`
+  - `agent.goldshore.ai/*`
+  - `mail.goldshore.ai/*`
+  - `ops.goldshore.ai/*`
+  - `trading.goldshore.ai/*`
+  - `dashboard.goldshore.ai/*`
+  - `dash.goldshore.ai/*`
   - `api-preview.goldshore.ai/*`
 
 **Bindings:**
@@ -74,20 +81,32 @@
   - Binding: `RISK_RADAR_CACHE`
   - Namespace: `gs-risk-radar-cache` / `gs-risk-radar-cache-preview` _(Risk Radar response and signal cache; API-only)_
 - D1:
-  - Binding: `DB`
-  - Database: `goldshore` / `gs_db_001` _(historical alias: `goldshore-api-db`)_
+  - Binding: `PLATFORM_DB`
+  - Database: `gs_platform_db` _(canonical platform database)_
+  - Binding: `AUDIT_DB`
+  - Database: `gs_audit_db`
+  - Binding: `SIGNALS_DB`
+  - Database: `gs_signals_db`
   - Binding: `RISK_RADAR_DB`
   - Database: `gs_risk_radar_db` _(Risk Radar canonical structured storage; API-only)_
+  - Binding: `JOBS_DB`
+  - Database: `gs_jobs_db`
 - R2:
-  - Binding: `ASSETS`
-  - Bucket: `gs-assets` _(historical alias: `goldshore-api-assets`)_
+  - Binding: `GS_ASSETS`
+  - Bucket: `gs-assets` _(historical alias only: `ASSETS`)_
   - Binding: `RISK_RADAR_R2`
   - Bucket: `gs-risk-radar-raw` / `gs-risk-radar-raw-preview` _(Risk Radar raw source object storage; API-only)_
 - AI:
   - Binding: `AI`
   - Gateway: `goldshore-ai-gateway`
+- Secrets Store:
+  - Binding: `INTEGRATION_MASTER_KEY`
+  - Store: `b9824d3280c54573a24137c7e7143b33`
+  - Secret: `INTEGRATION_MASTER_KEY`
 
 **Risk Radar storage policy:** bind Risk Radar storage only to `gs-api`; `gs-web` must call API endpoints rather than receiving `RISK_RADAR_DB`, `RISK_RADAR_CACHE`, or `RISK_RADAR_R2` directly.
+
+**Unclear live-state note:** legacy dashboard service bindings such as `AGENT`, `GS_MAIL`, `GS_WEB`, `GS_WEB PROD`, `API_SERVICE`, `GOLDSHORE_AI`, and historical store-object binding `SECRETS` are not part of the repo-managed `gs-api` binding set. If present in Cloudflare, validate traffic before deleting, but do not reintroduce them into Wrangler config without an ADR update.
 
 ---
 

--- a/infra/Cloudflare/gs-api.wrangler.toml
+++ b/infra/Cloudflare/gs-api.wrangler.toml
@@ -5,12 +5,23 @@ name = "gs-api"
 main = "../../apps/gs-api/src/index.ts"
 compatibility_date = "2026-04-18"
 compatibility_flags = ["nodejs_compat"]
+
 workers_dev = false
 
-# ── Production ────────────────────────────────────────────────────────────────
+# ══════════════════════════════════════════════════════════════════════════════
+# Production environment
+# Canonical environment name is "prod". Use `wrangler deploy --env prod`.
+# ══════════════════════════════════════════════════════════════════════════════
+
 [env.prod]
 routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "mail.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "ops.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "trading.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "dashboard.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "dash.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 
@@ -18,7 +29,11 @@ routes = [
 ENV = "production"
 CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
 CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
+CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
+GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
+GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
 
+# ── KV ───────────────────────────────────────────────────────────────────────
 [[env.prod.kv_namespaces]]
 binding = "KV"
 id = "e0b8b807191346c3b0afc25fe716d2cd"
@@ -31,6 +46,7 @@ id = "a52e94cb331c4e3db08f2aa507e6df09"
 binding = "RISK_RADAR_CACHE"
 id = "0e67c3fe3d2b3231e7d4dba704e7dcd6"
 
+# ── R2 ───────────────────────────────────────────────────────────────────────
 [[env.prod.r2_buckets]]
 binding = "GS_ASSETS"
 bucket_name = "gs-assets"
@@ -43,6 +59,7 @@ bucket_name = "gs-telemetry-storage"
 binding = "RISK_RADAR_R2"
 bucket_name = "gs-risk-radar-raw"
 
+# ── D1 ───────────────────────────────────────────────────────────────────────
 [[env.prod.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
@@ -68,21 +85,16 @@ binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
 
+# ── AI ───────────────────────────────────────────────────────────────────────
 [env.prod.ai]
 binding = "AI"
 
+# ── Durable Objects ──────────────────────────────────────────────────────────
 [[env.prod.durable_objects.bindings]]
 name = "AUTH_SESSION"
 class_name = "AuthSession"
 
-
-
-[[env.prod.services]]
-binding = "GS_WEB"
-service = "gs-web"
-environment = "prod"
-
-
+# ── Queues ───────────────────────────────────────────────────────────────────
 [[env.prod.queues.producers]]
 binding = "JOBS_QUEUE"
 queue = "goldshore-jobs"
@@ -99,34 +111,58 @@ queue = "gs-mail-jobs"
 binding = "DEAD_LETTER_QUEUE"
 queue = "gs-mail-dead-letter"
 
+[[env.prod.queues.consumers]]
+queue = "goldshore-jobs"
+
+[[env.prod.queues.consumers]]
+queue = "gs-mail-jobs"
+
+[[env.prod.queues.consumers]]
+queue = "gs-events"
+
+# ── Workflows ────────────────────────────────────────────────────────────────
 [[env.prod.workflows]]
 binding = "GS_SIGNALS"
 name = "signals-evaluator"
 class_name = "SignalsEvaluator"
 script_name = "gs-signals-prod"
 
-[[env.prod.secrets_store.bindings]]
-binding = "SECRETS"
+# ── Secrets Store ────────────────────────────────────────────────────────────
+# Secrets Store bindings are per secret, not a store object. The runtime reads
+# env.INTEGRATION_MASTER_KEY directly.
+[[env.prod.secrets_store_secrets]]
+binding = "INTEGRATION_MASTER_KEY"
 store_id = "b9824d3280c54573a24137c7e7143b33"
+secret_name = "INTEGRATION_MASTER_KEY"
 
-# ── Preview ───────────────────────────────────────────────────────────────────
+# ══════════════════════════════════════════════════════════════════════════════
+# Preview environment
+# ══════════════════════════════════════════════════════════════════════════════
+
 [env.preview]
-
-[[env.preview.routes]]
-pattern = "api-preview.goldshore.ai/*"
-zone_name = "goldshore.ai"
+workers_dev = true
+routes = [
+  { pattern = "api-preview.goldshore.ai/*", zone_name = "goldshore.ai" }
+]
 
 [env.preview.vars]
 ENV = "preview"
+GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 
+# ── KV ───────────────────────────────────────────────────────────────────────
 [[env.preview.kv_namespaces]]
 binding = "KV"
 id = "d4d20cee39094b999dea3f7e5f4c533a"
 
 [[env.preview.kv_namespaces]]
+binding = "CONTROL_LOGS"
+id = "09e43cb8bd4749fdaaed0dc9d4ff2284"
+
+[[env.preview.kv_namespaces]]
 binding = "RISK_RADAR_CACHE"
 id = "a2315c0e83f27b610c3dfdd30eb0a9ea"
 
+# ── R2 ───────────────────────────────────────────────────────────────────────
 [[env.preview.r2_buckets]]
 binding = "GS_ASSETS"
 bucket_name = "gs-assets-preview"
@@ -139,6 +175,7 @@ bucket_name = "gs-telemetry-storage"
 binding = "RISK_RADAR_R2"
 bucket_name = "gs-risk-radar-raw-preview"
 
+# ── D1 ───────────────────────────────────────────────────────────────────────
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
@@ -164,23 +201,16 @@ binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
 
+# ── AI ───────────────────────────────────────────────────────────────────────
 [env.preview.ai]
 binding = "AI"
 
+# ── Durable Objects ──────────────────────────────────────────────────────────
 [[env.preview.durable_objects.bindings]]
 name = "AUTH_SESSION"
 class_name = "AuthSession"
 
-
-
-[[env.preview.services]]
-binding = "GS_WEB"
-service = "gs-web"
-
-[[env.preview.services]]
-binding = "API_SERVICE"
-service = "gs-api"
-
+# ── Queues ───────────────────────────────────────────────────────────────────
 [[env.preview.queues.producers]]
 binding = "JOBS_QUEUE"
 queue = "goldshore-jobs"
@@ -193,11 +223,19 @@ queue = "gs-events"
 binding = "MAIL_JOBS_QUEUE"
 queue = "gs-mail-jobs"
 
-[[env.preview.secrets_store.bindings]]
-binding = "SECRETS"
-store_id = "b9824d3280c54573a24137c7e7143b33"
+[[env.preview.queues.producers]]
+binding = "DEAD_LETTER_QUEUE"
+queue = "gs-mail-dead-letter"
 
-# ── DO migrations (applied at deploy time) ────────────────────────────────────
+# ── Secrets Store ────────────────────────────────────────────────────────────
+# Secrets Store bindings are per secret, not a store object. The runtime reads
+# env.INTEGRATION_MASTER_KEY directly.
+[[env.preview.secrets_store_secrets]]
+binding = "INTEGRATION_MASTER_KEY"
+store_id = "b9824d3280c54573a24137c7e7143b33"
+secret_name = "INTEGRATION_MASTER_KEY"
+
+# ── Durable Object migrations ────────────────────────────────────────────────
 [[migrations]]
 tag = "v1-auth-session"
 new_sqlite_classes = ["AuthSession"]


### PR DESCRIPTION
### Motivation

- Standardize Cloudflare environment names/bindings and remove legacy store-object patterns to avoid runtime confusion and hostname ownership collisions.
- Move secret handling off the historical `SECRETS` store-object shape to a per-secret Secrets Store binding for the master encryption key.
- Consolidate routing/hostname ownership into `gs-api` and prevent other repo-managed workers from claiming production hostnames.

### Description

- Updated `apps/gs-api/wrangler.toml` and `infra/Cloudflare/*` references to use canonical environment name `prod` instead of `production`, added consolidated backend hostnames and Risk Radar bindings (`RISK_RADAR_CACHE`, `RISK_RADAR_DB`, `RISK_RADAR_R2`), and converted Secrets Store config to a per-secret binding `INTEGRATION_MASTER_KEY`.
- Changed `apps/gs-api/src/lib/encryption.ts` to read the master key from the `env.INTEGRATION_MASTER_KEY` binding and removed use of the legacy `SECRETS.get(...)` shape, and updated `apps/gs-api/src/types.ts` and `src/index.ts` to reflect the new binding names and remove retired service fetcher bindings.
- Adjusted `apps/gs-api/package.json` deploy/build scripts to target `--env prod` and left test scripts unchanged.
- Sanitized other workers' `wrangler.toml` files (`gs-control`, `gs-gateway`, `gs-trading`) to remove repo-managed production routes and services that would collide with the consolidated `gs-api` ownership and added explanatory comments.
- Updated documentation files (`CLAUDE.md`, `docs/WORKER_CONFIGURATION.md`, `infra/Cloudflare/BINDINGS_MAP.md`, and reference `infra/Cloudflare/gs-api.wrangler.toml`) to reflect the new canonical bindings, retired aliases, preview routes, and per-secret Secrets Store usage.

### Testing

- Ran the `apps/gs-api` unit tests with `pnpm --filter @goldshore/gs-api test` and they completed successfully.
- Performed a TypeScript typecheck / build for the workspace using `pnpm -w build` and there were no type/build errors.
- Verified `wrangler.toml` syntax for `apps/gs-api` and related reference files by static review (no automated deploys were run as part of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52746647bc8331a576b2322394932a)