### PR TITLE
Add regression coverage for Cloudflare deployment bindings

### DIFF
--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -43,4 +43,9 @@ describe('gs-api wrangler env bindings', () => {
       );
     });
   }
+
+  it('keeps CONTROL_SYNC_TOKEN out of plain-text environment variables', () => {
+    assert.doesNotMatch(wranglerToml, /^CONTROL_SYNC_TOKEN\s*=/m);
+    assert.doesNotMatch(wranglerToml, /__PROD_CONTROL_SYNC_TOKEN__/);
+  });
 });

--- a/apps/gs-web/tests/unit/runtime-config-binding.test.ts
+++ b/apps/gs-web/tests/unit/runtime-config-binding.test.ts
@@ -10,6 +10,7 @@ const webWrangler = readFileSync(
   repoRelative('../../../../infra/Cloudflare/gs-web.wrangler.toml'),
   'utf8',
 );
+const deployedWebWrangler = readFileSync(repoRelative('../../wrangler.toml'), 'utf8');
 
 const webReadme = readFileSync(repoRelative('../../README.md'), 'utf8');
 
@@ -25,4 +26,17 @@ test('gs-web README documents indirect runtime configuration until a concrete co
       'Do not add a `GS_CONFIG` binding to the web Pages project unless a concrete `apps/gs-web` runtime consumer needs live request-time reads.',
     ),
   );
+});
+
+test('gs-web deploy environments reuse the provisioned session namespace', () => {
+  const sessionNamespaceId = '09ae2ffbffe24e628c9538c8129dfe33';
+
+  for (const envName of ['prod', 'preview']) {
+    assert.match(
+      deployedWebWrangler,
+      new RegExp(
+        `\\[\\[env\\.${envName}\\.kv_namespaces\\]\\][\\s\\S]*?binding = "SESSION"[\\s\\S]*?id = "${sessionNamespaceId}"`,
+      ),
+    );
+  }
 });


### PR DESCRIPTION
Merge strategy: squash

### Motivation
- Prevent regressions that cause Wrangler to attempt creating duplicate KV namespaces or to overwrite managed Worker secrets during deploys.
- Ensure the web preview/production builds reuse the provisioned `gs-web-session` KV and that the API config does not expose `CONTROL_SYNC_TOKEN` as a committed var.

### Description
- Add a gs-web unit test at `apps/gs-web/tests/unit/runtime-config-binding.test.ts` that asserts both `prod` and `preview` environments bind `SESSION` to the existing `gs-web-session` KV namespace (`09ae2ffbffe24e628c9538c8129dfe33`).
- Add an API config assertion at `apps/gs-api/src/routes/wrangler-config.test.ts` that ensures `CONTROL_SYNC_TOKEN` is not present as a plain-text Wrangler variable or the `__PROD_CONTROL_SYNC_TOKEN__` placeholder.
- These changes only add test coverage and do not modify runtime bindings or secret material, and are intended to land on top of the deployment-fix changes.

### Testing
- Ran `pnpm --filter @goldshore/gs-web test:unit` and all 17 unit tests passed. 
- Ran `pnpm --filter @goldshore/gs-api test` and all 61 API tests passed. 
- Ran `pnpm check:wrangler-placeholders` and the placeholder scan passed for all scanned files. 
- Ran `pnpm --filter @goldshore/gs-api build` (Wrangler `--dry-run`) and the dry-run completed with `CONTROL_SYNC_TOKEN` not exposed as an environment variable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e70a3b2708331aabe5ca83ebe1d09)