### PR TITLE
Prefer DNS token for route reconciliation

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -58,7 +58,7 @@ jobs:
           NODE
           }
 
-          for source in CLOUDFLARE_BUILD_API_TOKEN CLOUDFLARE_API_TOKEN; do
+          for source in CLOUDFLARE_API_TOKEN CLOUDFLARE_BUILD_API_TOKEN; do
             token="$(normalize_token "$source")"
             if [ -n "$token" ]; then
               echo "::add-mask::$token"


### PR DESCRIPTION
## Summary
- prefer the repo `CLOUDFLARE_API_TOKEN` before `CLOUDFLARE_BUILD_API_TOKEN` for route-only reconciliation
- this avoids the build token path that failed with 403 before route repair could run

## Validation
- `npx prettier --check .github/workflows/reconcile-dns.yml`