### PR TITLE
fix(gs-web): correct verify-web-dist.mjs path check blocking every deploy

### DIFF
--- a/scripts/verify-web-dist.mjs
+++ b/scripts/verify-web-dist.mjs
@@ -3,8 +3,9 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
 const distDir = path.resolve('dist');
-const astroDir = path.join(distDir, '_astro');
-const indexPath = path.join(distDir, 'index.html');
+const clientDir = path.join(distDir, 'client');
+const astroDir = path.join(clientDir, '_astro');
+const indexPath = path.join(clientDir, 'index.html');
 const webAppRoot = path.resolve('.');
 const webLayoutPath = path.join(webAppRoot, 'src', 'layouts', 'WebLayout.astro');
 const publicDir = path.join(webAppRoot, 'public');


### PR DESCRIPTION
## Summary
- `deploy-gs-web.yml` has failed on every run since `da94269` (5+ consecutive failures on `main`), even though the underlying Astro build succeeds every time.
- Root cause: `scripts/verify-web-dist.mjs` checks for `dist/index.html` and `dist/_astro/*.{css,js}`, but `@astrojs/cloudflare` in `output: "server"` mode writes static output to `dist/client/index.html` and `dist/client/_astro/*` instead (`dist/server/` holds the Worker entry). The script has been checking a path that hasn't matched the adapter's actual layout, so it fails unconditionally.
- Fix: point `indexPath`/`astroDir` at `dist/client/` instead of `dist/`.

## Test plan
- [x] `pnpm --dir apps/gs-web build` succeeds locally
- [x] `node scripts/verify-web-dist.mjs` (run from `apps/gs-web`) now passes against the real build output: `✅ gs-web dist integrity check passed - CSS bundles: 7 - JS bundles: 5`
- [ ] Confirm `deploy-gs-web.yml` goes green on this branch/PR
- [ ] After merge, confirm production picks up the deploy and previously-404ing routes (e.g. `/admin/lead-submissions`) go live

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_