### PR TITLE
fix: add missing /api/leads/subscribe route in gs-web

### DIFF
--- a/apps/gs-web/src/pages/api/leads/subscribe.ts
+++ b/apps/gs-web/src/pages/api/leads/subscribe.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const apiBase = (env: Env | undefined) =>
+  (env?.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
+
+const jsonError = (status: number, message: string) => Response.json({ message }, { status });
+
+const forwardedHeaders = (request: Request) => {
+  const headers = new Headers();
+  for (const name of ['cf-connecting-ip', 'user-agent', 'x-forwarded-for']) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  return headers;
+};
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  if (!request.headers.get('content-type')?.includes('application/json')) {
+    return jsonError(415, 'Unsupported payload.');
+  }
+
+  let email: unknown;
+  try {
+    ({ email } = await request.json());
+  } catch {
+    return jsonError(400, 'Invalid request body.');
+  }
+
+  if (typeof email !== 'string' || !emailPattern.test(email.trim())) {
+    return jsonError(400, 'Please enter a valid email address.');
+  }
+
+  const env = locals.runtime?.env as Env | undefined;
+  const target = new URL(`${apiBase(env)}/v1/forms/newsletter/submissions`);
+  const formData = new FormData();
+  formData.set('email', email.trim().toLowerCase());
+  formData.set('redirectTo', '/');
+
+  let response: Response;
+  try {
+    response = await fetch(target, {
+      method: 'POST',
+      headers: forwardedHeaders(request),
+      body: formData,
+    });
+  } catch {
+    return jsonError(503, 'Subscription service unavailable. Please try again later.');
+  }
+
+  if (!response.ok) {
+    return jsonError(response.status, 'Subscription failed. Please try again.');
+  }
+
+  return Response.json({ success: true, message: 'Successfully subscribed!' }, { status: 200 });
+};
+
+export const GET: APIRoute = async () => jsonError(405, 'Method not allowed.');


### PR DESCRIPTION
SiteFooter.astro's newsletter signup form has always posted JSON to /api/leads/subscribe, but no such route existed in apps/gs-web/src/pages/api -- the only implementation lived in the legacy, out-of-policy apps/gs-admin app (a separate deployment on admin.goldshore.ai, unreachable from a relative fetch on goldshore.ai). The live subscribe button has been 404ing.

Rather than reintroducing the legacy KV-based implementation (which would also violate the "gs-web calls gs-api, doesn't touch storage directly" pattern already established by contact.ts), this proxies to gs-api's existing generic POST /v1/forms/:formId/submissions endpoint (formId="newsletter") -- the same route apps/gs-web/src/pages/api/contact.ts already uses for the contact form. No new bindings needed on either side: gs-web only needs PUBLIC_API (already declared), and gs-api's forms.ts persists to the already-bound PLATFORM_DB and sends notification/auto-responder mail via the already-configured mail path.

Client contract (JSON {email} in, {success,message} JSON out) is unchanged, so no changes needed in SiteFooter.astro.