### PR TITLE
ci: add DNS reconciliation workflow (dry-run by default)

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -1,0 +1,192 @@
+name: Reconcile DNS
+
+# Reconciles live Cloudflare DNS records against infra/Cloudflare/desired-state.yaml.
+# Creates missing records and corrects mismatched ones (content/proxied only).
+# Never deletes records -- deletion always requires a human, per
+# infra/Cloudflare/runbooks/DNS_AND_EMAIL.md ("Delete record" requires explicit
+# confirmation).
+#
+# goldshore.org and www.goldshore.org are intentionally excluded below. Three repo
+# docs disagree on who owns them:
+#   - infra/Cloudflare/desired-state.yaml and policy/ROUTE_POLICY.md (Authority:
+#     Marzton, 2026-04-24) describe a standalone "goldshore-org" router Worker.
+#   - docs/architecture/domain-ownership.md (2026-06-15, later) says gs-web/Pages
+#     owns goldshore.org, and explicitly states "goldshore-org is not canonical".
+#   - infra/Cloudflare/deploy.ts's gs-web smoke check treats goldshore.org as part
+#     of gs-web's own deploy verification, matching the domain-ownership.md read.
+# Resolve that conflict (update whichever doc is stale) before adding these two
+# records back here.
+#
+# Run manually: Actions -> Reconcile DNS -> Run workflow. dry_run defaults to true.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Show what would change without applying it'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  reconcile:
+    name: Reconcile DNS records
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    env:
+      CF_API: https://api.cloudflare.com/client/v4
+      # NOTE: policy/ROUTE_POLICY.md and infra/Cloudflare/README.md document
+      # CLOUDFLARE_BUILD_API_TOKEN as the canonical deploy token for this repo,
+      # with CLOUDFLARE_API_TOKEN called out as a legacy secret slated for
+      # removal. Using CLOUDFLARE_API_TOKEN here because that's the one that
+      # currently has Zone:DNS:Edit -- migrate this to CLOUDFLARE_BUILD_API_TOKEN
+      # once that token has the same permission added.
+      CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract desired DNS records (excluding goldshore.org)
+        run: |
+          set -euo pipefail
+          python3 - <<'EOF' > desired_records.json
+          import yaml, json
+
+          with open('infra/Cloudflare/desired-state.yaml') as f:
+              cfg = yaml.safe_load(f)
+
+          out = []
+          for r in cfg['cloudflare']['dns']['records']:
+              name = r['name']
+              zone = r.get('zone', 'goldshore.ai')
+              if zone == 'goldshore.org' or name in ('goldshore.org', 'www.goldshore.org'):
+                  continue
+              full_name = zone if name == zone else f"{name}.{zone}"
+              out.append({
+                  'name': name,
+                  'full_name': full_name,
+                  'type': r['type'],
+                  'content': r['content'],
+                  'proxied': r.get('proxied', False),
+                  'zone': zone,
+              })
+
+          print(json.dumps(out))
+          EOF
+          echo "Extracted $(jq 'length' desired_records.json) desired records (goldshore.org excluded, see workflow header):"
+          jq -r '.[] | "  \(.full_name) (\(.type)) -> \(.content) [proxied=\(.proxied)]"' desired_records.json
+
+      - name: Verify CF token has Zone DNS scope
+        run: |
+          set -euo pipefail
+          ZID=$(curl -sS "$CF_API/zones?name=goldshore.ai" -H "Authorization: Bearer $CF_TOKEN" | jq -r '.result[0].id // empty')
+          if [ -z "$ZID" ]; then
+            echo "::error::Could not resolve zone id for goldshore.ai -- token may lack Zone:Read, or DNS:Edit was added to a different token than CLOUDFLARE_API_TOKEN."
+            exit 1
+          fi
+          STATUS=$(curl -sS -o /dev/null -w '%{http_code}' "$CF_API/zones/$ZID/dns_records" -H "Authorization: Bearer $CF_TOKEN")
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN lacks Zone:DNS permission on goldshore.ai (HTTP $STATUS). Add Zone -> DNS -> Edit at https://dash.cloudflare.com/profile/api-tokens"
+            exit 1
+          fi
+          echo "Zone goldshore.ai ($ZID): DNS scope OK"
+
+      - name: Reconcile records
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          get_zone_id() {
+            curl -sS "$CF_API/zones?name=$1" -H "Authorization: Bearer $CF_TOKEN" | jq -r '.result[0].id // empty'
+          }
+
+          ZID_AI=$(get_zone_id goldshore.ai)
+          if [ -z "$ZID_AI" ]; then
+            echo "::error::Could not resolve zone id for goldshore.ai"
+            exit 1
+          fi
+          echo "goldshore.ai zone id: $ZID_AI"
+
+          CHANGED=0
+
+          while read -r rec; do
+            FULL_NAME=$(echo "$rec" | jq -r '.full_name')
+            TYPE=$(echo "$rec" | jq -r '.type')
+            CONTENT=$(echo "$rec" | jq -r '.content')
+            PROXIED=$(echo "$rec" | jq -r '.proxied')
+
+            LIST_RESP=$(curl -sS -w '\n%{http_code}' \
+              "$CF_API/zones/$ZID_AI/dns_records?name=$FULL_NAME&type=$TYPE" \
+              -H "Authorization: Bearer $CF_TOKEN")
+            LIST_STATUS="${LIST_RESP##*$'\n'}"
+            LIST_BODY="${LIST_RESP%$'\n'*}"
+            if [ "$LIST_STATUS" -lt 200 ] || [ "$LIST_STATUS" -ge 300 ]; then
+              echo "::warning::GET dns_records for $FULL_NAME ($TYPE) failed (HTTP $LIST_STATUS): $LIST_BODY -- skipping"
+              continue
+            fi
+
+            EXISTING_ID=$(echo "$LIST_BODY" | jq -r '.result[0].id // empty')
+            EXISTING_CONTENT=$(echo "$LIST_BODY" | jq -r '.result[0].content // empty')
+            EXISTING_PROXIED=$(echo "$LIST_BODY" | jq -r '.result[0].proxied // empty')
+
+            if [ -z "$EXISTING_ID" ]; then
+              echo "MISSING: $FULL_NAME ($TYPE) -> $CONTENT [proxied=$PROXIED]"
+              CHANGED=1
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  [dry-run] would CREATE"
+                continue
+              fi
+              BODY=$(jq -nc --arg t "$TYPE" --arg n "$FULL_NAME" --arg c "$CONTENT" --argjson p "$PROXIED" \
+                '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
+              CREATE_RESP=$(echo "$BODY" | curl -sS -w '\n%{http_code}' -X POST \
+                "$CF_API/zones/$ZID_AI/dns_records" \
+                -H "Authorization: Bearer $CF_TOKEN" \
+                -H "Content-Type: application/json" \
+                --data @-)
+              CREATE_STATUS="${CREATE_RESP##*$'\n'}"
+              CREATE_BODY="${CREATE_RESP%$'\n'*}"
+              if [ "$CREATE_STATUS" -lt 200 ] || [ "$CREATE_STATUS" -ge 300 ]; then
+                echo "::warning::CREATE $FULL_NAME failed (HTTP $CREATE_STATUS): $CREATE_BODY"
+              else
+                echo "  Created $FULL_NAME"
+              fi
+              continue
+            fi
+
+            if [ "$EXISTING_CONTENT" = "$CONTENT" ] && [ "$EXISTING_PROXIED" = "$PROXIED" ]; then
+              echo "OK: $FULL_NAME ($TYPE) already matches desired state"
+              continue
+            fi
+
+            echo "MISMATCH: $FULL_NAME ($TYPE) live=[$EXISTING_CONTENT proxied=$EXISTING_PROXIED] desired=[$CONTENT proxied=$PROXIED]"
+            CHANGED=1
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "  [dry-run] would UPDATE"
+              continue
+            fi
+            BODY=$(jq -nc --arg t "$TYPE" --arg n "$FULL_NAME" --arg c "$CONTENT" --argjson p "$PROXIED" \
+              '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
+            UPDATE_RESP=$(echo "$BODY" | curl -sS -w '\n%{http_code}' -X PUT \
+              "$CF_API/zones/$ZID_AI/dns_records/$EXISTING_ID" \
+              -H "Authorization: Bearer $CF_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data @-)
+            UPDATE_STATUS="${UPDATE_RESP##*$'\n'}"
+            UPDATE_BODY="${UPDATE_RESP%$'\n'*}"
+            if [ "$UPDATE_STATUS" -lt 200 ] || [ "$UPDATE_STATUS" -ge 300 ]; then
+              echo "::warning::UPDATE $FULL_NAME failed (HTTP $UPDATE_STATUS): $UPDATE_BODY"
+            else
+              echo "  Updated $FULL_NAME"
+            fi
+          done < <(jq -c '.[]' desired_records.json)
+
+          if [ "$DRY_RUN" = "true" ] && [ "$CHANGED" = "1" ]; then
+            echo ""
+            echo "::notice::Dry run found differences. Re-run with dry_run=false to apply."
+          elif [ "$CHANGED" = "0" ]; then
+            echo ""
+            echo "::notice::All records already match desired state -- nothing to do."
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/reconcile-dns.yml`: reconciles live Cloudflare DNS records against `infra/Cloudflare/desired-state.yaml` — creates missing records, corrects mismatched `content`/`proxied` values, **never deletes** (per `infra/Cloudflare/runbooks/DNS_AND_EMAIL.md`, deletion always requires a human).
- Parses `desired-state.yaml` directly at run time (Python/PyYAML) rather than hardcoding a duplicate record list, to avoid doc-vs-automation drift — already found twice in this repo today (`CLAUDE.md`'s stale "two-app monorepo" claim, and this same DNS conflict below).
- `dry_run` defaults to `true` — first run on any branch only reports differences, applies nothing.
- Uses `CLOUDFLARE_API_TOKEN` (has the needed Zone:DNS:Edit permission right now). Repo policy (`policy/ROUTE_POLICY.md`, `infra/Cloudflare/README.md`) documents `CLOUDFLARE_BUILD_API_TOKEN` as canonical and this one as legacy/slated for removal — left a `TODO` to migrate once that token has the same permission.

## Deliberately excluded
`goldshore.org` and `www.goldshore.org` are left out of the reconciled set. Three repo docs disagree on who owns them:
- `desired-state.yaml` + `policy/ROUTE_POLICY.md` (Authority: Marzton, 2026-04-24): a standalone `goldshore-org` router Worker.
- `docs/architecture/domain-ownership.md` (2026-06-15, later): `gs-web`/Pages owns it, explicitly states `goldshore-org` is not canonical.
- `infra/Cloudflare/deploy.ts`'s `gs-web` smoke check treats `goldshore.org` as part of `gs-web`'s own deploy verification — matches the `domain-ownership.md` read.

Needs a human decision (and a doc fix wherever it's stale) before automating that one.

## Test plan
- [ ] Run `Reconcile DNS` workflow from `main` with `dry_run=true` (default) — confirm it reports the expected diffs (`gw`, `api`, `mail`, `trading`/`dashboard`/`dash`, `ops`, `preview`, SendGrid records) without applying anything
- [ ] Review the dry-run output before ever running with `dry_run=false`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_