### PR TITLE
fix: remove legacy GitHub IdP from admin login

### DIFF
--- a/.github/workflows/reconcile-access-github-idp.yml
+++ b/.github/workflows/reconcile-access-github-idp.yml
@@ -50,6 +50,43 @@ jobs:
             <<<"$result" >/dev/null
           echo "Reconciled Cloudflare Access GitHub IdP: Gold Shore Cloudflare Access"
 
+      - name: Restrict Admin login to canonical identity providers
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::add-mask::$CF_AUTH_KEY"
+          auth=(-H "X-Auth-Email: $CF_AUTH_EMAIL" -H "X-Auth-Key: $CF_AUTH_KEY")
+          idp_endpoint="$CF_API/accounts/$CF_ACCOUNT_ID/access/identity_providers"
+          app_endpoint="$CF_API/accounts/$CF_ACCOUNT_ID/access/apps"
+          providers=$(curl -fsS "$idp_endpoint" "${auth[@]}")
+
+          canonical_github=$(jq -r '.result[] | select(.type == "github" and .name == "Gold Shore Cloudflare Access") | .id' <<<"$providers" | head -n1)
+          google=$(jq -r '.result[] | select(.type == "google") | .id' <<<"$providers" | head -n1)
+          otp=$(jq -r '.result[] | select(.type == "onetimepin") | .id' <<<"$providers" | head -n1)
+          test -n "$canonical_github"
+
+          allowed=$(jq -nc --arg github "$canonical_github" --arg google "$google" --arg otp "$otp" \
+            '[$github,$google,$otp] | map(select(length > 0)) | unique')
+          apps=$(curl -fsS "$app_endpoint" "${auth[@]}")
+          app_id=$(jq -r '.result[] | select(.name == "GoldShore Admin" and .domain == "admin.goldshore.ai") | .id' <<<"$apps" | head -n1)
+          test -n "$app_id"
+
+          payload=$(jq -nc --argjson allowed "$allowed" '{
+            name:"GoldShore Admin",
+            type:"self_hosted",
+            domain:"admin.goldshore.ai",
+            self_hosted_domains:["admin.goldshore.ai","admin.goldshore.org","admin-preview.goldshore.ai","admin.gs-admin.pages.dev"],
+            session_duration:"24h",
+            http_only_cookie_attribute:true,
+            auto_redirect_to_identity:false,
+            allowed_idps:$allowed
+          }')
+          result=$(curl -fsS -X PUT "$app_endpoint/$app_id" "${auth[@]}" \
+            -H 'Content-Type: application/json' --data "$payload")
+          jq -e --arg legacy "b2795891-ffe8-4e7c-84b0-9221f0f1497d" \
+            '.success == true and ((.result.allowed_idps // []) | index($legacy) | not)' <<<"$result" >/dev/null
+          echo "Restricted GoldShore Admin to canonical GitHub, Google, and one-time PIN providers."
+
       - name: Verify admin login advertises the repaired OAuth client
         shell: bash
         run: |
@@ -58,4 +95,5 @@ jobs:
           test -n "$location"
           page=$(curl -fsSL "$location")
           grep -q "$GITHUB_OAUTH_CLIENT_ID" <<<"$page"
+          ! grep -q "Iv23limmOL0SIIk3cZcl" <<<"$page"
           echo "Verified admin.goldshore.ai uses the dedicated GitHub OAuth client."


### PR DESCRIPTION
Restricts the GoldShore Admin Access application to the canonical GitHub OAuth provider, Google, and one-time PIN. Excludes the broken legacy GitHub IdP (b2795891 / Iv23limm) and verifies it is absent from the live login page.