### PR TITLE
fix: correct workers.dev subdomain drift in desired-state.yaml

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -130,7 +130,11 @@ jobs:
 
             EXISTING_ID=$(echo "$LIST_BODY" | jq -r '.result[0].id // empty')
             EXISTING_CONTENT=$(echo "$LIST_BODY" | jq -r '.result[0].content // empty')
-            EXISTING_PROXIED=$(echo "$LIST_BODY" | jq -r '.result[0].proxied // empty')
+            # NOTE: do not use `// empty` for a boolean field -- jq's `//` treats
+            # `false` as falsy and would silently turn a legitimate proxied=false
+            # into "", causing every correctly-unproxied record to misreport as a
+            # mismatch against the string "false".
+            EXISTING_PROXIED=$(echo "$LIST_BODY" | jq -r 'if .result[0].proxied == null then "" else (.result[0].proxied | tostring) end')
 
             if [ -z "$EXISTING_ID" ]; then
               echo "MISSING: $FULL_NAME ($TYPE) -> $CONTENT [proxied=$PROXIED]"

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -110,14 +110,15 @@ jobs:
           fi
           echo "goldshore.ai zone id: $ZID_AI"
 
-          # goldshore.ai (apex) and api.goldshore.ai both report as MISSING via a
-          # type=CNAME query despite being live and working today -- almost
-          # certainly provisioned through a Pages/Workers custom-domain mechanism
-          # that doesn't show up as a plain CNAME through this API. Auto-creating
-          # a record for either without eyes-on verification risks a conflicting
-          # record on the two most important hostnames in the zone, so skip CREATE
-          # for them until manually confirmed.
-          SKIP_CREATE_HOSTS="goldshore.ai api.goldshore.ai"
+          # goldshore.ai (apex), api.goldshore.ai, and preview.goldshore.ai all
+          # report as MISSING via a type=CNAME query despite being live and
+          # working today -- provisioned through a Pages/Workers custom-domain
+          # mechanism that doesn't show up as a plain CNAME through this API.
+          # Confirmed for preview.goldshore.ai: Cloudflare rejected a real CREATE
+          # attempt with code 81062 ("A DNS record managed by Workers already
+          # exists on that host"). Skip CREATE for all three rather than let
+          # every run log a false MISSING/warning pair.
+          SKIP_CREATE_HOSTS="goldshore.ai api.goldshore.ai preview.goldshore.ai"
 
           CHANGED=0
 

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -130,6 +130,14 @@ jobs:
 
             EXISTING_ID=$(echo "$LIST_BODY" | jq -r '.result[0].id // empty')
             EXISTING_CONTENT=$(echo "$LIST_BODY" | jq -r '.result[0].content // empty')
+            # Cloudflare returns TXT record content wrapped in literal quote
+            # characters; desired-state.yaml stores the unquoted value, so strip
+            # one matching pair before comparing or every TXT record would
+            # misreport as a mismatch even when the value is identical.
+            if [ "$TYPE" = "TXT" ]; then
+              EXISTING_CONTENT="${EXISTING_CONTENT%\"}"
+              EXISTING_CONTENT="${EXISTING_CONTENT#\"}"
+            fi
             # NOTE: do not use `// empty` for a boolean field -- jq's `//` treats
             # `false` as falsy and would silently turn a legitimate proxied=false
             # into "", causing every correctly-unproxied record to misreport as a

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -110,6 +110,15 @@ jobs:
           fi
           echo "goldshore.ai zone id: $ZID_AI"
 
+          # goldshore.ai (apex) and api.goldshore.ai both report as MISSING via a
+          # type=CNAME query despite being live and working today -- almost
+          # certainly provisioned through a Pages/Workers custom-domain mechanism
+          # that doesn't show up as a plain CNAME through this API. Auto-creating
+          # a record for either without eyes-on verification risks a conflicting
+          # record on the two most important hostnames in the zone, so skip CREATE
+          # for them until manually confirmed.
+          SKIP_CREATE_HOSTS="goldshore.ai api.goldshore.ai"
+
           CHANGED=0
 
           while read -r rec; do
@@ -146,6 +155,12 @@ jobs:
 
             if [ -z "$EXISTING_ID" ]; then
               echo "MISSING: $FULL_NAME ($TYPE) -> $CONTENT [proxied=$PROXIED]"
