### PR TITLE
fix: activate goldshore.ai apex (no DNS record existed)

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -110,22 +110,21 @@ jobs:
           fi
           echo "goldshore.ai zone id: $ZID_AI"
 
-          # goldshore.ai (apex) and preview.goldshore.ai report as MISSING via a
-          # type=CNAME query despite being live and working today -- both are
-          # provisioned through a Workers Custom Domain mechanism that doesn't
-          # show up as a plain CNAME through this API. Confirmed for
-          # preview.goldshore.ai: Cloudflare rejected a real CREATE attempt
-          # with code 81062 ("A DNS record managed by Workers already exists
-          # on that host"). Skip CREATE for both rather than let every run log
-          # a false MISSING/warning pair.
+          # preview.goldshore.ai reports as MISSING via a type=CNAME query
+          # despite being live and working today -- it's provisioned through
+          # a real Workers Custom Domain that doesn't show up as a plain
+          # CNAME through this API. Confirmed: Cloudflare rejected a real
+          # CREATE attempt with code 81062 ("A DNS record managed by Workers
+          # already exists on that host"). Skip CREATE rather than let every
+          # run log a false MISSING/warning pair.
           #
-          # api.goldshore.ai is deliberately NOT in this list: verified via
-          # the raw Cloudflare API that it has zero DNS records of any kind
-          # (no CNAME, no wildcard, no Custom Domain) despite having a
-          # configured Worker Route (api.goldshore.ai/* -> gs-api-prod) --
-          # the route had nothing to activate it and the hostname was down.
-          # It needs a real CREATE, not a skip.
-          SKIP_CREATE_HOSTS="goldshore.ai preview.goldshore.ai"
+          # goldshore.ai (apex) and api.goldshore.ai are deliberately NOT in
+          # this list: verified via the raw Cloudflare API that both have
+          # zero DNS records of any kind (no CNAME, no wildcard, no Custom
+          # Domain) despite having a configured Worker Route -- the route had
+          # nothing to activate it and the hostname was down. They need a
+          # real CREATE, not a skip.
+          SKIP_CREATE_HOSTS="preview.goldshore.ai"
 
           CHANGED=0
 

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -7,9 +7,20 @@ cloudflare:
   dns:
     records:
       # A. Web App (gs-web)
+      # No DNS record previously existed for the apex at all -- it is not a
+      # Workers Custom Domain (verified via the account-level Custom Domains
+      # API: goldshore.ai apex is absent from that list, unlike
+      # preview.goldshore.ai/core.goldshore.ai/agent.goldshore.ai/
+      # signals.goldshore.ai which are real Custom Domains). The zone-level
+      # Worker Route (goldshore.ai/* -> gs-web-prod) had nothing to activate
+      # it, so the hostname didn't resolve at all -- same failure mode as
+      # api.goldshore.ai above. Content points at the real live worker
+      # (gs-web-prod), matching the pattern already used for
+      # admin.goldshore.ai below, rather than the stale gs-web.pages.dev
+      # Pages target from before the Pages-to-Worker migration.
       - name: "goldshore.ai"
         type: CNAME
-        content: "gs-web.pages.dev"
+        content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
       # www.goldshore.ai — DNS auto-provisioned by gs-www-redirect Worker custom_domain; do NOT add a manual CNAME here
       # goldshore.org + www.goldshore.org — owned by goldshore-org Worker (route-based, needs proxied DNS)


### PR DESCRIPTION
## Summary
- `goldshore.ai` (the bare apex) has had **zero DNS records of any kind** — confirmed via the Cloudflare API directly, and independently via a plain `curl` from a GitHub Actions runner returning `Could not resolve host: goldshore.ai`.
- It is *not* a Workers Custom Domain, unlike `preview.goldshore.ai` / `core.goldshore.ai` / `agent.goldshore.ai` / `signals.goldshore.ai`, which are real Custom Domains (confirmed via the account-level Custom Domains API). The zone-level Worker Route (`goldshore.ai/*` → `gs-web-prod`) had nothing to activate it.
- `reconcile-dns.yml` was silently skipping the apex based on a stale comment claiming it was already provisioned as a Custom Domain. It wasn't.
- Same failure mode as the `api.goldshore.ai` outage fixed earlier this session.

## Changes
- `infra/Cloudflare/desired-state.yaml`: apex CNAME target corrected from the stale `gs-web.pages.dev` (pre-migration Pages target) to `gs-web-prod.goldshore.workers.dev`, matching the pattern already used for `admin.goldshore.ai`.
- `.github/workflows/reconcile-dns.yml`: removed `goldshore.ai` from `SKIP_CREATE_HOSTS` so the record actually gets created on the next reconcile run.

## Test plan
- [x] Confirmed via Cloudflare API that the apex has no DNS record and no Custom Domain entry
- [x] Confirmed via a GitHub Actions runner (independent network, no proxy) that `goldshore.ai` fails to resolve
- [ ] Run `Reconcile DNS` workflow with `dry_run=false` to create the record, then verify `https://goldshore.ai/` resolves and serves gs-web
