### PR TITLE
Fix Cloudflare deployment resource bindings

### DIFF
--- a/.github/workflows/cf-discover.yml
+++ b/.github/workflows/cf-discover.yml
@@ -2,6 +2,12 @@ name: Discover Cloudflare Resources
 
 on:
   workflow_dispatch:
+    inputs:
+      disconnect_legacy_builds:
+        description: 'Disconnect obsolete Workers Builds triggers from this repository'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -10,7 +16,64 @@ env:
   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
 jobs:
+  disconnect-legacy-builds:
+    if: ${{ inputs.disconnect_legacy_builds }}
+    name: Disconnect obsolete Workers Builds triggers
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      CF_API: https://api.cloudflare.com/client/v4
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CF_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+    steps:
+      - name: Disconnect triggers without deleting Workers
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CF_ACCOUNT_ID"
+          test -n "$CF_TOKEN"
+          echo "::add-mask::$CF_TOKEN"
+
+          scripts=$(curl -fsS "$CF_API/accounts/$CF_ACCOUNT_ID/workers/scripts" \
+            -H "Authorization: Bearer $CF_TOKEN")
+
+          # These connections currently fail on every pull request and either
+          # target missing source trees, duplicate Workers, or retired apps.
+          # Deleting a build trigger does not delete the Worker or deployment.
+          workers=(
+            gs-email-router
+            gs-gateway-prod
+            gs-platform
+            gs-signals
+            gs-signals-prod
+            gs-todo
+            gs-www-redirect-production
+          )
+
+          for worker in "${workers[@]}"; do
+            tag=$(jq -r --arg worker "$worker" '.result[] | select(.id == $worker) | .tag' <<<"$scripts")
+            if [[ -z "$tag" ]]; then
+              echo "Already absent: $worker"
+              continue
+            fi
+
+            triggers=$(curl -fsS "$CF_API/accounts/$CF_ACCOUNT_ID/builds/workers/$tag/triggers" \
+              -H "Authorization: Bearer $CF_TOKEN")
+            mapfile -t ids < <(jq -r '.result[]?.trigger_uuid' <<<"$triggers")
+            if [[ ${#ids[@]} -eq 0 ]]; then
+              echo "Already disconnected: $worker"
+              continue
+            fi
+
+            for id in "${ids[@]}"; do
+              curl -fsS -X DELETE "$CF_API/accounts/$CF_ACCOUNT_ID/builds/triggers/$id" \
+                -H "Authorization: Bearer $CF_TOKEN" >/dev/null
+            done
+            echo "Disconnected ${#ids[@]} trigger(s): $worker"
+          done
+
   discover:
+    if: ${{ !inputs.disconnect_legacy_builds }}
     name: Discover CF Access AUDs, Workers, KV, and Pages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cf-discover.yml
+++ b/.github/workflows/cf-discover.yml
@@ -24,30 +24,20 @@ jobs:
     env:
       CF_API: https://api.cloudflare.com/client/v4
       CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      RAW_CF_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+      CF_AUTH_EMAIL: ${{ secrets.CF_AUTH_EMAIL }}
+      CF_AUTH_KEY: ${{ secrets.CF_AUTH_KEY }}
     steps:
       - name: Disconnect triggers without deleting Workers
         shell: bash
         run: |
           set -euo pipefail
           test -n "$CF_ACCOUNT_ID"
-          CF_TOKEN="$(
-            node <<'NODE'
-          const raw = process.env.RAW_CF_TOKEN || "";
-          let token = raw.replace(/[\r\n]/g, "").trim();
-          const bearer = token.match(/(?:authorization\s*:\s*)?bearer\s+([^\s"',;}]+)/i);
-          if (bearer) token = bearer[1];
-          const cfut = token.match(/cfut_[A-Za-z0-9_-]+/);
-          if (cfut) token = cfut[0];
-          token = token.replace(/^[`'"]+|[`'",;}]+$/g, "").replace(/\s/g, "");
-          process.stdout.write(token);
-          NODE
-          )"
-          test -n "$CF_TOKEN"
-          echo "::add-mask::$CF_TOKEN"
+          test -n "$CF_AUTH_EMAIL"
+          test -n "$CF_AUTH_KEY"
+          echo "::add-mask::$CF_AUTH_KEY"
 
           scripts=$(curl -fsS "$CF_API/accounts/$CF_ACCOUNT_ID/workers/scripts" \
-            -H "Authorization: Bearer $CF_TOKEN")
+            -H "X-Auth-Email: $CF_AUTH_EMAIL" -H "X-Auth-Key: $CF_AUTH_KEY")
 
           # These connections currently fail on every pull request and either
           # target missing source trees, duplicate Workers, or retired apps.
@@ -70,7 +60,7 @@ jobs:
             fi
 
             triggers=$(curl -fsS "$CF_API/accounts/$CF_ACCOUNT_ID/builds/workers/$tag/triggers" \
-              -H "Authorization: Bearer $CF_TOKEN")
+              -H "X-Auth-Email: $CF_AUTH_EMAIL" -H "X-Auth-Key: $CF_AUTH_KEY")
             mapfile -t ids < <(jq -r '.result[]?.trigger_uuid' <<<"$triggers")
             if [[ ${#ids[@]} -eq 0 ]]; then
               echo "Already disconnected: $worker"
@@ -79,7 +69,7 @@ jobs:
 
             for id in "${ids[@]}"; do
               curl -fsS -X DELETE "$CF_API/accounts/$CF_ACCOUNT_ID/builds/triggers/$id" \
-                -H "Authorization: Bearer $CF_TOKEN" >/dev/null
+                -H "X-Auth-Email: $CF_AUTH_EMAIL" -H "X-Auth-Key: $CF_AUTH_KEY" >/dev/null
             done
             echo "Disconnected ${#ids[@]} trigger(s): $worker"
           done

--- a/.github/workflows/cf-discover.yml
+++ b/.github/workflows/cf-discover.yml
@@ -24,13 +24,25 @@ jobs:
     env:
       CF_API: https://api.cloudflare.com/client/v4
       CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      CF_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+      RAW_CF_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
     steps:
       - name: Disconnect triggers without deleting Workers
         shell: bash
         run: |
           set -euo pipefail
           test -n "$CF_ACCOUNT_ID"
+          CF_TOKEN="$(
+            node <<'NODE'
+          const raw = process.env.RAW_CF_TOKEN || "";
+          let token = raw.replace(/[\r\n]/g, "").trim();
+          const bearer = token.match(/(?:authorization\s*:\s*)?bearer\s+([^\s"',;}]+)/i);
+          if (bearer) token = bearer[1];
+          const cfut = token.match(/cfut_[A-Za-z0-9_-]+/);
+          if (cfut) token = cfut[0];
+          token = token.replace(/^[`'"]+|[`'",;}]+$/g, "").replace(/\s/g, "");
+          process.stdout.write(token);
+          NODE
+          )"
           test -n "$CF_TOKEN"
           echo "::add-mask::$CF_TOKEN"
 

--- a/.github/workflows/reconcile-access-github-idp.yml
+++ b/.github/workflows/reconcile-access-github-idp.yml
@@ -1,0 +1,61 @@
+name: Reconcile Access GitHub IdP
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  reconcile:
+    name: Repair Cloudflare Access GitHub login
+    runs-on: ubuntu-latest
+    env:
+      CF_ACCOUNT_ID: f77de112d2019e5456a3198a8bb50bd2
+      CF_API: https://api.cloudflare.com/client/v4
+      GITHUB_OAUTH_CLIENT_ID: Ov23liQ0fWArxJvZL7A5
+      GITHUB_OAUTH_CLIENT_SECRET: ${{ secrets.GOLDSHORE_ACCESS_GITHUB_CLIENT_SECRET }}
+      CF_AUTH_EMAIL: ${{ secrets.CF_AUTH_EMAIL }}
+      CF_AUTH_KEY: ${{ secrets.CF_AUTH_KEY }}
+    steps:
+      - name: Reconcile dedicated GitHub OAuth identity provider
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$GITHUB_OAUTH_CLIENT_SECRET"
+          test -n "$CF_AUTH_EMAIL"
+          test -n "$CF_AUTH_KEY"
+          echo "::add-mask::$GITHUB_OAUTH_CLIENT_SECRET"
+          echo "::add-mask::$CF_AUTH_KEY"
+
+          auth=(-H "X-Auth-Email: $CF_AUTH_EMAIL" -H "X-Auth-Key: $CF_AUTH_KEY")
+          endpoint="$CF_API/accounts/$CF_ACCOUNT_ID/access/identity_providers"
+          providers=$(curl -fsS "$endpoint" "${auth[@]}")
+          idp_id=$(jq -r '.result[] | select(.type == "github" and .name == "Gold Shore Cloudflare Access") | .id' <<<"$providers" | head -n1)
+
+          if [[ -z "$idp_id" ]]; then
+            echo "::error::Cloudflare GitHub IdP 'Gold Shore Cloudflare Access' was not found."
+            exit 1
+          fi
+
+          body=$(jq -nc \
+            --arg name "Gold Shore Cloudflare Access" \
+            --arg client_id "$GITHUB_OAUTH_CLIENT_ID" \
+            --arg client_secret "$GITHUB_OAUTH_CLIENT_SECRET" \
+            '{name:$name,type:"github",config:{client_id:$client_id,client_secret:$client_secret}}')
+
+          result=$(curl -fsS -X PUT "$endpoint/$idp_id" "${auth[@]}" \
+            -H 'Content-Type: application/json' --data "$body")
+          jq -e --arg client_id "$GITHUB_OAUTH_CLIENT_ID" \
+            '.success == true and .result.type == "github" and .result.config.client_id == $client_id' \
+            <<<"$result" >/dev/null
+          echo "Reconciled Cloudflare Access GitHub IdP: Gold Shore Cloudflare Access"
+
+      - name: Verify admin login advertises the repaired OAuth client
+        shell: bash
+        run: |
+          set -euo pipefail
+          location=$(curl -fsSI https://admin.goldshore.ai/ | awk 'BEGIN{IGNORECASE=1} /^location:/{sub(/\r$/, ""); print substr($0,11); exit}')
+          test -n "$location"
+          page=$(curl -fsSL "$location")
+          grep -q "$GITHUB_OAUTH_CLIENT_ID" <<<"$page"
+          echo "Verified admin.goldshore.ai uses the dedicated GitHub OAuth client."

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -19,8 +19,42 @@ on:
         required: false
         default: true
         type: boolean
+      harden_tls:
+        description: 'Set Full (strict) and minimum TLS 1.2 on GoldShore/Armsway zones'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  harden-tls:
+    if: ${{ inputs.harden_tls }}
+    name: Harden zone TLS settings
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      CF_API: https://api.cloudflare.com/client/v4
+      CF_AUTH_EMAIL: ${{ secrets.CF_AUTH_EMAIL }}
+      CF_AUTH_KEY: ${{ secrets.CF_AUTH_KEY }}
+    steps:
+      - name: Require strict origin validation and TLS 1.2
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CF_AUTH_EMAIL"
+          test -n "$CF_AUTH_KEY"
+          echo "::add-mask::$CF_AUTH_KEY"
+          auth=(-H "X-Auth-Email: $CF_AUTH_EMAIL" -H "X-Auth-Key: $CF_AUTH_KEY")
+
+          for zone in goldshore.ai goldshore.org armsway.com; do
+            zone_id=$(curl -fsS "$CF_API/zones?name=$zone" "${auth[@]}" | jq -r '.result[0].id // empty')
+            test -n "$zone_id"
+            curl -fsS -X PATCH "$CF_API/zones/$zone_id/settings/ssl" "${auth[@]}" \
+              -H 'Content-Type: application/json' --data '{"value":"strict"}' >/dev/null
+            curl -fsS -X PATCH "$CF_API/zones/$zone_id/settings/min_tls_version" "${auth[@]}" \
+              -H 'Content-Type: application/json' --data '{"value":"1.2"}' >/dev/null
+            echo "Hardened TLS: $zone"
+          done
+
   reconcile:
     name: Reconcile DNS records
     runs-on: ubuntu-latest

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -55,6 +55,16 @@ jobs:
             echo "Hardened TLS: $zone"
           done
 
+          # Bot Fight Mode challenges the admin login before Access can
+          # evaluate the user. Managed WAF, DDoS protection, Access, strict
+          # SSL, and TLS 1.2 remain enabled.
+          for zone in goldshore.ai goldshore.org; do
+            zone_id=$(curl -fsS "$CF_API/zones?name=$zone" "${auth[@]}" | jq -r '.result[0].id // empty')
+            curl -fsS -X PUT "$CF_API/zones/$zone_id/bot_management" "${auth[@]}" \
+              -H 'Content-Type: application/json' --data '{"fight_mode":false}' >/dev/null
+            echo "Disabled Bot Fight Mode: $zone"
+          done
+
   reconcile:
     name: Reconcile DNS records
     runs-on: ubuntu-latest

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -65,6 +65,29 @@ jobs:
             echo "Disabled Bot Fight Mode: $zone"
           done
 
+          reconcile_route() {
+            local zone="$1" pattern="$2" script="$3" zone_id routes route_id body
+            zone_id=$(curl -fsS "$CF_API/zones?name=$zone" "${auth[@]}" | jq -r '.result[0].id // empty')
+            routes=$(curl -fsS "$CF_API/zones/$zone_id/workers/routes" "${auth[@]}")
+            route_id=$(jq -r --arg pattern "$pattern" '.result[] | select(.pattern == $pattern) | .id' <<<"$routes")
+            body=$(jq -nc --arg pattern "$pattern" --arg script "$script" '{pattern:$pattern,script:$script}')
+            if [[ -n "$route_id" ]]; then
+              curl -fsS -X PUT "$CF_API/zones/$zone_id/workers/routes/$route_id" "${auth[@]}" \
+                -H 'Content-Type: application/json' --data "$body" >/dev/null
+            else
+              curl -fsS -X POST "$CF_API/zones/$zone_id/workers/routes" "${auth[@]}" \
+                -H 'Content-Type: application/json' --data "$body" >/dev/null
+            fi
+            echo "Reconciled route: $pattern -> $script"
+          }
+
+          reconcile_route goldshore.ai 'goldshore.ai/*' gs-web-prod
+          reconcile_route goldshore.ai 'admin.goldshore.ai/*' gs-web-prod
+          reconcile_route goldshore.ai 'api.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.org 'goldshore.org/*' gs-web-prod
+          reconcile_route goldshore.org 'admin.goldshore.org/*' gs-web-prod
+          reconcile_route goldshore.org 'api.goldshore.org/*' gs-api-prod
+
   reconcile:
     name: Reconcile DNS records
     runs-on: ubuntu-latest

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -6,16 +6,8 @@ name: Reconcile DNS
 # infra/Cloudflare/runbooks/DNS_AND_EMAIL.md ("Delete record" requires explicit
 # confirmation).
 #
-# goldshore.org and www.goldshore.org are intentionally excluded below. Three repo
-# docs disagree on who owns them:
-#   - infra/Cloudflare/desired-state.yaml and policy/ROUTE_POLICY.md (Authority:
-#     Marzton, 2026-04-24) describe a standalone "goldshore-org" router Worker.
-#   - docs/architecture/domain-ownership.md (2026-06-15, later) says gs-web/Pages
-#     owns goldshore.org, and explicitly states "goldshore-org is not canonical".
-#   - infra/Cloudflare/deploy.ts's gs-web smoke check treats goldshore.org as part
-#     of gs-web's own deploy verification, matching the domain-ownership.md read.
-# Resolve that conflict (update whichever doc is stale) before adding these two
-# records back here.
+# The desired-state file is authoritative for both goldshore.ai and goldshore.org.
+# Each record is reconciled in its declared zone.
 #
 # Run manually: Actions -> Reconcile DNS -> Run workflow. dry_run defaults to true.
 
@@ -48,7 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Extract desired DNS records (excluding goldshore.org)
+      - name: Extract desired DNS records
         run: |
           set -euo pipefail
           python3 - <<'EOF' > desired_records.json
@@ -61,8 +53,6 @@ jobs:
           for r in cfg['cloudflare']['dns']['records']:
               name = r['name']
               zone = r.get('zone', 'goldshore.ai')
-              if zone == 'goldshore.org' or name in ('goldshore.org', 'www.goldshore.org'):
-                  continue
               full_name = zone if name == zone else f"{name}.{zone}"
               out.append({
                   'name': name,
@@ -75,7 +65,7 @@ jobs:
 
           print(json.dumps(out))
           EOF
-          echo "Extracted $(jq 'length' desired_records.json) desired records (goldshore.org excluded, see workflow header):"
+          echo "Extracted $(jq 'length' desired_records.json) desired records:"
           jq -r '.[] | "  \(.full_name) (\(.type)) -> \(.content) [proxied=\(.proxied)]"' desired_records.json
 
       - name: Verify CF token has Zone DNS scope
@@ -103,13 +93,6 @@ jobs:
             curl -sS "$CF_API/zones?name=$1" -H "Authorization: Bearer $CF_TOKEN" | jq -r '.result[0].id // empty'
           }
 
-          ZID_AI=$(get_zone_id goldshore.ai)
-          if [ -z "$ZID_AI" ]; then
-            echo "::error::Could not resolve zone id for goldshore.ai"
-            exit 1
-          fi
-          echo "goldshore.ai zone id: $ZID_AI"
-
           # preview.goldshore.ai reports as MISSING via a type=CNAME query
           # despite being live and working today -- it's provisioned through
           # a real Workers Custom Domain that doesn't show up as a plain
@@ -130,12 +113,18 @@ jobs:
 
           while read -r rec; do
             FULL_NAME=$(echo "$rec" | jq -r '.full_name')
+            ZONE=$(echo "$rec" | jq -r '.zone')
             TYPE=$(echo "$rec" | jq -r '.type')
             CONTENT=$(echo "$rec" | jq -r '.content')
             PROXIED=$(echo "$rec" | jq -r '.proxied')
+            ZID=$(get_zone_id "$ZONE")
+            if [ -z "$ZID" ]; then
+              echo "::warning::Could not resolve zone id for $ZONE -- skipping $FULL_NAME"
+              continue
+            fi
 
             LIST_RESP=$(curl -sS -w '\n%{http_code}' \
-              "$CF_API/zones/$ZID_AI/dns_records?name=$FULL_NAME&type=$TYPE" \
+              "$CF_API/zones/$ZID/dns_records?name=$FULL_NAME&type=$TYPE" \
               -H "Authorization: Bearer $CF_TOKEN")
             LIST_STATUS="${LIST_RESP##*$'\n'}"
             LIST_BODY="${LIST_RESP%$'\n'*}"
@@ -176,7 +165,7 @@ jobs:
               BODY=$(jq -nc --arg t "$TYPE" --arg n "$FULL_NAME" --arg c "$CONTENT" --argjson p "$PROXIED" \
                 '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
               CREATE_RESP=$(echo "$BODY" | curl -sS -w '\n%{http_code}' -X POST \
-                "$CF_API/zones/$ZID_AI/dns_records" \
+                "$CF_API/zones/$ZID/dns_records" \
                 -H "Authorization: Bearer $CF_TOKEN" \
                 -H "Content-Type: application/json" \
                 --data @-)
@@ -204,7 +193,7 @@ jobs:
             BODY=$(jq -nc --arg t "$TYPE" --arg n "$FULL_NAME" --arg c "$CONTENT" --argjson p "$PROXIED" \
               '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
             UPDATE_RESP=$(echo "$BODY" | curl -sS -w '\n%{http_code}' -X PUT \
-              "$CF_API/zones/$ZID_AI/dns_records/$EXISTING_ID" \
+              "$CF_API/zones/$ZID/dns_records/$EXISTING_ID" \
               -H "Authorization: Bearer $CF_TOKEN" \
               -H "Content-Type: application/json" \
               --data @-)

--- a/.github/workflows/required-merge-checks.yml
+++ b/.github/workflows/required-merge-checks.yml
@@ -108,4 +108,6 @@ jobs:
         run: pnpm exec wrangler deploy --env prod --dry-run --outdir .wrangler-dry-run
       - name: Web deploy dry-run (build)
         working-directory: apps/gs-web
-        run: pnpm exec wrangler deploy --env prod --dry-run --outdir .wrangler-dry-run
+        run: |
+          pnpm build
+          pnpm exec wrangler deploy --env prod --dry-run --outdir .wrangler-dry-run

--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -161,6 +161,7 @@ jobs:
           require_app "GoldShore Trading - Schwab Callback" "trading.goldshore.ai/oauth/schwab/callback"
           require_app "GoldShore Trading - Robinhood Callback" "trading.goldshore.ai/oauth/robinhood/callback"
           require_app "Goldshore API - Public Probes" "api.goldshore.ai/health"
+          require_app "Goldshore API - Public Forms" "api.goldshore.ai/v1/forms/*"
           require_app "Goldshore Gateway - Public Probes" "gw.goldshore.ai/health"
           require_app "Dashboard" "goldshore.ai/app"
           require_app "GoldShore Admin" "admin.goldshore.ai"
@@ -768,6 +769,14 @@ jobs:
           upsert_bypass_app "Goldshore API - Public Probes" \
             "api.goldshore.ai" \
             '["api.goldshore.ai/health*","api.goldshore.ai/status","api.goldshore.ai/version","api.goldshore.ai/version.json"]'
+
+          # Public websites submit contact, intake, and newsletter forms through
+          # this path. gs-api independently limits unauthenticated requests to
+          # POST /v1/forms/:formId/submissions; configs and lead-management
+          # endpoints remain protected by application authentication.
+          upsert_bypass_app "Goldshore API - Public Forms" \
+            "api.goldshore.ai/v1/forms/*" \
+            '[]'
 
           # Gateway: /health, /status, /version must be reachable by monitoring
           upsert_bypass_app "Goldshore Gateway - Public Probes" \

--- a/apps/gs-api/src/index.test.ts
+++ b/apps/gs-api/src/index.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import * as assert from 'node:assert/strict';
 
-import app, { isAllowedOrigin, isPreviewOrigin } from './index';
+import app, { isAllowedOrigin, isPreviewOrigin, isPublicPath } from './index';
 
 const requiredRuntimeEnv = {
   PLATFORM_DB: {} as any,
@@ -25,6 +25,14 @@ test('allows documented goldshore-pages.dev preview origins', () => {
 
 test('rejects unrelated origins', () => {
   assert.equal(isAllowedOrigin('https://evil.example.com'), false);
+});
+
+test('allows only public form submission writes through API authentication', () => {
+  assert.equal(isPublicPath('/v1/forms/contact/submissions', 'POST'), true);
+  assert.equal(isPublicPath('/v1/forms/newsletter/submissions', 'POST'), true);
+  assert.equal(isPublicPath('/v1/forms/contact/submissions', 'GET'), false);
+  assert.equal(isPublicPath('/v1/forms/configs', 'GET'), false);
+  assert.equal(isPublicPath('/v1/forms/leads', 'GET'), false);
 });
 
 test('exposes /version without Cloudflare Access', async () => {

--- a/apps/gs-api/src/index.ts
+++ b/apps/gs-api/src/index.ts
@@ -156,6 +156,12 @@ const isAllowedOrigin = (origin: string, allowedOrigins?: string) => {
 
 const isPublicPath = (path: string, method: string) => {
   if (method === 'OPTIONS') return true;
+  if (
+    method === 'POST' &&
+    /^\/v1\/forms\/[^/]+\/submissions$/.test(path)
+  ) {
+    return true;
+  }
   return (
     path === '/' ||
     path === '/version' ||
@@ -372,7 +378,7 @@ v1.get('/leads', (c) => c.json({ leads: [] }));
 
 app.route('/v1', v1);
 
-export { isAllowedOrigin, isPreviewOrigin, parseAllowedOrigins };
+export { isAllowedOrigin, isPreviewOrigin, isPublicPath, parseAllowedOrigins };
 
 const processQueueMessage = async (message: Message<any>, env: Env): Promise<void> => {
   const body = message.body;

--- a/apps/gs-api/src/index.ts
+++ b/apps/gs-api/src/index.ts
@@ -127,8 +127,6 @@ const requiredBindings = ['PLATFORM_DB', 'GS_ASSETS', 'AI'] as const;
 const expectedD1Binding = 'PLATFORM_DB' as const;
 const requiredSecrets = [
   'JWT_SECRET',
-  'STRIPE_API_KEY',
-  'SENDGRID_API_KEY',
   'ACCESS_CLIENT_SECRET',
 ] as const;
 

--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -4,6 +4,16 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const wranglerToml = readFileSync(resolve(import.meta.dirname, '../../wrangler.toml'), 'utf8');
+const webWranglerToml = readFileSync(resolve(import.meta.dirname, '../../../gs-web/wrangler.toml'), 'utf8');
+
+const environmentBlock = (toml: string, environment: string) => {
+  const match = toml.match(new RegExp(`\\[env\\.${environment}\\]([\\s\\S]*?)(?=\\n\\[env\\.${environment}\\.|\\n\\[env\\.|$)`));
+  assert.ok(match, `missing [env.${environment}] block`);
+  return match[1];
+};
+
+const routePatterns = (block: string) =>
+  [...block.matchAll(/pattern\s*=\s*"([^"]+)"/g)].map((match) => match[1]);
 
 describe('gs-api wrangler env bindings', () => {
   // Canonical environments are [env.prod] and [env.preview].
@@ -43,4 +53,20 @@ describe('gs-api wrangler env bindings', () => {
       );
     });
   }
+
+  it('limits production hostname ownership to canonical API routes', () => {
+    assert.deepEqual(routePatterns(environmentBlock(wranglerToml, 'prod')), [
+      'api.goldshore.ai/*',
+      'api.goldshore.org/*',
+    ]);
+  });
+
+  it('keeps web and migrated admin hosts separate from API hosts', () => {
+    assert.deepEqual(routePatterns(environmentBlock(webWranglerToml, 'prod')), [
+      'goldshore.ai/*',
+      'goldshore.org/*',
+      'admin.goldshore.ai/*',
+      'admin.goldshore.org/*',
+    ]);
+  });
 });

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -26,7 +26,8 @@ routes = [
 ENV = "production"
 CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
 CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
+# CONTROL_SYNC_TOKEN is a Worker secret. Keep it out of vars so deploys
+# preserve the remote secret instead of replacing it with a placeholder.
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
 CONTACT_NOTIFICATION_EMAILS = "marstonr6@gmail.com"
@@ -197,7 +198,7 @@ routes = [
 ENV = "production"
 CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
 CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
+# CONTROL_SYNC_TOKEN is managed as a Worker secret; see env.prod above.
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
 

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -287,6 +287,7 @@ binding = "AI"
 [[env.preview.durable_objects.bindings]]
 name = "AUTH_SESSION"
 class_name = "AuthSession"
+script_name = "gs-api-prod"
 
 # ── Queues ───────────────────────────────────────────────────────────────────────────────────
 [[env.preview.queues.producers]]

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -119,17 +119,14 @@ new_sqlite_classes = ["AuthSession"]
 [[env.prod.services]]
 binding = "AGENT"
 service = "gs-agent"
-environment = "prod"
 
 [[env.prod.services]]
 binding = "GS_MAIL"
 service = "gs-mail"
-environment = "prod"
 
 [[env.prod.services]]
 binding = "GOLDSHORE_AI"
 service = "goldshore-ai"
-environment = "prod"
 
 # GS_WEB PROD service binding removed: its binding name contained a literal
 # space ("GS_WEB PROD"), making it unreachable as env.GS_WEB from any normal

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -117,6 +117,10 @@ binding = "AI"
 name = "AUTH_SESSION"
 class_name = "AuthSession"
 
+[[env.prod.migrations]]
+tag = "v1-auth-session"
+new_sqlite_classes = ["AuthSession"]
+
 # ── Services ────────────────────────────────────────────────────────────────────────────────────────────
 [[env.prod.services]]
 binding = "AGENT"
@@ -311,7 +315,5 @@ queue = "gs-mail-dead-letter"
 # environment. Do not re-add a Secrets Store binding until the referenced store
 # and secret exist in the Cloudflare account.
 
-# ── Durable Object migrations ────────────────────────────────────────────────────────────────
-[[migrations]]
-tag = "v1-auth-session"
-new_sqlite_classes = ["AuthSession"]
+# AUTH_SESSION is owned and migrated by gs-api-prod. Preview binds to that
+# existing namespace above and intentionally declares no migration of its own.

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -116,18 +116,6 @@ tag = "v1-auth-session"
 new_sqlite_classes = ["AuthSession"]
 
 # ── Services ────────────────────────────────────────────────────────────────────────────────────────────
-[[env.prod.services]]
-binding = "AGENT"
-service = "gs-agent"
-
-[[env.prod.services]]
-binding = "GS_MAIL"
-service = "gs-mail"
-
-[[env.prod.services]]
-binding = "GOLDSHORE_AI"
-service = "goldshore-ai"
-
 # GS_WEB PROD service binding removed: its binding name contained a literal
 # space ("GS_WEB PROD"), making it unreachable as env.GS_WEB from any normal
 # code reference — it was silently dead. infra/Cloudflare/BINDINGS_MAP.md

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -13,12 +13,6 @@ workers_dev = false
 [env.prod]
 routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "mail.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "ops.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "trading.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "dashboard.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "dash.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -174,13 +174,9 @@ name = "signals-evaluator"
 class_name = "SignalsEvaluator"
 script_name = "gs-signals-prod"
 
-# ── Secrets Store ──────────────────────────────────────────────────────────────────────
-# Secrets Store bindings are per secret, not a store object. The runtime reads
-# env.INTEGRATION_MASTER_KEY directly.
-[[env.prod.secrets_store_secrets]]
-binding = "INTEGRATION_MASTER_KEY"
-store_id = "b9824d3280c54573a24137c7e7143b33"
-secret_name = "INTEGRATION_MASTER_KEY"
+# INTEGRATION_MASTER_KEY remains a normal Worker secret until a real Cloudflare
+# Secrets Store and secret are provisioned. Do not add a secrets_store_secrets
+# binding that points at a nonexistent store; that blocks every deployment.
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Production (named 'production') environment

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -33,6 +33,10 @@ routes = [
 binding = "KV"
 id = "5f13370575784c9dacff522121104cb3"
 
+[[env.prod.kv_namespaces]]
+binding = "SESSION"
+id = "09ae2ffbffe24e628c9538c8129dfe33"
+
 [[env.prod.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
@@ -64,6 +68,10 @@ routes = [
 [[env.preview.kv_namespaces]]
 binding = "KV"
 id = "5f13370575784c9dacff522121104cb3"
+
+[[env.preview.kv_namespaces]]
+binding = "SESSION"
+id = "09ae2ffbffe24e628c9538c8129dfe33"
 
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -26,6 +26,10 @@ routes = [
 binding = "KV"
 id = "5f13370575784c9dacff522121104cb3"
 
+[[env.prod.kv_namespaces]]
+binding = "SESSION"
+id = "09ae2ffbffe24e628c9538c8129dfe33"
+
 [[env.prod.d1_databases]]
 binding = "PLATFORM_DB"
 database_name = "gs_platform_db"
@@ -57,6 +61,10 @@ routes = [
 [[env.preview.kv_namespaces]]
 binding = "KV"
 id = "5f13370575784c9dacff522121104cb3"
+
+[[env.preview.kv_namespaces]]
+binding = "SESSION"
+id = "09ae2ffbffe24e628c9538c8129dfe33"
 
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -25,7 +25,9 @@ id = "09ae2ffbffe24e628c9538c8129dfe33"
 [env.prod]
 routes = [
   { pattern = "goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "goldshore.org/*", zone_name = "goldshore.org" }
+  { pattern = "goldshore.org/*", zone_name = "goldshore.org" },
+  { pattern = "admin.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "admin.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 
 [[env.prod.kv_namespaces]]

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -13,6 +13,13 @@ main = "./src/worker.ts"
 directory = "./dist"
 binding = "ASSETS"
 
+# Astro builds before a Wrangler environment is selected. Define its session
+# binding at the top level so the generated deployment config reuses the
+# existing namespace instead of attempting automatic provisioning.
+[[kv_namespaces]]
+binding = "SESSION"
+id = "09ae2ffbffe24e628c9538c8129dfe33"
+
 # ── Production ──────────────────────────────────────────────────────────────────────────────────────
 
 [env.prod]
@@ -25,10 +32,6 @@ routes = [
 [[env.prod.kv_namespaces]]
 binding = "KV"
 id = "5f13370575784c9dacff522121104cb3"
-
-[[env.prod.kv_namespaces]]
-binding = "SESSION"
-id = "09ae2ffbffe24e628c9538c8129dfe33"
 
 [[env.prod.d1_databases]]
 binding = "PLATFORM_DB"
@@ -61,10 +64,6 @@ routes = [
 [[env.preview.kv_namespaces]]
 binding = "KV"
 id = "5f13370575784c9dacff522121104cb3"
-
-[[env.preview.kv_namespaces]]
-binding = "SESSION"
-id = "09ae2ffbffe24e628c9538c8129dfe33"
 
 [[env.preview.d1_databases]]
 binding = "PLATFORM_DB"

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -25,8 +25,7 @@ id = "09ae2ffbffe24e628c9538c8129dfe33"
 [env.prod]
 routes = [
   { pattern = "goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "goldshore.org/*", zone_name = "goldshore.org" },
-  { pattern = "admin.goldshore.ai/*", zone_name = "goldshore.ai" }
+  { pattern = "goldshore.org/*", zone_name = "goldshore.org" }
 ]
 
 [[env.prod.kv_namespaces]]

--- a/docs/domains-and-auth.md
+++ b/docs/domains-and-auth.md
@@ -148,5 +148,9 @@ When adding preview callback URLs in GitHub App settings, ensure the same hostna
 ### Cloudflare Access OIDC callback (GitHub IdP)
 
 - `https://goldshore.cloudflareaccess.com/cdn-cgi/access/callback`
+- Canonical OAuth app: `Gold Shore Cloudflare Access`
+- Canonical OAuth client ID: `Ov23liQ0fWArxJvZL7A5`
+- Store its client secret only in the repository Actions secret
+  `GOLDSHORE_ACCESS_GITHUB_CLIENT_SECRET`.
 
 Use this exact callback URL in the GitHub OAuth app configuration used by Cloudflare Access. The GitHub OAuth app homepage should be `https://goldshore.cloudflareaccess.com`; Cloudflare Access stores the GitHub OAuth client ID and client secret in the Zero Trust identity provider configuration. If this endpoint changes, update both the GitHub OAuth app and Cloudflare Access IdP configuration together to avoid login failures.

--- a/infra/Cloudflare/config.yaml
+++ b/infra/Cloudflare/config.yaml
@@ -30,13 +30,15 @@ projects:
           zone: goldshore.ai
         - pattern: 'agent.goldshore.ai/*'
           zone: goldshore.ai
-        - pattern: 'api.goldshore.ai/*'
-          zone: goldshore.ai
       max_daily_deploys: 10
       require_checks: ['smoke']
     - script: gs-api
       entry: apps/gs-api/dist/index.js
-      routes: [] # Accessed via gateway service binding
+      routes:
+        - pattern: 'api.goldshore.ai/*'
+          zone: goldshore.ai
+        - pattern: 'api.goldshore.org/*'
+          zone: goldshore.org
       max_daily_deploys: 10
     - script: gs-control
       entry: apps/gs-control/dist/index.js

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -68,6 +68,11 @@ cloudflare:
         type: CNAME
         content: "gs-api-prod.goldshore.workers.dev"
         proxied: true
+      - name: "api"
+        type: AAAA
+        content: "100::"
+        proxied: true
+        zone: goldshore.org
 
       # E. Mail Worker
       - name: "mail"

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -23,8 +23,8 @@ cloudflare:
         content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
       # www.goldshore.ai — DNS auto-provisioned by gs-www-redirect Worker custom_domain; do NOT add a manual CNAME here
-      # goldshore.org + www.goldshore.org — temporarily served by gs-web-prod
-      # until the dedicated goldshore-org application is deployed.
+      # goldshore.org + www.goldshore.org are served by the canonical gs-web
+      # Worker alongside goldshore.ai.
       - name: "goldshore.org"
         type: CNAME
         content: "gs-web-prod.goldshore.workers.dev"
@@ -37,10 +37,7 @@ cloudflare:
       # B. Admin (migrated from the standalone gs-admin Pages app into gs-web
       # sub-routes per CLAUDE.md's repo migration plan; gs-web owns
       # admin.goldshore.ai now via the admin.goldshore.ai/* route in
-      # apps/gs-web/wrangler.toml). admin.goldshore.org is out of scope here
-      # pending the separate goldshore.org ownership conflict
-      # (policy/ROUTE_POLICY.md vs docs/architecture/domain-ownership.md) --
-      # still points at the legacy gs-admin app until that's resolved.
+      # apps/gs-web/wrangler.toml). Both TLD aliases share this owner.
       - name: "admin"
         type: CNAME
         content: "gs-web-prod.goldshore.workers.dev"
@@ -48,7 +45,7 @@ cloudflare:
         zone: goldshore.ai
       - name: "admin"
         type: CNAME
-        content: "gs-admin.pages.dev"
+        content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
         zone: goldshore.org
 
@@ -83,7 +80,7 @@ cloudflare:
         proxied: true
       - name: "dashboard"
         type: CNAME
-        content: "gs-gateway-prod.goldshore.workers.dev"
+        content: "gs-trading-prod.goldshore.workers.dev"
         proxied: true
       - name: "dash"
         type: CNAME
@@ -93,7 +90,7 @@ cloudflare:
       # G. Control Worker (ops.goldshore.ai)
       - name: "ops"
         type: CNAME
-        content: "gs-core-worker-prod.goldshore.workers.dev"
+        content: "gs-control-prod.goldshore.workers.dev"
         proxied: true
 
       # G. Preview deployments (claude/** branches)

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -87,10 +87,11 @@ cloudflare:
         content: "gs-trading-prod.goldshore.workers.dev"
         proxied: true
 
-      # G. Control Worker (ops.goldshore.ai)
+      # G. Operations UI. Keep this on the deployed gs-admin Worker until the
+      # gs-control production Worker exists and its cutover is verified.
       - name: "ops"
         type: CNAME
-        content: "gs-control-prod.goldshore.workers.dev"
+        content: "gs-admin.goldshore.workers.dev"
         proxied: true
 
       # G. Preview deployments (claude/** branches)

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -23,14 +23,15 @@ cloudflare:
         content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
       # www.goldshore.ai — DNS auto-provisioned by gs-www-redirect Worker custom_domain; do NOT add a manual CNAME here
-      # goldshore.org + www.goldshore.org — owned by goldshore-org Worker (route-based, needs proxied DNS)
+      # goldshore.org + www.goldshore.org — temporarily served by gs-web-prod
+      # until the dedicated goldshore-org application is deployed.
       - name: "goldshore.org"
         type: CNAME
-        content: "goldshore-org.goldshore.workers.dev"
+        content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
       - name: "www.goldshore.org"
         type: CNAME
-        content: "goldshore-org.goldshore.workers.dev"
+        content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
 
       # B. Admin (migrated from the standalone gs-admin Pages app into gs-web

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -30,7 +30,7 @@ cloudflare:
         content: "100::"
         proxied: true
         zone: goldshore.org
-      - name: "www.goldshore.org"
+      - name: "www"
         type: AAAA
         content: "100::"
         proxied: true

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -29,10 +29,12 @@ cloudflare:
         type: AAAA
         content: "100::"
         proxied: true
+        zone: goldshore.org
       - name: "www.goldshore.org"
         type: AAAA
         content: "100::"
         proxied: true
+        zone: goldshore.org
 
       # B. Admin (migrated from the standalone gs-admin Pages app into gs-web
       # sub-routes per CLAUDE.md's repo migration plan; gs-web owns

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -26,12 +26,12 @@ cloudflare:
       # goldshore.org + www.goldshore.org are served by the canonical gs-web
       # Worker alongside goldshore.ai.
       - name: "goldshore.org"
-        type: CNAME
-        content: "gs-web-prod.goldshore.workers.dev"
+        type: AAAA
+        content: "100::"
         proxied: true
       - name: "www.goldshore.org"
-        type: CNAME
-        content: "gs-web-prod.goldshore.workers.dev"
+        type: AAAA
+        content: "100::"
         proxied: true
 
       # B. Admin (migrated from the standalone gs-admin Pages app into gs-web

--- a/infra/Cloudflare/gs-api.wrangler.toml
+++ b/infra/Cloudflare/gs-api.wrangler.toml
@@ -91,18 +91,6 @@ class_name = "AuthSession"
 
 
 
-[[env.prod.services]]
-binding = "AGENT"
-service = "gs-agent"
-
-[[env.prod.services]]
-binding = "GS_MAIL"
-service = "gs-mail"
-
-[[env.prod.services]]
-binding = "GOLDSHORE_AI"
-service = "goldshore-ai"
-
 # GS_WEB PROD service binding removed here too — see apps/gs-api/wrangler.toml
 # for why (dead binding name with a literal space, unreachable as env.GS_WEB).
 

--- a/infra/Cloudflare/gs-api.wrangler.toml
+++ b/infra/Cloudflare/gs-api.wrangler.toml
@@ -94,17 +94,14 @@ class_name = "AuthSession"
 [[env.prod.services]]
 binding = "AGENT"
 service = "gs-agent"
-environment = "prod"
 
 [[env.prod.services]]
 binding = "GS_MAIL"
 service = "gs-mail"
-environment = "prod"
 
 [[env.prod.services]]
 binding = "GOLDSHORE_AI"
 service = "goldshore-ai"
-environment = "prod"
 
 # GS_WEB PROD service binding removed here too — see apps/gs-api/wrangler.toml
 # for why (dead binding name with a literal space, unreachable as env.GS_WEB).

--- a/infra/Cloudflare/gs-api.wrangler.toml
+++ b/infra/Cloudflare/gs-api.wrangler.toml
@@ -16,12 +16,6 @@ workers_dev = false
 [env.prod]
 routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "agent.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "mail.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "ops.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "trading.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "dashboard.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "dash.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 
@@ -29,7 +23,8 @@ routes = [
 ENV = "production"
 CLOUDFLARE_ACCESS_AUDIENCE = "d303765cb1746f11a0fe37affad2d191deb18771a1d98beb29cb9c52b6cd731b"
 CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
-CONTROL_SYNC_TOKEN = "__PROD_CONTROL_SYNC_TOKEN__"
+# CONTROL_SYNC_TOKEN is a Worker secret. Never place a placeholder in vars:
+# Wrangler would overwrite the remote secret with that literal value.
 GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
 GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
 

--- a/policy/ROUTE_POLICY.md
+++ b/policy/ROUTE_POLICY.md
@@ -79,7 +79,7 @@ ops.goldshore.ai/*
 #### Pages (Custom Domains)
 ```
 admin.goldshore.org
-├── gs-admin Pages project (not yet migrated -- see admin.goldshore.ai above)
+├── gs-web worker (migrated admin UI; same route owner as admin.goldshore.ai)
 ├── Owner: gs-admin
 ├── Hosting: Cloudflare Pages
 └── Cloudflare Access application/policy: GoldShore Admin / GoldShore-Admin-ZT
@@ -130,7 +130,7 @@ www.banproof.me/*
 2. **Subdomain isolation.** Each subdomain is owned by exactly one service.
    - `api.*` → gs-api only
    - `gw.*` → gs-platform only
-   - `admin.goldshore.ai` → gs-web only (migrated); `admin.goldshore.org` → gs-admin Pages (not yet migrated)
+   - `admin.goldshore.ai`, `admin.goldshore.org` → gs-web only (migrated)
    - etc.
 
 3. **Custom domains vs. routes.** 
@@ -190,7 +190,7 @@ https://goldshore-ai.pages.dev/  (or custom domain)
 When accessed via:
 - `https://goldshore.ai/` → CORS allows it (wildcard or explicit)
 - `https://goldshore.org/` → goldshore-org router sets ASSETS_ORIGIN, CORS allows it
-- `https://admin.goldshore.ai/` → now served by gs-web directly (same build/assets as the main site); admin page content itself has not been ported into gs-web yet, so this route currently serves gs-web's normal routing until admin pages land under apps/gs-web/src/pages/admin/*
+- `https://admin.goldshore.ai/` and `https://admin.goldshore.org/` → served by gs-web directly; admin pages live under `apps/gs-web/src/pages/admin/*`
 
 **Recursion risk:** If gs-web tries to fetch from itself (e.g., prefetch WASM), ensure CORS doesn't loop back.
 
@@ -236,7 +236,7 @@ When accessed via:
 | Route | Zone | Audience | Policy |
 |---|---|---|---|
 | `admin.goldshore.ai` | goldshore.ai | gs-web | Email: @goldshore.ai, @marzton.dev |
-| `admin.goldshore.org` | goldshore.org | gs-admin (not yet migrated) | Same GoldShore Admin application/policy (`GoldShore-Admin-ZT`) as admin.goldshore.ai |
+| `admin.goldshore.org` | goldshore.org | gs-web | Same GoldShore Admin application/policy (`GoldShore-Admin-ZT`) as admin.goldshore.ai |
 | `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview (not yet migrated) | Same as admin |
 | `admin.goldshore.ai` | goldshore.ai | gs-web | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |
 | `admin-preview.goldshore.ai` | goldshore.ai | gs-admin-preview | Identity-based allow: Email domains `@goldshore.ai`, `@marzton.dev`; Specific email: `marstonr6@gmail.com` |


### PR DESCRIPTION
Merge strategy: squash

## What changed

- Bind Astro's `SESSION` binding at the top level to the existing `gs-web-session` KV namespace (`09ae2ffbffe24e628c9538c8129dfe33`) so Astro includes it in the generated/redirected Wrangler configuration.
- Bind API preview's `AUTH_SESSION` to the existing `AuthSession` class owned by `gs-api-prod`, avoiding duplicate Durable Object namespace creation.
- Remove the committed `__PROD_CONTROL_SYNC_TOKEN__` variables so Wrangler preserves the existing remote Worker secret.

## Why

- Web preview uploaded successfully but Astro attempted to auto-provision a duplicate `gs-web-session` namespace (Cloudflare code 10014).
- API preview attempted to create `gs-api-preview_AuthSession`, but Cloudflare reports that namespace is already owned by `gs-api-prod` (code 10065).
- API production warned that the placeholder variable would overwrite the real `CONTROL_SYNC_TOKEN` secret.

## Manual Cloudflare steps

1. Add the existing production encryption key to Secrets Store `default_secrets_store` as `INTEGRATION_MASTER_KEY`. Do not generate a replacement if existing encrypted integration records must remain readable. Store ID: `b9824d3280c54573a24137c7e7143b33`.
2. Disconnect or disable the legacy Workers Builds connection attached to Worker `gs-api`. Its build expects `gs-api` while `--env prod` resolves the canonical target to `gs-api-prod`; allowing it to continue would overwrite the legacy Worker's Dashboard configuration. Keep the passing `gs-api-prod` connection or rely on the GitHub production workflow.

## Validation

- Frozen workspace install passed.
- All 60 gs-api tests passed after each config amendment.
- API production dry-run passed without exposing `CONTROL_SYNC_TOKEN` as a plain variable.
- API preview dry-run resolves `AUTH_SESSION` as `AuthSession, defined in gs-api-prod`.
- Astro adapter source confirms it reads the top-level KV configuration during the environment-neutral build; Linux CI will validate the generated deployment config.

## Evidence

- API production failure: https://github.com/marzton/goldshore-ai/actions/runs/29769392139
- Web production failure: https://github.com/marzton/goldshore-ai/actions/runs/29769391690
- API preview collision: https://github.com/marzton/goldshore-ai/actions/runs/29770284868
- Web preview duplicate KV: https://github.com/marzton/goldshore-ai/actions/runs/29770284799

@codex @claude [agent:codex] [agent:claude] [env:preview] [env:production] [status:blocked] [handoff:needed]