+              case " $SKIP_CREATE_HOSTS " in
+                *" $FULL_NAME "*)
+                  echo "  [skip] $FULL_NAME is in SKIP_CREATE_HOSTS -- not auto-creating, verify manually"
+                  continue
+                  ;;
+              esac
               CHANGED=1
               if [ "$DRY_RUN" = "true" ]; then
                 echo "  [dry-run] would CREATE"

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -15,11 +15,11 @@ cloudflare:
       # goldshore.org + www.goldshore.org — owned by goldshore-org Worker (route-based, needs proxied DNS)
       - name: "goldshore.org"
         type: CNAME
-        content: "goldshore-org.goldshore-account.workers.dev"
+        content: "goldshore-org.goldshore.workers.dev"
         proxied: true
       - name: "www.goldshore.org"
         type: CNAME
-        content: "goldshore-org.goldshore-account.workers.dev"
+        content: "goldshore-org.goldshore.workers.dev"
         proxied: true
 
       # B. Admin App (gs-admin — both .ai and .org)
@@ -37,39 +37,39 @@ cloudflare:
       # C. API Gateway Worker
       - name: "gw"
         type: CNAME
-        content: "gs-gateway.goldshore-account.workers.dev"
+        content: "gs-gateway-prod.goldshore.workers.dev"
         proxied: true
 
       # D. API Worker
       - name: "api"
         type: CNAME
-        content: "gs-api.goldshore-account.workers.dev"
+        content: "gs-api.goldshore.workers.dev"
         proxied: true
 
       # E. Mail Worker
       - name: "mail"
         type: CNAME
-        content: "gs-mail.goldshore-account.workers.dev"
+        content: "gs-mail.goldshore.workers.dev"
         proxied: true
 
       # F. Trading dashboard aliases — route-based, protected by GoldShore-Trading-ZT
       - name: "trading"
         type: CNAME
-        content: "gs-trading-prod.goldshore-account.workers.dev"
+        content: "gs-trading-prod.goldshore.workers.dev"
         proxied: true
       - name: "dashboard"
         type: CNAME
-        content: "gs-trading-prod.goldshore-account.workers.dev"
+        content: "gs-gateway-prod.goldshore.workers.dev"
         proxied: true
       - name: "dash"
         type: CNAME
-        content: "gs-trading-prod.goldshore-account.workers.dev"
+        content: "gs-trading-prod.goldshore.workers.dev"
         proxied: true
 
       # G. Control Worker (ops.goldshore.ai)
       - name: "ops"
         type: CNAME
-        content: "gs-control.goldshore-account.workers.dev"
+        content: "gs-core-worker-prod.goldshore.workers.dev"
         proxied: true
 
       # G. Preview deployments (claude/** branches)


### PR DESCRIPTION
## Summary
- `infra/Cloudflare/desired-state.yaml` used the `account_name` placeholder `goldshore-account` as the `*.workers.dev` subdomain for `gw`/`api`/`mail`/`trading`/`dashboard`/`dash`/`ops`/`goldshore.org` records. The real subdomain is `goldshore` (confirmed against every currently-live/working record and the live Workers list) — applying the file as-is via `Reconcile DNS` would have repointed `gw`/`mail`/`trading` (all live and working today) at a host that doesn't exist.
- `ops.goldshore.ai`: desired-state.yaml pointed at a `gs-control` worker that doesn't exist anywhere in the account. Changed to `gs-core-worker-prod` per owner confirmation.
- `dashboard.goldshore.ai`: desired-state.yaml pointed at `gs-trading-prod`, but the live record serves `gs-gateway-prod`. Reverted to match live rather than silently changing production, per owner confirmation.
- `.github/workflows/reconcile-dns.yml`: fixed a real bug — jq's `//` operator treats `false` as falsy, so `.result[0].proxied // empty` silently turned legitimate `proxied: false` values into `""`, making every correctly-unproxied record (SendGrid CNAMEs, DMARC TXT) misreport as a MISMATCH. Replaced with an explicit null check.

## Test plan
- [ ] Run `Reconcile DNS` with `dry_run=true` on `main` — confirm the SendGrid/DMARC records now report `OK` instead of a false MISMATCH, and `gw`/`mail`/`trading` report `OK` or a real, sane diff instead of pointing at `goldshore-account.workers.dev`
- [ ] Review the corrected dry-run output before ever running with `dry_run=false`

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_