### PR TITLE
fix(gs-web): repair broken forms/[slug].ts syntax error blocking all CI

### DIFF
--- a/apps/gs-web/src/pages/api/forms/[slug].ts
+++ b/apps/gs-web/src/pages/api/forms/[slug].ts
@@ -5,156 +5,30 @@ export const prerender = false;
 const apiBase = (env: Env | undefined) =>
   (env?.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
 
-  const fetchSite = request.headers.get('sec-fetch-site');
-  if (fetchSite) {
-    return fetchSite === 'same-origin' || fetchSite === 'none';
+const forwardedHeaders = (request: Request) => {
+  const headers = new Headers();
+  for (const name of ['accept', 'authorization', 'cookie', 'cf-connecting-ip', 'user-agent', 'content-type']) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
   }
-
-  return false;
+  return headers;
 };
 
-const unauthorizedResponse = () =>
-  Response.json({ error: 'Authentication required.' }, { status: 401 });
+const proxy = async (request: Request, env: Env | undefined, slug?: string) => {
+  if (!slug) return new Response('Form slug is required.', { status: 400 });
 
-const forbiddenResponse = (message = 'Insufficient permissions.') =>
-  Response.json({ error: message }, { status: 403 });
-
-const requirePermission = async (
-  request: Request,
-  env: AccessEnv,
-  permission: AdminPermission,
-) => {
-  const claims = await verifyAccessWithClaims(request, env);
-  if (!claims) {
-    return { response: unauthorizedResponse() };
-  }
-
-  const session = buildAdminSession(claims);
-  if (!session.permissions.includes(permission)) {
-    return { response: forbiddenResponse() };
-  }
-
-  return { response: null };
-};
-
-export const GET: APIRoute = async ({ request, locals, params }) => {
-  const env = locals.runtime?.env as Env | undefined;
-  const slug = params.slug;
-
-  if (!env?.PLATFORM_DB) {
-    return new Response('Storage unavailable.', { status: 503 });
-  }
-
-  const auth = await requirePermission(request, env as AccessEnv, 'forms:read');
-  if (auth.response) {
-    return auth.response;
-  }
-
-  if (!slug) {
-    return new Response('Form slug is required.', { status: 400 });
-  }
-
-  const result = await env.PLATFORM_DB.prepare(
-    `SELECT id, slug, name, status, fields, recipients, integrations, created_at, updated_at
-     FROM form_configs
-     WHERE slug = ?
-     LIMIT 1`
-  )
-    .bind(slug)
-    .all();
-
-  const row = result?.results?.[0] as Record<string, string> | undefined;
-  if (!row) {
-    return new Response('Form not found.', { status: 404 });
-  }
-
-  return Response.json({ config: normalizeRow(row) });
-};
-
-export const PUT: APIRoute = async ({ request, locals, params }) => {
-  const env = locals.runtime?.env as Env | undefined;
-  const slug = params.slug;
-
-  if (!env?.PLATFORM_DB) {
-    return new Response('Storage unavailable.', { status: 503 });
-  }
-
-  if (!isSameOriginRequest(request)) {
-    return forbiddenResponse('Forbidden: CSRF check failed.');
-  }
-
-  const auth = await requirePermission(request, env as AccessEnv, 'forms:write');
-  if (auth.response) {
-    return auth.response;
-  }
-
-  if (!slug) {
-    return new Response('Form slug is required.', { status: 400 });
-  }
-
-  const payload = (await request.json()) as {
-    name?: string;
-    status?: string;
-    fields?: Record<string, unknown>[];
-    recipients?: Record<string, unknown>[];
-    integrations?: Record<string, unknown>[];
-  };
-
-  const existing = await env.PLATFORM_DB.prepare(
-    `SELECT id, slug, name, status, fields, recipients, integrations, created_at, updated_at
-     FROM form_configs
-     WHERE slug = ?
-     LIMIT 1`
-  )
-    .bind(slug)
-    .all();
-
-  const row = existing?.results?.[0] as Record<string, string> | undefined;
-  if (!row) {
-    return new Response('Form not found.', { status: 404 });
-  }
-
-  const updated = {
-    name: payload.name ?? row.name,
-    status: payload.status ?? row.status,
-    fields: payload.fields ?? parseJson(row.fields ?? null, [] as Record<string, unknown>[]),
-    recipients: payload.recipients ?? parseJson(row.recipients ?? null, [] as Record<string, unknown>[]),
-    integrations: payload.integrations ?? parseJson(row.integrations ?? null, [] as Record<string, unknown>[]),
-  };
-
-  const now = new Date().toISOString();
-
-  await env.PLATFORM_DB.prepare(
-    `UPDATE form_configs
-     SET name = ?, status = ?, fields = ?, recipients = ?, integrations = ?, updated_at = ?
-     WHERE slug = ?`
-  )
-    .bind(
-      updated.name,
-      updated.status,
-      JSON.stringify(updated.fields),
-      JSON.stringify(updated.recipients),
-      JSON.stringify(updated.integrations),
-      now,
-      slug
-    )
-    .run();
-
-  return Response.json({
-    config: {
-      id: row.id,
-      slug,
-      name: updated.name,
-      status: updated.status,
-      fields: updated.fields,
-      recipients: updated.recipients,
-      integrations: updated.integrations,
-      createdAt: row.created_at,
-      updatedAt: now,
-    },
+  const target = new URL(`${apiBase(env)}/v1/forms/configs/${encodeURIComponent(slug)}`);
+  const response = await fetch(target, {
+    method: request.method,
+    headers: forwardedHeaders(request),
+    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.text(),
   });
+
+  return new Response(response.body, { status: response.status, headers: response.headers });
 };
 
-export const GET: APIRoute = async ({ request, locals, params }) => proxy(request, locals.runtime?.env as Env | undefined, params.slug);
-export const PUT: APIRoute = async ({ request, locals, params }) => proxy(request, locals.runtime?.env as Env | undefined, params.slug);
+export const GET: APIRoute = async ({ request, locals, params }) =>
+  proxy(request, locals.runtime?.env as Env | undefined, params.slug);
+export const PUT: APIRoute = async ({ request, locals, params }) =>
+  proxy(request, locals.runtime?.env as Env | undefined, params.slug);
 export const PATCH = PUT;


### PR DESCRIPTION
## Summary

`apps/gs-web/src/pages/api/forms/[slug].ts` has a syntax error (`Unexpected "}"` at line 14) that's currently breaking `gs-web-build` and `lint-test-build` on **every** PR against `main`, including unrelated ones (surfaced while investigating CI on #5677).

Root cause: two API route implementations were spliced together — an old direct-D1-access version (referencing `requirePermission`/`normalizeRow`/`parseJson`/`AccessEnv`, none of which were even imported) and a new proxy version at the bottom calling an undefined `proxy()` function. The top of the old `isSameOriginRequest` function was deleted but its body was left dangling, producing a stray top-level `};`.

This landed via a clean, unflagged auto-merge in #5672 — the PR branch's own copy of this file was already broken, and since nothing textually conflicted with `main`'s version, git merged it in as-is without surfacing anything to resolve.

## Fix

Rewrites the file as a single, working proxy to `gs-api`'s already-existing `GET`/`PUT`/`PATCH` `/v1/forms/configs/:slug` handlers (which already do their own CF Access auth via `requirePermission`), matching the same proxy pattern `contact.ts` already uses post-refactor.

## Verified

- `esbuild` compiles the rewritten file cleanly to valid JS (previously failed with a parse error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01URPXiZHLNCuLYrP7a5eWyt)_