### PR TITLE
Add route-only Cloudflare reconciliation

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -24,8 +24,105 @@ on:
         required: false
         default: false
         type: boolean
+      reconcile_routes:
+        description: 'Reconcile live Worker routes without changing DNS or TLS settings'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  reconcile-routes:
+    if: ${{ inputs.reconcile_routes }}
+    name: Reconcile Worker routes
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      CF_API: https://api.cloudflare.com/client/v4
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+    steps:
+      - name: Normalize Cloudflare token
+        shell: bash
+        run: |
+          normalize_token() {
+            local env_name="$1"
+            node <<NODE
+          const raw = process.env["$env_name"] || "";
+          let token = raw.replace(/[\r\n]/g, "").trim();
+          const bearer = token.match(/(?:authorization\s*:\s*)?bearer\s+([^\s"',;}]+)/i);
+          if (bearer) token = bearer[1];
+          const cfut = token.match(/cfut_[A-Za-z0-9_-]+/);
+          if (cfut) token = cfut[0];
+          token = token.replace(/^[\`'"]+|[\`'",;}]+$/g, "").replace(/\s/g, "");
+          process.stdout.write(token);
+          NODE
+          }
+
+          for source in CLOUDFLARE_BUILD_API_TOKEN CLOUDFLARE_API_TOKEN; do
+            token="$(normalize_token "$source")"
+            if [ -n "$token" ]; then
+              echo "::add-mask::$token"
+              echo "CF_ROUTE_TOKEN=$token" >> "$GITHUB_ENV"
+              echo "Using route token from $source"
+              exit 0
+            fi
+          done
+
+          echo "::error::No Cloudflare token available for route reconciliation"
+          exit 1
+
+      - name: Reconcile routes
+        shell: bash
+        run: |
+          set -euo pipefail
+          auth=(-H "Authorization: Bearer $CF_ROUTE_TOKEN")
+
+          zone_id_for() {
+            curl -fsS "$CF_API/zones?name=$1" "${auth[@]}" | jq -r '.result[0].id // empty'
+          }
+
+          reconcile_route() {
+            local zone="$1" pattern="$2" script="$3" zone_id routes route_id body
+            zone_id="$(zone_id_for "$zone")"
+            test -n "$zone_id"
+            routes="$(curl -fsS "$CF_API/zones/$zone_id/workers/routes" "${auth[@]}")"
+            route_id="$(jq -r --arg pattern "$pattern" '.result[] | select(.pattern == $pattern) | .id' <<<"$routes")"
+            body="$(jq -nc --arg pattern "$pattern" --arg script "$script" '{pattern:$pattern,script:$script}')"
+            if [[ -n "$route_id" ]]; then
+              curl -fsS -X PUT "$CF_API/zones/$zone_id/workers/routes/$route_id" "${auth[@]}" \
+                -H 'Content-Type: application/json' --data "$body" >/dev/null
+            else
+              curl -fsS -X POST "$CF_API/zones/$zone_id/workers/routes" "${auth[@]}" \
+                -H 'Content-Type: application/json' --data "$body" >/dev/null
+            fi
+            echo "Reconciled route: $zone $pattern -> $script"
+          }
+
+          delete_route_if_present() {
+            local zone="$1" pattern="$2" zone_id routes route_id
+            zone_id="$(zone_id_for "$zone")"
+            test -n "$zone_id"
+            routes="$(curl -fsS "$CF_API/zones/$zone_id/workers/routes" "${auth[@]}")"
+            route_id="$(jq -r --arg pattern "$pattern" '.result[] | select(.pattern == $pattern) | .id' <<<"$routes")"
+            if [[ -z "$route_id" ]]; then
+              echo "Route absent: $zone $pattern"
+              return
+            fi
+            curl -fsS -X DELETE "$CF_API/zones/$zone_id/workers/routes/$route_id" "${auth[@]}" >/dev/null
+            echo "Deleted malformed route: $zone $pattern"
+          }
+
+          reconcile_route goldshore.ai 'goldshore.ai/*' gs-web-prod
+          reconcile_route goldshore.ai 'admin.goldshore.ai/*' gs-web-prod
+          reconcile_route goldshore.ai 'admin-preview.goldshore.ai/*' gs-web-prod
+          reconcile_route goldshore.ai 'api.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.org 'goldshore.org/*' gs-web-prod
+          reconcile_route goldshore.org 'admin.goldshore.org/*' gs-web-prod
+          reconcile_route goldshore.org 'api.goldshore.org/*' gs-api-prod
+
+          delete_route_if_present goldshore.org 'admin.goldshore.ai/*'
+          delete_route_if_present goldshore.org 'api.goldshore.ai/*'
+
   harden-tls:
     if: ${{ inputs.harden_tls }}
     name: Harden zone TLS settings


### PR DESCRIPTION
## Summary
- add a `reconcile_routes` workflow_dispatch input to `Reconcile DNS`
- add a route-only job that fixes live Worker route ownership without changing DNS or TLS settings
- reconcile `api.goldshore.ai/*` and `api.goldshore.org/*` to `gs-api-prod`, web/admin routes to `gs-web-prod`, and delete malformed `goldshore.ai` route patterns from the `goldshore.org` zone

## Validation
- `npx prettier --check .github/workflows/reconcile-dns.yml`