### PR TITLE
fix: provision admin preview hostname

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -83,6 +83,7 @@ jobs:
 
           reconcile_route goldshore.ai 'goldshore.ai/*' gs-web-prod
           reconcile_route goldshore.ai 'admin.goldshore.ai/*' gs-web-prod
+          reconcile_route goldshore.ai 'admin-preview.goldshore.ai/*' gs-web-prod
           reconcile_route goldshore.ai 'api.goldshore.ai/*' gs-api-prod
           reconcile_route goldshore.org 'goldshore.org/*' gs-web-prod
           reconcile_route goldshore.org 'admin.goldshore.org/*' gs-web-prod

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -27,6 +27,7 @@ routes = [
   { pattern = "goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "goldshore.org/*", zone_name = "goldshore.org" },
   { pattern = "admin.goldshore.ai/*", zone_name = "goldshore.ai" },
+  { pattern = "admin-preview.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "admin.goldshore.org/*", zone_name = "goldshore.org" }
 ]
 

--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -45,6 +45,11 @@ cloudflare:
         content: "gs-web-prod.goldshore.workers.dev"
         proxied: true
         zone: goldshore.ai
+      - name: "admin-preview"
+        type: CNAME
+        content: "gs-web-prod.goldshore.workers.dev"
+        proxied: true
+        zone: goldshore.ai
       - name: "admin"
         type: CNAME
         content: "gs-web-prod.goldshore.workers.dev"


### PR DESCRIPTION
## Summary
- add the missing proxied DNS record for admin-preview.goldshore.ai
- route the preview hostname to gs-web-prod in Wrangler
- reconcile the Worker route alongside the existing admin routes

## Why
Cloudflare Access currently authorizes admin-preview.goldshore.ai as an Admin application hostname, but public DNS returns NXDOMAIN. That breaks Access callbacks that land on the preview alias.

## Validation
- git diff --check
- verified desired DNS, Wrangler route, and reconciliation route agree on admin-preview.goldshore.ai -> gs-web-prod