### PR TITLE
Fix gs-api queue consumer ownership

### DIFF
--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -3,17 +3,34 @@ import assert from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const wranglerToml = readFileSync(resolve(import.meta.dirname, '../../wrangler.toml'), 'utf8');
-const webWranglerToml = readFileSync(resolve(import.meta.dirname, '../../../gs-web/wrangler.toml'), 'utf8');
+const wranglerToml = readFileSync(
+  resolve(import.meta.dirname, '../../wrangler.toml'),
+  'utf8',
+);
+const webWranglerToml = readFileSync(
+  resolve(import.meta.dirname, '../../../gs-web/wrangler.toml'),
+  'utf8',
+);
 
 const environmentBlock = (toml: string, environment: string) => {
-  const match = toml.match(new RegExp(`\\[env\\.${environment}\\]([\\s\\S]*?)(?=\\n\\[env\\.${environment}\\.|\\n\\[env\\.|$)`));
+  const match = toml.match(
+    new RegExp(
+      `\\[env\\.${environment}\\]([\\s\\S]*?)(?=\\n\\[env\\.${environment}\\.|\\n\\[env\\.|$)`,
+    ),
+  );
   assert.ok(match, `missing [env.${environment}] block`);
   return match[1];
 };
 
 const routePatterns = (block: string) =>
   [...block.matchAll(/pattern\s*=\s*"([^"]+)"/g)].map((match) => match[1]);
+
+const queueConsumerNames = (block: string) =>
+  [
+    ...block.matchAll(
+      /\[\[env\.[^.]+\.queues\.consumers\]\][\s\S]*?queue\s*=\s*"([^"]+)"/g,
+    ),
+  ].map((match) => match[1]);
 
 describe('gs-api wrangler env bindings', () => {
   // Canonical environments are [env.prod] and [env.preview].
@@ -22,34 +39,46 @@ describe('gs-api wrangler env bindings', () => {
     it(`keeps the KV binding required by runtime handlers in ${envName}`, () => {
       assert.match(
         wranglerToml,
-        new RegExp(`\\[\\[env\\.${envName}\\.kv_namespaces\\]\\][\\s\\S]*?binding = "KV"[\\s\\S]*?id = "`)
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.kv_namespaces\\]\\][\\s\\S]*?binding = "KV"[\\s\\S]*?id = "`,
+        ),
       );
       assert.match(
         wranglerToml,
-        new RegExp(`\\[\\[env\\.${envName}\\.kv_namespaces\\]\\][\\s\\S]*?binding = "RISK_RADAR_CACHE"[\\s\\S]*?id = "`)
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.kv_namespaces\\]\\][\\s\\S]*?binding = "RISK_RADAR_CACHE"[\\s\\S]*?id = "`,
+        ),
       );
     });
 
     it(`defines platform, Risk Radar, and AI bindings for ${envName}`, () => {
       assert.match(
         wranglerToml,
-        new RegExp(`\\[\\[env\\.${envName}\\.r2_buckets\\]\\][\\s\\S]*?binding = "GS_ASSETS"`)
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.r2_buckets\\]\\][\\s\\S]*?binding = "GS_ASSETS"`,
+        ),
       );
       assert.match(
         wranglerToml,
-        new RegExp(`\\[\\[env\\.${envName}\\.r2_buckets\\]\\][\\s\\S]*?binding = "RISK_RADAR_R2"`)
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.r2_buckets\\]\\][\\s\\S]*?binding = "RISK_RADAR_R2"`,
+        ),
       );
       assert.match(
         wranglerToml,
-        new RegExp(`\\[\\[env\\.${envName}\\.d1_databases\\]\\][\\s\\S]*?binding = "PLATFORM_DB"`)
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.d1_databases\\]\\][\\s\\S]*?binding = "PLATFORM_DB"`,
+        ),
       );
       assert.match(
         wranglerToml,
-        new RegExp(`\\[\\[env\\.${envName}\\.d1_databases\\]\\][\\s\\S]*?binding = "RISK_RADAR_DB"`)
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.d1_databases\\]\\][\\s\\S]*?binding = "RISK_RADAR_DB"`,
+        ),
       );
       assert.match(
         wranglerToml,
-        new RegExp(`\\[env\\.${envName}\\.ai\\][\\s\\S]*?binding = "AI"`)
+        new RegExp(`\\[env\\.${envName}\\.ai\\][\\s\\S]*?binding = "AI"`),
       );
     });
   }
