### PR TITLE
fix(ci): infrastructure-guard.yml canonical-worker heading references are stale

### DIFF
--- a/.github/workflows/infrastructure-guard.yml
+++ b/.github/workflows/infrastructure-guard.yml
@@ -30,8 +30,13 @@ jobs:
 
       - name: Verify all wrangler configs reference canonical worker names
         run: |
-          # Dynamically extract canonical worker names from the Workers table in INFRASTRUCTURE.md
-          CANONICAL_WORKERS=$(sed -n '/^## Workers/,/^---$/p' infra/INFRASTRUCTURE.md | grep -oP '^\| `\K[a-z0-9_-]+(?=` \|)' | sort -u)
+          # Dynamically extract canonical worker names from the live-inventory table in
+          # INFRASTRUCTURE.md. The heading was renamed from "## Workers" during the
+          # 2026-07 doc restructure (infra/INFRASTRUCTURE.md split into live inventory,
+          # legacy dispositions, and target architecture) without updating this guard,
+          # which made CANONICAL_WORKERS empty and failed every PR touching
+          # apps/*/wrangler.toml or infra/**.
+          CANONICAL_WORKERS=$(sed -n '/^## Current live Cloudflare worker inventory/,/^---$/p' infra/INFRASTRUCTURE.md | grep -oP '^\| `\K[a-z0-9_-]+(?=` \|)' | sort -u)
 
           echo "Canonical workers:"
           echo "$CANONICAL_WORKERS"
@@ -194,11 +199,13 @@ jobs:
           with open("infra/INFRASTRUCTURE.md") as f:
               manifest = f.read()
 
-          # Extract worker names from canonical Workers section (fail if found outside this)
+          # Extract worker names from the live-inventory section (fail if found outside this).
+          # Heading renamed during the 2026-07 doc restructure; see the matching comment
+          # in the manifest-integrity job above.
           import re
-          workers_section = re.search(r"(?ms)^## Workers \(canonical[^\n]*\n(.*?)(?=^## |\Z)", manifest)
+          workers_section = re.search(r"(?ms)^## Current live Cloudflare worker inventory[^\n]*\n(.*?)(?=^## |\Z)", manifest)
           if not workers_section:
-              raise SystemExit("Could not find '## Workers (canonical' section in infra/INFRASTRUCTURE.md")
+              raise SystemExit("Could not find '## Current live Cloudflare worker inventory' section in infra/INFRASTRUCTURE.md")
           canonical = sorted(set(re.findall(r"\| `([a-z0-9_-]+)` \|", workers_section.group(1))))
 
           print(f"Live workers:      {live_names}")


### PR DESCRIPTION
## Summary

Merge strategy: merge

Phase 0 of `marzton/goldclaw#6` (target architecture SOP). Restores `infrastructure-guard.yml` to actually working order after the `infra/INFRASTRUCTURE.md` restructure renamed its `## Workers` heading.

## What broke

`infra/INFRASTRUCTURE.md` was split into live inventory / legacy dispositions / target architecture sections, and `## Workers` became `## Current live Cloudflare worker inventory (observed — not all canonical)`. Both required-status-check jobs in this guard still searched for the old heading:

- **`manifest-integrity`**: `sed -n '/^## Workers/,/^---$/p'` matched nothing → `CANONICAL_WORKERS` empty → the worker-name check failed on the first `apps/*/wrangler.toml` with a `name` field, i.e. every PR touching that path.
- **`live-state-audit`**: Python regex required a literal `## Workers (canonical` heading → `raise SystemExit` immediately.

Both are listed as required status checks in `infra/branch-protection.json` (`"Manifest integrity check"`, `"Cloudflare live state audit"`), so this silently blocked every PR modifying `apps/*/wrangler.toml` or `infra/**` — exactly the kind of PR that's been merging all week.

## Fix

Repointed both extractions at the renamed heading. Verified locally by running each job's extraction logic directly against `infra/INFRASTRUCTURE.md`:

- `manifest-integrity`'s sed/grep now extracts all 34 documented worker names and the per-`wrangler.toml` name check passes for every current `apps/*/wrangler.toml`.
- `live-state-audit`'s Python regex now finds the section and extracts the same 34 names, correctly including `gs-gateway` and `gs-web` (both already documented, so this fix doesn't introduce new false failures for the recent gateway rename / Pages migration).

No change to the D1 consistency check (job 1's second step) — its `## D1 Databases` heading was never renamed and wasn't broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URPXiZHLNCuLYrP7a5eWyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01URPXiZHLNCuLYrP7a5eWyt)_