### PR TITLE
Harden gs-api Cloudflare Builds fallback

### DIFF
--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -22,6 +22,8 @@ const environmentBlock = (toml: string, environment: string) => {
   return match[1];
 };
 
+const topLevelBlock = (toml: string) => toml.split(/\r?\n\[env\.prod\]/)[0];
+
 const routePatterns = (block: string) =>
   [...block.matchAll(/pattern\s*=\s*"([^"]+)"/g)].map((match) => match[1]);
 
@@ -82,6 +84,29 @@ describe('gs-api wrangler env bindings', () => {
       );
     });
   }
+
+  it('keeps top-level bindings safe for Cloudflare Workers Builds version uploads', () => {
+    const topLevel = topLevelBlock(wranglerToml);
+
+    assert.match(topLevel, /\[vars\][\s\S]*?ENV\s*=\s*"production"/);
+    assert.match(
+      topLevel,
+      /\[vars\][\s\S]*?CLOUDFLARE_ACCESS_AUDIENCE\s*=\s*"8510d42c31fc791e295427031ffeef7c7ebc0f1b62d8634fbb284bf82562f528"/,
+    );
+    assert.match(
+      topLevel,
+      /\[\[kv_namespaces\]\][\s\S]*?binding\s*=\s*"KV"[\s\S]*?id\s*=\s*"e0b8b807191346c3b0afc25fe716d2cd"/,
+    );
+    assert.match(
+      topLevel,
+      /\[\[d1_databases\]\][\s\S]*?binding\s*=\s*"PLATFORM_DB"/,
+    );
+    assert.match(
+      topLevel,
+      /\[\[r2_buckets\]\][\s\S]*?binding\s*=\s*"GS_ASSETS"/,
+    );
+    assert.match(topLevel, /\[ai\][\s\S]*?binding\s*=\s*"AI"/);
+  });
 
   it('limits production hostname ownership to canonical API routes', () => {
     assert.deepEqual(routePatterns(environmentBlock(wranglerToml, 'prod')), [

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -5,6 +5,86 @@ compatibility_flags = ["nodejs_compat"]
 
 workers_dev = false
 
+# Cloudflare Workers Builds can run `npx wrangler versions upload` without
+# selecting `--env prod`. Keep the top-level binding set production-compatible
+# so those version uploads do not replace gs-api-prod with a bindingless build.
+[vars]
+ENV = "production"
+CLOUDFLARE_ACCESS_AUDIENCE = "8510d42c31fc791e295427031ffeef7c7ebc0f1b62d8634fbb284bf82562f528"
+CLOUDFLARE_TEAM_DOMAIN = "goldshore.cloudflareaccess.com"
+GOOGLE_OAUTH_CLIENT_ID = "1054833139648-gt5o3k9uqhltt08nne0sigh8l3vodji7.apps.googleusercontent.com"
+GOOGLE_OAUTH_REDIRECT_URI = "https://api.goldshore.ai/goldclaw/oauth/google/callback"
+CONTACT_NOTIFICATION_EMAILS = "marstonr6@gmail.com"
+MAILCHANNELS_SENDER_NAME = "GoldShore"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "e0b8b807191346c3b0afc25fe716d2cd"
+
+[[kv_namespaces]]
+binding = "CONTROL_LOGS"
+id = "a52e94cb331c4e3db08f2aa507e6df09"
+
+[[kv_namespaces]]
+binding = "RISK_RADAR_CACHE"
+id = "0b56873b6d7b451f9279481920a15447"
+
+[[r2_buckets]]
+binding = "GS_ASSETS"
+bucket_name = "gs-assets"
+
+[[r2_buckets]]
+binding = "TELEMETRY"
+bucket_name = "gs-telemetry-storage"
+
+[[r2_buckets]]
+binding = "RISK_RADAR_R2"
+bucket_name = "risk-radar-raw"
+
+[[d1_databases]]
+binding = "PLATFORM_DB"
+database_name = "gs_platform_db"
+database_id = "9703574e-adb7-481e-8d98-96f8ce5f8a90"
+
+[[d1_databases]]
+binding = "AUDIT_DB"
+database_name = "gs_audit_db"
+database_id = "1ae71d76-188f-481b-91d9-db2d39013f68"
+
+[[d1_databases]]
+binding = "SIGNALS_DB"
+database_name = "gs_signals_db"
+database_id = "76af4653-7f44-417b-b46e-250143d906fd"
+
+[[d1_databases]]
+binding = "RISK_RADAR_DB"
+database_name = "risk-radar-db"
+database_id = "b0bf3b0e-a7d0-49ae-ac82-4f19450b2ce2"
+
+[[d1_databases]]
+binding = "JOBS_DB"
+database_name = "gs_jobs_db"
+database_id = "750c469c-788d-49e8-9254-77231cffd70f"
+
+[ai]
+binding = "AI"
+
+[[queues.producers]]
+binding = "JOBS_QUEUE"
+queue = "goldshore-jobs"
+
+[[queues.producers]]
+binding = "EVENTS_QUEUE"
+queue = "gs-events"
+
+[[queues.producers]]
+binding = "MAIL_JOBS_QUEUE"
+queue = "gs-mail-jobs"
+
+[[queues.producers]]
+binding = "DEAD_LETTER_QUEUE"
+queue = "gs-mail-dead-letter"
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Production environment
 # Canonical environment name is "prod". Use `wrangler deploy --env prod`.

--- a/docs/WORKER_CONFIGURATION.md
+++ b/docs/WORKER_CONFIGURATION.md
@@ -15,6 +15,7 @@ Do not add new app workers or deploy workflows for retired services. All backend
 - **Wrangler:** `apps/gs-api/wrangler.toml`
 - **Production routes:** `api.goldshore.ai/*`, `api.goldshore.org/*`, plus consolidated backend hostnames `agent.goldshore.ai/*`, `mail.goldshore.ai/*`, `ops.goldshore.ai/*`, `trading.goldshore.ai/*`, `dashboard.goldshore.ai/*`, and `dash.goldshore.ai/*`
 - **Preview:** `workers_dev = true`; preview API route `api-preview.goldshore.ai/*`
+- **Cloudflare Builds fallback:** top-level bindings intentionally mirror production runtime bindings because the dashboard Workers Builds integration may run `wrangler versions upload` without `--env prod`. Do not remove that block until the dashboard trigger is disabled or changed to `wrangler deploy --env prod --config wrangler.toml`.
 - **Canonical bindings:**
   - KV: `KV`, `CONTROL_LOGS`, `RISK_RADAR_CACHE`
   - D1: `PLATFORM_DB`, `AUDIT_DB`, `SIGNALS_DB`, `RISK_RADAR_DB`, `JOBS_DB`


### PR DESCRIPTION
## Summary
- mirror the production gs-api runtime bindings at the top level of apps/gs-api/wrangler.toml
- guard the Cloudflare Workers Builds no-env upload path with a config test
- document why the fallback should remain until the dashboard trigger is changed or disabled

## Why
Cloudflare Workers Builds has dashboard triggers on gs-api-prod that currently run bare Wrangler commands from /apps/gs-api:
- default branch: `npx wrangler deploy`
- non-production branches: `npx wrangler versions upload`

Those commands do not select `--env prod`, so they can upload a version without the `PLATFORM_DB`/KV/R2/AI bindings expected by the production script. Attempting to patch the dashboard trigger through the Builds API is blocked by Cloudflare auth code 10000 with the current token; the API docs indicate editing triggers requires a user-scoped token with `Workers Builds Configuration Edit`.

## Validation
- `pnpm --filter @goldshore/gs-api test`
- `pnpm --filter @goldshore/gs-api build`
- `npx wrangler deploy --dry-run --outdir=dist-default` from `apps/gs-api`
- `pnpm exec prettier --check apps/gs-api/src/routes/wrangler-config.test.ts docs/WORKER_CONFIGURATION.md`

## Live ops note
Production was restored with `deploy-gs-api.yml` run 29863402014. After propagation, these were healthy:
- `https://api.goldshore.ai/health`
- `https://api.goldshore.ai/health?type=deep`
- `https://api.goldshore.org/health`
- `https://api.goldshore.org/health?type=deep`