@@ -59,6 +88,13 @@ describe('gs-api wrangler env bindings', () => {
       'api.goldshore.ai/*',
       'api.goldshore.org/*',
     ]);
+  });
+
+  it('keeps production gs-api queue ownership producer-only for externally consumed queues', () => {
+    assert.deepEqual(
+      queueConsumerNames(environmentBlock(wranglerToml, 'prod')),
+      [],
+    );
   });
 
   it('keeps web and migrated admin hosts separate from API hosts', () => {

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -143,14 +143,11 @@ queue = "gs-mail-jobs"
 binding = "DEAD_LETTER_QUEUE"
 queue = "gs-mail-dead-letter"
 
-[[env.prod.queues.consumers]]
-queue = "goldshore-jobs"
-
-[[env.prod.queues.consumers]]
-queue = "gs-mail-jobs"
-
-[[env.prod.queues.consumers]]
-queue = "gs-events"
+# Production queue consumers are owned outside gs-api today:
+# - goldshore-jobs and gs-events are consumed by gs-mail.
+# - gs-mail-jobs is configured as an HTTP pull consumer.
+# Keep gs-api as a producer only so deploys do not fail while attempting to
+# replace existing queue consumers.
 
 # ── Workflows ──────────────────────────────────────────────────────────────────────────
 [[env.prod.workflows]]

--- a/docs/WORKER_CONFIGURATION.md
+++ b/docs/WORKER_CONFIGURATION.md
@@ -21,7 +21,7 @@ Do not add new app workers or deploy workflows for retired services. All backend
   - R2: `GS_ASSETS`, `TELEMETRY`, `RISK_RADAR_R2`
   - AI: `AI`
   - Durable Object: `AUTH_SESSION`
-  - Queues produced: `JOBS_QUEUE`, `EVENTS_QUEUE`, `MAIL_JOBS_QUEUE`, `DEAD_LETTER_QUEUE`; `gs-api` is also the production consumer for consolidated backend queues
+  - Queues produced: `JOBS_QUEUE`, `EVENTS_QUEUE`, `MAIL_JOBS_QUEUE`, `DEAD_LETTER_QUEUE`; production queue consumers are not declared by `gs-api` while live Cloudflare routes `goldshore-jobs`/`gs-events` to `gs-mail` and `gs-mail-jobs` to an HTTP pull consumer
   - Worker secret: `INTEGRATION_MASTER_KEY` (provision with `wrangler secret put`; do not use a Secrets Store binding unless the store and secret already exist)
 - **Retired aliases/service bindings:** `DB`, `ASSETS`, `TELEMETRY_DB`, `SECRETS`, `AGENT`, `GS_MAIL`, `GS_WEB`, `GS_WEB PROD`, `API_SERVICE`, and `GOLDSHORE_AI` must not be used as `gs-api` bindings. If Cloudflare still shows any of these in the dashboard, treat them as live-state cleanup candidates until a human confirms otherwise.
 

--- a/docs/ops/queue-contract-matrix.md
+++ b/docs/ops/queue-contract-matrix.md
@@ -2,18 +2,19 @@
 
 This matrix is generated from the Wrangler manifests in `apps/*/wrangler.toml` and is the source of truth for queue producer/consumer ownership.
 
-| Queue name | Producer worker | Consumer worker | Environment |
-| --- | --- | --- | --- |
-| `gs-platform-checkout-events-dev` | `gs-gateway` | `gs-mail` | `dev` |
-| `gs-platform-contact-events-dev` | `gs-gateway` | `gs-mail` | `dev` |
-| `gs-platform-checkout-events-preview` | `gs-gateway` | `gs-mail` | `preview` |
-| `gs-platform-contact-events-preview` | `gs-gateway` | `gs-mail` | `preview` |
-| `gs-platform-checkout-events-prod` | `gs-gateway` | `gs-mail` | `prod` |
-| `gs-platform-contact-events-prod` | `gs-gateway` | `gs-mail` | `prod` |
-| `goldshore-jobs` | _not declared in current manifests_ | `gs-agent` | `default`, `prod` |
+| Queue name                            | Producer worker                     | Consumer worker | Environment       |
+| ------------------------------------- | ----------------------------------- | --------------- | ----------------- |
+| `gs-platform-checkout-events-dev`     | `gs-gateway`                        | `gs-mail`       | `dev`             |
+| `gs-platform-contact-events-dev`      | `gs-gateway`                        | `gs-mail`       | `dev`             |
+| `gs-platform-checkout-events-preview` | `gs-gateway`                        | `gs-mail`       | `preview`         |
+| `gs-platform-contact-events-preview`  | `gs-gateway`                        | `gs-mail`       | `preview`         |
+| `gs-platform-checkout-events-prod`    | `gs-gateway`                        | `gs-mail`       | `prod`            |
+| `gs-platform-contact-events-prod`     | `gs-gateway`                        | `gs-mail`       | `prod`            |
+| `goldshore-jobs`                      | _not declared in current manifests_ | `gs-agent`      | `default`, `prod` |
 
 ## Notes
 
 - `gs-platform` is deployed from `apps/gs-gateway`; therefore checkout/contact producer queues are declared in `apps/gs-gateway/wrangler.toml`.
 - `gs-mail` consumes the exact checkout/contact queue identifiers emitted by `gs-platform` in each environment (`dev`, `preview`, `prod`).
 - `goldshore-jobs` is currently consumer-only in this repository and should either gain an explicit producer declaration or be removed from `gs-agent` when unused.
+- Live Cloudflare audit on 2026-07-21: `goldshore-jobs` and `gs-events` are worker-consumed by `gs-mail`, and `gs-mail-jobs` is an HTTP pull consumer. `gs-api` intentionally declares producer bindings only for these queues until consumer ownership is migrated.

--- a/infra/Cloudflare/gs-api.wrangler.toml
+++ b/infra/Cloudflare/gs-api.wrangler.toml
@@ -111,14 +111,11 @@ queue = "gs-mail-jobs"
 binding = "DEAD_LETTER_QUEUE"
 queue = "gs-mail-dead-letter"
 
-[[env.prod.queues.consumers]]
-queue = "goldshore-jobs"
-
-[[env.prod.queues.consumers]]
-queue = "gs-mail-jobs"
-
-[[env.prod.queues.consumers]]
-queue = "gs-events"
+# Production queue consumers are owned outside gs-api today:
+# - goldshore-jobs and gs-events are consumed by gs-mail.
+# - gs-mail-jobs is configured as an HTTP pull consumer.
+# Keep gs-api as a producer only so deploys do not fail while attempting to
+# replace existing queue consumers.
 
 # ── Workflows ────────────────────────────────────────────────────────────────
 [[env.prod.workflows]]


### PR DESCRIPTION
## Summary
- Remove production queue consumer declarations from `apps/gs-api/wrangler.toml` and the infra mirror so gs-api remains producer-only for queues consumed elsewhere.
- Add a wrangler config test that keeps prod gs-api queue consumers empty.
- Document the 2026-07-21 live Cloudflare queue audit: `goldshore-jobs`/`gs-events` are consumed by `gs-mail`; `gs-mail-jobs` is an HTTP pull consumer.

## Validation
- `pnpm --filter @goldshore/gs-api test`
- `pnpm --filter @goldshore/gs-api build`
- `pnpm validate:queues`
- `pnpm exec prettier --check apps/gs-api/src/routes/wrangler-config.test.ts docs/WORKER_CONFIGURATION.md docs/ops/queue-contract-matrix.md`

## Operational note
A production deploy from main already restored HTTP health after uploading gs-api-prod with the correct D1/KV/R2/AI bindings, but that run failed after upload while Wrangler attempted to attach queue consumers already owned by live Cloudflare. This PR prevents that failure from recurring.