### PR TITLE
admin: cut admin.goldshore.ai over from gs-admin Pages to gs-web

### DIFF
--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -18,7 +18,8 @@ binding = "ASSETS"
 [env.prod]
 routes = [
   { pattern = "goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "goldshore.org/*", zone_name = "goldshore.org" }
+  { pattern = "goldshore.org/*", zone_name = "goldshore.org" },
+  { pattern = "admin.goldshore.ai/*", zone_name = "goldshore.ai" }
 ]
 
 [[env.prod.kv_namespaces]]

--- a/docs/architecture/domain-ownership.md
+++ b/docs/architecture/domain-ownership.md
@@ -15,8 +15,8 @@ This file is the canonical human-readable route ownership policy for GoldShore C
 | `api.goldshore.ai/*` | `gs-api` | Worker | API surface |
 | `gw.goldshore.ai/*` | `gs-gateway` | Worker | Gateway surface |
 | `agent.goldshore.ai/*` | `gs-gateway` | Worker | Agent-facing gateway route |
-| `admin.goldshore.ai` | `gs-admin` | Pages + Cloudflare Access | Admin UI |
-| `admin-preview.goldshore.ai` | `gs-admin` | Pages + Cloudflare Access | Admin preview UI |
+| `admin.goldshore.ai` | `gs-web` | Worker + Cloudflare Access | Admin UI (migrated off gs-admin; admin page content not yet ported into gs-web) |
+| `admin-preview.goldshore.ai` | `gs-admin` | Pages + Cloudflare Access | Admin preview UI (not yet migrated) |
 | `ops.goldshore.ai/*` | `gs-control` | Worker | Control plane |
 | `mail.goldshore.ai/*` | `gs-mail` | Worker | Mail/events worker |
 | `rmarston.com` | `rmarston-com` | Separate repo/project | Personal site |

--- a/infra/Cloudflare/BINDINGS_MAP.md
+++ b/infra/Cloudflare/BINDINGS_MAP.md
@@ -27,16 +27,18 @@
 
 ### 2. Admin (Cockpit)
 
-- Project: `gs-admin`
+`admin.goldshore.ai` was migrated off the standalone `gs-admin` Pages project onto `gs-web` (route `admin.goldshore.ai/*` in `apps/gs-web/wrangler.toml`), per CLAUDE.md's repo migration plan. The DNS/routing cutover is done; the actual admin page/route content under `apps/gs-admin/src` has not been ported into `apps/gs-web` yet — that migration is in progress.
+
+- Project (legacy, not yet retired): `gs-admin`
 - Repo: `goldshore-ai`
 - Root: `apps/gs-admin`
-- Custom Domains:
-  - `admin.goldshore.ai`
+- Custom Domains still on the legacy project:
   - `admin-preview.goldshore.ai`
+  - `admin.goldshore.org` (pending the separate `goldshore.org` ownership conflict — see `policy/ROUTE_POLICY.md` vs `docs/architecture/domain-ownership.md`)
 
 **Zero Trust:**
 
-- Access policy required on `admin.goldshore.ai` (email allowlist).
+- Access policy required on `admin.goldshore.ai` (email allowlist) — unchanged by the cutover, still applies to the same hostname regardless of which Worker/Pages project serves it.
 
 **Environment Variables:**
 

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -22,10 +22,16 @@ cloudflare:
         content: "goldshore-org.goldshore.workers.dev"
         proxied: true
 
-      # B. Admin App (gs-admin — both .ai and .org)
+      # B. Admin (migrated from the standalone gs-admin Pages app into gs-web
+      # sub-routes per CLAUDE.md's repo migration plan; gs-web owns
+      # admin.goldshore.ai now via the admin.goldshore.ai/* route in
+      # apps/gs-web/wrangler.toml). admin.goldshore.org is out of scope here
+      # pending the separate goldshore.org ownership conflict
+      # (policy/ROUTE_POLICY.md vs docs/architecture/domain-ownership.md) --
+      # still points at the legacy gs-admin app until that's resolved.
       - name: "admin"
         type: CNAME
-        content: "gs-admin.pages.dev"
+        content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
         zone: goldshore.ai
       - name: "admin"

--- a/policy/ROUTE_POLICY.md
+++ b/policy/ROUTE_POLICY.md
@@ -35,11 +35,12 @@ preview.goldshore.ai
 └── Same build, same code, different DNS name (for QA)
 
 admin.goldshore.ai
-├── gs-admin Pages project
+├── gs-web Worker (migrated off the standalone gs-admin Pages project)
+├── Route: admin.goldshore.ai/* (apps/gs-web/wrangler.toml env.prod)
 └── Cloudflare Access policy: email allowlist required
 
 admin-preview.goldshore.ai
-├── gs-admin Pages preview environment
+├── gs-admin Pages preview environment (not yet migrated)
 └── Same Access policy as admin.goldshore.ai
 ```
 
@@ -78,7 +79,7 @@ ops.goldshore.ai/*
 #### Pages (Custom Domains)
 ```
 admin.goldshore.org
-├── gs-admin Pages project
+├── gs-admin Pages project (not yet migrated -- see admin.goldshore.ai above)
 ├── Owner: gs-admin
 ├── Hosting: Cloudflare Pages
 └── Cloudflare Access application/policy: GoldShore Admin / GoldShore-Admin-ZT
@@ -129,7 +130,7 @@ www.banproof.me/*
 2. **Subdomain isolation.** Each subdomain is owned by exactly one service.
    - `api.*` → gs-api only
    - `gw.*` → gs-platform only
-   - `admin.*` → gs-admin Pages only
+   - `admin.goldshore.ai` → gs-web only (migrated); `admin.goldshore.org` → gs-admin Pages (not yet migrated)
    - etc.
 
 3. **Custom domains vs. routes.** 
@@ -189,7 +190,7 @@ https://goldshore-ai.pages.dev/  (or custom domain)
 When accessed via:
 - `https://goldshore.ai/` → CORS allows it (wildcard or explicit)
 - `https://goldshore.org/` → goldshore-org router sets ASSETS_ORIGIN, CORS allows it
-- `https://admin.goldshore.ai/` → gs-admin is a separate build, may have own assets
+- `https://admin.goldshore.ai/` → now served by gs-web directly (same build/assets as the main site); admin page content itself has not been ported into gs-web yet, so this route currently serves gs-web's normal routing until admin pages land under apps/gs-web/src/pages/admin/*
 
 **Recursion risk:** If gs-web tries to fetch from itself (e.g., prefetch WASM), ensure CORS doesn't loop back.
 
@@ -234,10 +235,10 @@ When accessed via:
 
 | Route | Zone | Audience | Policy |
 |---|---|---|---|
-| `admin.goldshore.ai` | goldshore.ai | gs-admin | Email: @goldshore.ai, @marzton.dev |
-| `admin.goldshore.org` | goldshore.org | gs-admin | Same GoldShore Admin application/policy (`GoldShore-Admin-ZT`) as admin.goldshore.ai |
-| `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview | Same as admin |
-| `admin.goldshore.ai` | goldshore.ai | gs-admin | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |
+| `admin.goldshore.ai` | goldshore.ai | gs-web | Email: @goldshore.ai, @marzton.dev |
+| `admin.goldshore.org` | goldshore.org | gs-admin (not yet migrated) | Same GoldShore Admin application/policy (`GoldShore-Admin-ZT`) as admin.goldshore.ai |
+| `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview (not yet migrated) | Same as admin |
+| `admin.goldshore.ai` | goldshore.ai | gs-web | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |
 | `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |
 | `ops.goldshore.ai` | goldshore.ai | gs-control | Email: @goldshore.ai (ops team only) |
 | `agent.goldshore.ai/*` | goldshore.ai | Goldshore Gateway shared AUD | Bypass `/health` and `/status`; protect all other agent paths |


### PR DESCRIPTION
Per explicit confirmation from the account owner: admin-facing work moves into apps/gs-web sub-routes rather than the standalone, out-of-policy apps/gs-admin app (CLAUDE.md's two-app policy already forbids routing new work there). This cuts the DNS/routing layer over now, ahead of the actual admin page/route content migration.

- apps/gs-web/wrangler.toml: add admin.goldshore.ai/* to env.prod routes, alongside the existing goldshore.ai/* and goldshore.org/* patterns.
- desired-state.yaml: admin CNAME (goldshore.ai zone) now points at gs-web-prod.goldshore.workers.dev instead of gs-admin.pages.dev. admin.goldshore.org is explicitly left untouched -- it's either served by a different deployment (marzton/goldshore-admin, a standalone repo per CLAUDE.md, not apps/gs-admin) or pending the separate goldshore.org ownership conflict; out of scope here.
- policy/ROUTE_POLICY.md, docs/architecture/domain-ownership.md, infra/Cloudflare/BINDINGS_MAP.md: updated to reflect gs-web as the new owner of admin.goldshore.ai, with explicit notes that the actual admin page/route content has not been ported into apps/gs-web yet -- only the DNS/routing layer has moved. Until that content lands, admin.goldshore.ai will fall through to gs-web's normal routing (e.g. the marketing homepage), not an admin UI.

Cloudflare Access policy on admin.goldshore.ai is unaffected -- Access applications are bound by hostname, independent of which Worker/Pages project serves the backend.

## Next
The actual apps/gs-admin -> apps/gs-web page/route/integration migration (pages, API routes, lib/integrations, trading admin panels, auth middleware) is tracked as separate follow-up work -- not included in this change.