### PR TITLE
fix: activate api.goldshore.ai (no DNS record existed)

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -110,15 +110,22 @@ jobs:
           fi
           echo "goldshore.ai zone id: $ZID_AI"
 
-          # goldshore.ai (apex), api.goldshore.ai, and preview.goldshore.ai all
-          # report as MISSING via a type=CNAME query despite being live and
-          # working today -- provisioned through a Pages/Workers custom-domain
-          # mechanism that doesn't show up as a plain CNAME through this API.
-          # Confirmed for preview.goldshore.ai: Cloudflare rejected a real CREATE
-          # attempt with code 81062 ("A DNS record managed by Workers already
-          # exists on that host"). Skip CREATE for all three rather than let
-          # every run log a false MISSING/warning pair.
-          SKIP_CREATE_HOSTS="goldshore.ai api.goldshore.ai preview.goldshore.ai"
+          # goldshore.ai (apex) and preview.goldshore.ai report as MISSING via a
+          # type=CNAME query despite being live and working today -- both are
+          # provisioned through a Workers Custom Domain mechanism that doesn't
+          # show up as a plain CNAME through this API. Confirmed for
+          # preview.goldshore.ai: Cloudflare rejected a real CREATE attempt
+          # with code 81062 ("A DNS record managed by Workers already exists
+          # on that host"). Skip CREATE for both rather than let every run log
+          # a false MISSING/warning pair.
+          #
+          # api.goldshore.ai is deliberately NOT in this list: verified via
+          # the raw Cloudflare API that it has zero DNS records of any kind
+          # (no CNAME, no wildcard, no Custom Domain) despite having a
+          # configured Worker Route (api.goldshore.ai/* -> gs-api-prod) --
+          # the route had nothing to activate it and the hostname was down.
+          # It needs a real CREATE, not a skip.
+          SKIP_CREATE_HOSTS="goldshore.ai preview.goldshore.ai"
 
           CHANGED=0
 

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -41,9 +41,15 @@ cloudflare:
         proxied: true
 
       # D. API Worker
+      # No DNS record previously existed for api.goldshore.ai at all -- the
+      # zone-level Worker Route (api.goldshore.ai/* -> gs-api-prod) had
+      # nothing to activate it, so the hostname was down. Content value is
+      # mostly cosmetic (the Route intercepts before CNAME resolution
+      # matters) but points at the real live worker, gs-api-prod, matching
+      # the Route target rather than the nonexistent "gs-api".
       - name: "api"
         type: CNAME
-        content: "gs-api.goldshore.workers.dev"
+        content: "gs-api-prod.goldshore.workers.dev"
         proxied: true
 
       # E. Mail Worker


### PR DESCRIPTION
## Summary
- `api.goldshore.ai` had **zero DNS records of any kind** (no CNAME, no wildcard, no Workers Custom Domain), verified directly against the raw Cloudflare API. A Worker Route (`api.goldshore.ai/*` → `gs-api-prod`) is configured and expects to serve it, but a Route only activates once some proxied DNS record exists at the exact hostname — without one, traffic never reaches Cloudflare's edge. Confirmed with the repo owner: `api.goldshore.ai` is currently down.
- `infra/Cloudflare/desired-state.yaml`: `api` record content now points at `gs-api-prod.goldshore.workers.dev` (the real live worker backing the Route) instead of the nonexistent `gs-api` worker.
- `.github/workflows/reconcile-dns.yml`: removed `api.goldshore.ai` from `SKIP_CREATE_HOSTS`. Unlike `goldshore.ai`/`preview.goldshore.ai` (which have hidden Custom-Domain-managed records a CREATE would conflict with), nothing exists at `api.goldshore.ai`, so it's safe to create for real.

## Test plan
- [ ] Run `Reconcile DNS` with `dry_run=true` — confirm it now reports `api.goldshore.ai` as `MISSING` with `would CREATE`, not `[skip]`
- [ ] Run with `dry_run=false` — confirm the record is created successfully
- [ ] Confirm `https://api.goldshore.ai/health` (or similar) responds afterward

Co-authored-by: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_