### PR TITLE
feat(admin): port Google Search Console dashboard into gs-web

### DIFF
--- a/apps/gs-web/src/env.d.ts
+++ b/apps/gs-web/src/env.d.ts
@@ -43,6 +43,10 @@ interface Env {
   GOOGLE_ADSENSE_CLIENT_SECRET?: string;
   GOOGLE_ADSENSE_REFRESH_TOKEN?: string;
   GOOGLE_ADSENSE_ACCOUNT_ID?: string;
+  GOOGLE_GSC_CLIENT_ID?: string;
+  GOOGLE_GSC_CLIENT_SECRET?: string;
+  GOOGLE_GSC_REFRESH_TOKEN?: string;
+  GOOGLE_GSC_SITE_URL?: string;
 }
 
 declare namespace App {

--- a/apps/gs-web/src/lib/search-console.ts
+++ b/apps/gs-web/src/lib/search-console.ts
@@ -1,0 +1,122 @@
+export type SearchConsoleConfig = {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  siteUrl: string;
+};
+
+export type SearchConsoleMetrics = {
+  date: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
+
+export type SearchConsoleQuery = {
+  query: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+};
+
+export const getSearchConsoleConfig = (env: Env | undefined): SearchConsoleConfig | null => {
+  const clientId = env?.GOOGLE_GSC_CLIENT_ID || '';
+  const clientSecret = env?.GOOGLE_GSC_CLIENT_SECRET || '';
+  const refreshToken = env?.GOOGLE_GSC_REFRESH_TOKEN || '';
+  const siteUrl = env?.GOOGLE_GSC_SITE_URL || '';
+
+  if (!clientId || !clientSecret || !refreshToken || !siteUrl) {
+    return null;
+  }
+
+  return { clientId, clientSecret, refreshToken, siteUrl };
+};
+
+export const getSearchConsoleAccessToken = async (config: SearchConsoleConfig): Promise<string | null> => {
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      refresh_token: config.refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!response.ok) return null;
+  const data = (await response.json()) as { access_token?: string };
+  return data.access_token ?? null;
+};
+
+const querySearchAnalytics = async (
+  config: SearchConsoleConfig,
+  accessToken: string,
+  body: Record<string, unknown>,
+): Promise<{ rows?: Array<{ keys?: string[]; clicks?: number; impressions?: number; ctr?: number; position?: number }> } | null> => {
+  const response = await fetch(
+    `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(config.siteUrl)}/searchAnalytics/query`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.ok) return null;
+  return (await response.json()) as {
+    rows?: Array<{ keys?: string[]; clicks?: number; impressions?: number; ctr?: number; position?: number }>;
+  };
+};
+
+export const fetchTopQueries = async (
+  config: SearchConsoleConfig,
+  accessToken: string,
+  options?: { startDate?: string; endDate?: string; limit?: number },
+): Promise<SearchConsoleQuery[] | null> => {
+  const startDate = options?.startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const endDate = options?.endDate || new Date().toISOString().split('T')[0];
+
+  const data = await querySearchAnalytics(config, accessToken, {
+    startDate,
+    endDate,
+    dimensions: ['query'],
+    rowLimit: options?.limit ?? 25,
+  });
+  if (!data) return null;
+
+  return (data.rows ?? []).map((row) => ({
+    query: row.keys?.[0] ?? '',
+    clicks: row.clicks ?? 0,
+    impressions: row.impressions ?? 0,
+    ctr: (row.ctr ?? 0) * 100,
+    position: row.position ?? 0,
+  }));
+};
+
+export const fetchPerformanceMetrics = async (
+  config: SearchConsoleConfig,
+  accessToken: string,
+  options?: { startDate?: string; endDate?: string },
+): Promise<SearchConsoleMetrics[] | null> => {
+  const startDate = options?.startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const endDate = options?.endDate || new Date().toISOString().split('T')[0];
+
+  const data = await querySearchAnalytics(config, accessToken, {
+    startDate,
+    endDate,
+    dimensions: ['date'],
+    rowLimit: 90,
+  });
+  if (!data) return null;
+
+  return (data.rows ?? []).map((row) => ({
+    date: row.keys?.[0] ?? '',
+    clicks: row.clicks ?? 0,
+    impressions: row.impressions ?? 0,
+    ctr: (row.ctr ?? 0) * 100,
+    position: row.position ?? 0,
+  }));
+};

--- a/apps/gs-web/src/pages/admin/search-console.astro
+++ b/apps/gs-web/src/pages/admin/search-console.astro
@@ -1,0 +1,163 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { authorizeAdminRequest, getAdminRouteRule } from '../../utils/admin-access';
+
+export const prerender = false;
+
+const env = Astro.locals.runtime?.env as Env | undefined;
+const rule = getAdminRouteRule('/admin/search-console', 'GET');
+
+let authError: { status: number; message: string } | null = null;
+if (!rule) {
+  authError = { status: 404, message: 'Not found.' };
+} else {
+  const authResult = await authorizeAdminRequest(Astro.request, env as never, rule);
+  if (!authResult.ok) {
+    authError = { status: authResult.status, message: authResult.error };
+  }
+}
+---
+
+<BaseLayout title="Search Console | GoldShore Admin" description="Organic search performance from Google Search Console">
+  <section class="gs-section">
+    <div class="gs-grid columns-2">
+      <div>
+        <h1>Search Console</h1>
+        <p class="gs-text-lg">Organic search clicks, impressions, and top queries from Google Search Console.</p>
+      </div>
+      <div class="gs-card">
+        <h2 class="section-title"><span>◆</span>Actions</h2>
+        <button id="refresh-gsc" class="gs-button" type="button">Refresh data</button>
+      </div>
+    </div>
+
+    {authError ? (
+      <div class="gs-card" style="margin-top: 2rem;">
+        <p class="gs-text-lg">{authError.message}</p>
+      </div>
+    ) : (
+      <>
+        <div class="gs-grid columns-2" style="margin-top: 2rem;">
+          <div class="gs-card">
+            <h2 class="section-title"><span>◆</span>Summary (last 30 days)</h2>
+            <ul>
+              <li>Clicks: <strong id="total-clicks">0</strong></li>
+              <li>Impressions: <strong id="total-impressions">0</strong></li>
+              <li>Avg CTR: <strong id="avg-ctr">0.00%</strong></li>
+              <li>Avg position: <strong id="avg-position">0.0</strong></li>
+              <li>Status: <span id="gsc-status" class="gs-badge info">Checking…</span></li>
+            </ul>
+          </div>
+          <div class="gs-card" style="overflow-x: auto;">
+            <h2 class="section-title"><span>◆</span>Top queries</h2>
+            <table class="gs-table">
+              <thead>
+                <tr><th>Query</th><th>Clicks</th><th>Impressions</th><th>CTR</th><th>Position</th></tr>
+              </thead>
+              <tbody id="gsc-queries-tbody">
+                <tr><td colspan="5">Loading…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="gs-card" style="margin-top: 2rem; overflow-x: auto;">
+          <h2 class="section-title"><span>◆</span>Performance over time</h2>
+          <table class="gs-table">
+            <thead>
+              <tr><th>Date</th><th>Clicks</th><th>Impressions</th><th>CTR</th><th>Position</th></tr>
+            </thead>
+            <tbody id="gsc-metrics-tbody">
+              <tr><td colspan="5">Loading…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </>
+    )}
+  </section>
+
+  <script>
+    async function loadSearchConsoleData() {
+      const metricsBody = document.getElementById('gsc-metrics-tbody');
+      const queriesBody = document.getElementById('gsc-queries-tbody');
+      const statusEl = document.getElementById('gsc-status');
+
+      try {
+        const res = await fetch('/api/admin/search-console');
+        const data = await res.json();
+
+        if (!data.success) {
+          if (statusEl) {
+            statusEl.textContent = data.error ?? 'Not connected';
+            statusEl.className = 'gs-badge';
+          }
+          const message = data.error ?? 'Search Console not configured.';
+          if (metricsBody) metricsBody.innerHTML = `<tr><td colspan="5">${message}</td></tr>`;
+          if (queriesBody) queriesBody.innerHTML = `<tr><td colspan="5">${message}</td></tr>`;
+          return;
+        }
+
+        const { summary, metrics, topQueries } = data;
+
+        const set = (id: string, value: string) => {
+          const el = document.getElementById(id);
+          if (el) el.textContent = value;
+        };
+        set('total-clicks', summary.totalClicks.toLocaleString());
+        set('total-impressions', summary.totalImpressions.toLocaleString());
+        set('avg-ctr', `${summary.avgCTR.toFixed(2)}%`);
+        set('avg-position', summary.avgPosition.toFixed(1));
+        if (statusEl) {
+          statusEl.textContent = 'Connected';
+          statusEl.className = 'gs-badge success';
+        }
+
+        if (metricsBody) {
+          if (!metrics?.length) {
+            metricsBody.innerHTML = '<tr><td colspan="5">No data for this period.</td></tr>';
+          } else {
+            metricsBody.innerHTML = metrics
+              .map(
+                (m: { date: string; clicks: number; impressions: number; ctr: number; position: number }) => `
+                <tr>
+                  <td>${new Date(m.date).toLocaleDateString()}</td>
+                  <td>${m.clicks.toLocaleString()}</td>
+                  <td>${m.impressions.toLocaleString()}</td>
+                  <td>${m.ctr.toFixed(2)}%</td>
+                  <td>${m.position.toFixed(1)}</td>
+                </tr>`,
+              )
+              .join('');
+          }
+        }
+
+        if (queriesBody) {
+          if (!topQueries?.length) {
+            queriesBody.innerHTML = '<tr><td colspan="5">No queries for this period.</td></tr>';
+          } else {
+            queriesBody.innerHTML = topQueries
+              .map(
+                (q: { query: string; clicks: number; impressions: number; ctr: number; position: number }) => `
+                <tr>
+                  <td>${q.query}</td>
+                  <td>${q.clicks.toLocaleString()}</td>
+                  <td>${q.impressions.toLocaleString()}</td>
+                  <td>${q.ctr.toFixed(2)}%</td>
+                  <td>${q.position.toFixed(1)}</td>
+                </tr>`,
+              )
+              .join('');
+          }
+        }
+      } catch {
+        if (statusEl) {
+          statusEl.textContent = 'Network error';
+          statusEl.className = 'gs-badge';
+        }
+      }
+    }
+
+    document.getElementById('refresh-gsc')?.addEventListener('click', loadSearchConsoleData);
+    loadSearchConsoleData();
+  </script>
+</BaseLayout>

--- a/apps/gs-web/src/pages/api/admin/search-console.ts
+++ b/apps/gs-web/src/pages/api/admin/search-console.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro';
+import { authorizeAdminRequest, getAdminRouteRule } from '../../../utils/admin-access';
+import { getSearchConsoleConfig, getSearchConsoleAccessToken, fetchTopQueries, fetchPerformanceMetrics } from '../../../lib/search-console';
+
+export const GET: APIRoute = async ({ request, locals }) => {
+  const env = locals.runtime?.env as Env | undefined;
+  const rule = getAdminRouteRule('/api/admin/search-console', 'GET');
+  if (!rule) {
+    return new Response('Not found.', { status: 404 });
+  }
+
+  const authResult = await authorizeAdminRequest(request, env as never, rule);
+  if (!authResult.ok) {
+    return Response.json({ success: false, error: authResult.error }, { status: authResult.status });
+  }
+
+  const config = getSearchConsoleConfig(env);
+  if (!config) {
+    return Response.json({ success: false, error: 'Search Console not configured.' }, { status: 503 });
+  }
+
+  const accessToken = await getSearchConsoleAccessToken(config);
+  if (!accessToken) {
+    return Response.json({ success: false, error: 'Failed to authenticate with Search Console.' }, { status: 502 });
+  }
+
+  try {
+    const [queries, metrics] = await Promise.all([
+      fetchTopQueries(config, accessToken),
+      fetchPerformanceMetrics(config, accessToken),
+    ]);
+
+    if (!queries || !metrics) {
+      return Response.json({ success: false, error: 'Failed to fetch Search Console data.' }, { status: 502 });
+    }
+
+    const totalClicks = metrics.reduce((sum, m) => sum + m.clicks, 0);
+    const totalImpressions = metrics.reduce((sum, m) => sum + m.impressions, 0);
+    const avgPosition = metrics.length ? metrics.reduce((sum, m) => sum + m.position, 0) / metrics.length : 0;
+    const avgCTR = totalImpressions > 0 ? (totalClicks / totalImpressions) * 100 : 0;
+
+    return Response.json({
+      success: true,
+      summary: { totalClicks, totalImpressions, avgPosition, avgCTR, period: `Last ${metrics.length} days` },
+      metrics: metrics.slice(-7),
+      topQueries: queries,
+    });
+  } catch {
+    return Response.json({ success: false, error: 'Search Console request failed.' }, { status: 502 });
+  }
+};

--- a/apps/gs-web/src/utils/admin-access.ts
+++ b/apps/gs-web/src/utils/admin-access.ts
@@ -123,7 +123,9 @@ export const getAdminRouteRule = (
     normalizedPath === '/api/admin/cf/workers' ||
     normalizedPath === '/api/admin/cf/worker-detail' ||
     normalizedPath === '/admin/monetization' ||
-    normalizedPath === '/api/admin/monetization/adsense'
+    normalizedPath === '/api/admin/monetization/adsense' ||
+    normalizedPath === '/admin/search-console' ||
+    normalizedPath === '/api/admin/search-console'
   ) {
     return {
       canonicalPath: normalizedPath,


### PR DESCRIPTION
## Summary
- Adds `/admin/search-console`: organic search summary (clicks, impressions, avg CTR, avg position), a top-queries table, and a performance-over-time table, sourced from the Google Search Console (Webmasters v3) `searchAnalytics.query` API.
- New `apps/gs-web/src/lib/search-console.ts`: config/OAuth/fetch helpers reading from the Cloudflare `Env` binding (no `process.env`), following the exact pattern already established for `apps/gs-web/src/lib/adsense.ts`.
- New `GET /api/admin/search-console` same-origin API route, gated by `authorizeAdminRequest` (`system:read`), matching `/api/admin/monetization/adsense`.
- `apps/gs-admin/src/lib/integrations/GoogleSearchConsole.ts` (and its `gs-api` counterpart) exist but were confirmed dead code — never wired to any route in either app — so this is a new implementation rather than a port of working UI, unlike the AdSense page which had a real (if broken/unauthenticated) page to port.
- New env vars: `GOOGLE_GSC_CLIENT_ID`, `GOOGLE_GSC_CLIENT_SECRET`, `GOOGLE_GSC_REFRESH_TOKEN`, `GOOGLE_GSC_SITE_URL` (all optional on `Env`; page/route degrade to a "not configured" state when unset).
- Route rules added to `admin-access.ts` for `/admin/search-console` and `/api/admin/search-console`, requiring `system:read` + admin role.

## Test plan
- [x] `pnpm --filter gs-web run build` — builds cleanly
- [x] `node --experimental-strip-types --test tests/unit/admin-access.test.ts` — 4/4 pass
- [ ] Provide real Google OAuth credentials (`GOOGLE_GSC_*` secrets) to verify a live connection in production behind Access


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_