### PR TITLE
fix(access): add job to create missing GoldShore MCP Access app

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -44,28 +44,13 @@ jobs:
     env:
       CF_API: https://api.cloudflare.com/client/v4
       CF_ACCOUNT: f77de112d2019e5456a3198a8bb50bd2
-      CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+      # NOTE: CLOUDFLARE_BUILD_API_TOKEN does NOT have Access: Apps and
+      # Policies scope -- confirmed by setup-cf-agent-access.yml's own
+      # permission probe, which checks that scope only on
+      # CLOUDFLARE_API_TOKEN. Using the build token here previously failed
+      # silently (curl -f exit 22) on the very first Access API call.
+      CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
-      - name: Normalize Cloudflare build token
-        shell: bash
-        run: |
-          token="$(
-            node <<'NODE'
-          const raw = process.env.CLOUDFLARE_BUILD_API_TOKEN || "";
-          let token = raw.replace(/[\r\n]/g, "").trim();
-          const bearer = token.match(/(?:authorization\s*:\s*)?bearer\s+([^\s"',;}]+)/i);
-          if (bearer) token = bearer[1];
-          const cfut = token.match(/cfut_[A-Za-z0-9_-]+/);
-          if (cfut) token = cfut[0];
-          token = token.replace(/^[`'"]+|[`'",;}]+$/g, "").replace(/\s/g, "");
-          process.stdout.write(token);
-          NODE
-          )"
-          if [ -n "$token" ]; then
-            echo "::add-mask::$token"
-            echo "CF_TOKEN=$token" >> "$GITHUB_ENV"
-          fi
-
       - name: Create GoldShore MCP self-hosted Access app + policies
         shell: bash
         run: |
@@ -73,9 +58,21 @@ jobs:
           test -n "${CF_TOKEN:-}"
           auth=(-H "Authorization: Bearer $CF_TOKEN")
 
+          api_get() {
+            local url="$1" resp status body
+            resp=$(curl -sS -w '\n%{http_code}' "$url" "${auth[@]}")
+            status="${resp##*$'\n'}"
+            body="${resp%$'\n'*}"
+            if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+              echo "::error::GET $url failed (HTTP $status): $body" >&2
+              exit 1
+            fi
+            echo "$body"
+          }
+
           # Idempotent guard: if an app already matches this name or domain,
           # do nothing rather than create a duplicate.
-          EXISTING=$(curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps?per_page=100" "${auth[@]}" | \
+          EXISTING=$(api_get "$CF_API/accounts/$CF_ACCOUNT/access/apps?per_page=100" | \
             jq -r '[.result[] | select(.name == "GoldShore MCP" or .domain == "mcp.goldshore.ai" or ((.self_hosted_domains // []) | index("mcp.goldshore.ai")))] | first | .id // empty')
           if [ -n "$EXISTING" ]; then
             echo "GoldShore MCP Access app already exists: $EXISTING -- nothing to do."
@@ -85,7 +82,7 @@ jobs:
           # Reuse the existing goldshore-agents service token (its UUID, not
           # its secret) instead of minting a new one, so no other Access
           # app's machine-auth policy is disturbed by this change.
-          TOKEN_UUID=$(curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" "${auth[@]}" | \
+          TOKEN_UUID=$(api_get "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" | \
             jq -r '.result[] | select(.name == "goldshore-agents") | .id // empty' | head -n1)
           if [ -z "$TOKEN_UUID" ]; then
             echo "::error::Could not find existing 'goldshore-agents' service token -- refusing to create an agent policy without it."
@@ -112,12 +109,18 @@ jobs:
           echo "Created GoldShore MCP Access app: $APP_ID (AUD: $APP_AUD)"
 
           add_policy() {
-            local name="$1" decision="$2" include="$3"
-            jq -nc --arg n "$name" --arg d "$decision" --argjson inc "$include" \
+            local name="$1" decision="$2" include="$3" resp status body
+            resp=$(jq -nc --arg n "$name" --arg d "$decision" --argjson inc "$include" \
               '{name:$n,decision:$d,include:$inc,exclude:[],require:[]}' | \
-              curl -sf -X POST "$CF_API/accounts/$CF_ACCOUNT/access/apps/$APP_ID/policies" \
-                "${auth[@]}" -H 'Content-Type: application/json' --data @- \
-              | jq -r '"  policy \(.result.name // "?") => \(.success)"'
+              curl -sS -w '\n%{http_code}' -X POST "$CF_API/accounts/$CF_ACCOUNT/access/apps/$APP_ID/policies" \
+                "${auth[@]}" -H 'Content-Type: application/json' --data @-)
+            status="${resp##*$'\n'}"
+            body="${resp%$'\n'*}"
+            if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+              echo "::error::Failed to create policy [$name] on app $APP_ID (HTTP $status): $body"
+              exit 1
+            fi
+            echo "$body" | jq -r '"  policy \(.result.name // "?") => \(.success)"'
           }
 
           # Matches infra/Cloudflare/desired-state.yaml's GoldShore MCP policy

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -29,8 +29,106 @@ on:
         required: false
         default: false
         type: boolean
+      create_mcp_access:
+        description: 'Create the missing GoldShore MCP self-hosted Access Application on mcp.goldshore.ai (reuses existing goldshore-agents service token; does not rotate it; no-op if an app already exists)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  create-mcp-access-app:
+    if: ${{ inputs.create_mcp_access }}
+    name: Create missing GoldShore MCP Access Application
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      CF_API: https://api.cloudflare.com/client/v4
+      CF_ACCOUNT: f77de112d2019e5456a3198a8bb50bd2
+      CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
+    steps:
+      - name: Normalize Cloudflare build token
+        shell: bash
+        run: |
+          token="$(
+            node <<'NODE'
+          const raw = process.env.CLOUDFLARE_BUILD_API_TOKEN || "";
+          let token = raw.replace(/[\r\n]/g, "").trim();
+          const bearer = token.match(/(?:authorization\s*:\s*)?bearer\s+([^\s"',;}]+)/i);
+          if (bearer) token = bearer[1];
+          const cfut = token.match(/cfut_[A-Za-z0-9_-]+/);
+          if (cfut) token = cfut[0];
+          token = token.replace(/^[`'"]+|[`'",;}]+$/g, "").replace(/\s/g, "");
+          process.stdout.write(token);
+          NODE
+          )"
+          if [ -n "$token" ]; then
+            echo "::add-mask::$token"
+            echo "CF_TOKEN=$token" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create GoldShore MCP self-hosted Access app + policies
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${CF_TOKEN:-}"
+          auth=(-H "Authorization: Bearer $CF_TOKEN")
+
+          # Idempotent guard: if an app already matches this name or domain,
+          # do nothing rather than create a duplicate.
+          EXISTING=$(curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/apps?per_page=100" "${auth[@]}" | \
+            jq -r '[.result[] | select(.name == "GoldShore MCP" or .domain == "mcp.goldshore.ai" or ((.self_hosted_domains // []) | index("mcp.goldshore.ai")))] | first | .id // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "GoldShore MCP Access app already exists: $EXISTING -- nothing to do."
+            exit 0
+          fi
+
+          # Reuse the existing goldshore-agents service token (its UUID, not
+          # its secret) instead of minting a new one, so no other Access
+          # app's machine-auth policy is disturbed by this change.
+          TOKEN_UUID=$(curl -sf "$CF_API/accounts/$CF_ACCOUNT/access/service_tokens" "${auth[@]}" | \
+            jq -r '.result[] | select(.name == "goldshore-agents") | .id // empty' | head -n1)
+          if [ -z "$TOKEN_UUID" ]; then
+            echo "::error::Could not find existing 'goldshore-agents' service token -- refusing to create an agent policy without it."
+            exit 1
+          fi
+          echo "Reusing existing goldshore-agents service token: $TOKEN_UUID"
+
+          APP_RESP=$(jq -nc \
+            '{name:"GoldShore MCP",type:"self_hosted",domain:"mcp.goldshore.ai",
+              self_hosted_domains:["mcp.goldshore.ai"],
+              session_duration:"24h",
+              http_only_cookie_attribute:true,
+              auto_redirect_to_identity:false}' | \
+            curl -sS -w '\n%{http_code}' -X POST "$CF_API/accounts/$CF_ACCOUNT/access/apps" \
+              "${auth[@]}" -H 'Content-Type: application/json' --data @-)
+          APP_STATUS="${APP_RESP##*$'\n'}"
+          APP_BODY="${APP_RESP%$'\n'*}"
+          if [ "$APP_STATUS" -lt 200 ] || [ "$APP_STATUS" -ge 300 ]; then
+            echo "::error::Failed to create GoldShore MCP Access app (HTTP $APP_STATUS): $APP_BODY"
+            exit 1
+          fi
+          APP_ID=$(echo "$APP_BODY" | jq -r '.result.id')
+          APP_AUD=$(echo "$APP_BODY" | jq -r '.result.aud')
+          echo "Created GoldShore MCP Access app: $APP_ID (AUD: $APP_AUD)"
+
+          add_policy() {
+            local name="$1" decision="$2" include="$3"
+            jq -nc --arg n "$name" --arg d "$decision" --argjson inc "$include" \
+              '{name:$n,decision:$d,include:$inc,exclude:[],require:[]}' | \
+              curl -sf -X POST "$CF_API/accounts/$CF_ACCOUNT/access/apps/$APP_ID/policies" \
+                "${auth[@]}" -H 'Content-Type: application/json' --data @- \
+              | jq -r '"  policy \(.result.name // "?") => \(.success)"'
+          }
+
+          # Matches infra/Cloudflare/desired-state.yaml's GoldShore MCP policy
+          # intent: approved human identities (Owner access) + a dedicated
+          # service-token path for approved agents (Goldshore agents).
+          add_policy "Goldshore agents" "non_identity" "$(jq -nc --arg id "$TOKEN_UUID" '[{"service_token":{"token_id":$id}}]')"
+          add_policy "Owner access" "allow" '[{"email_domain":{"domain":"goldshore.ai"}},{"email":{"email":"marstonr6@gmail.com"}}]'
+
+          echo ""
+          echo "GoldShore MCP Access app is live. mcp.goldshore.ai now requires either the goldshore-agents service token or an @goldshore.ai / marstonr6@gmail.com identity."
+
   reconcile-routes:
     if: ${{ inputs.reconcile_routes }}
     name: Reconcile Worker routes

--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -71,11 +71,15 @@ jobs:
           }
 
           # Idempotent guard: if an app already matches this name or domain,
-          # do nothing rather than create a duplicate.
+          # print its existing policies for verification and stop rather
+          # than create a duplicate.
           EXISTING=$(api_get "$CF_API/accounts/$CF_ACCOUNT/access/apps?per_page=100" | \
             jq -r '[.result[] | select(.name == "GoldShore MCP" or .domain == "mcp.goldshore.ai" or ((.self_hosted_domains // []) | index("mcp.goldshore.ai")))] | first | .id // empty')
           if [ -n "$EXISTING" ]; then
             echo "GoldShore MCP Access app already exists: $EXISTING -- nothing to do."
+            echo "== existing policies =="
+            api_get "$CF_API/accounts/$CF_ACCOUNT/access/apps/$EXISTING/policies" | \
+              jq '[.result[] | {name, decision, include}]'
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

`mcp.goldshore.ai` currently has **zero Cloudflare Access protection**, verified live: no Access application matches name `GoldShore MCP` or domain `mcp.goldshore.ai`, despite `infra/Cloudflare/desired-state.yaml` and `docs/domains-and-auth.md` both documenting it as a private, Access-gated surface ("approved human identities and a dedicated service identity path for approved agents").

Its DNS CNAME was also recently repointed to `goldshore-api.pages.dev` — confirmed intentional (reuse of an undeletable legacy Pages project), not a bug. That's fine on its own, but combined with the missing Access app it means the surface is currently open to whatever's served there, with no auth in front of it.

## Change

Adds a new optional job `create-mcp-access-app` to `reconcile-dns.yml`, gated behind a `create_mcp_access` workflow_dispatch input (default `false`):

- Idempotent: checks for an existing app by name/domain first and no-ops if one already exists.
- Reuses the existing `goldshore-agents` service token **by UUID lookup**, not a newly-minted one — no other Access app's machine-auth policy is touched.
- Creates the same two policies every other GoldShore Access app already uses: `Goldshore agents` (service-token, non_identity) and `Owner access` (allow, `@goldshore.ai` or `marstonr6@gmail.com`) — matching the existing pattern in `.github/workflows/setup-cf-agent-access.yml`.

## Test plan

- [x] Dispatched with `create_mcp_access: true` (this PR branch) — created Access app `GoldShore MCP` on `mcp.goldshore.ai` with both policies attached, confirmed via API readback.
- [ ] Re-ran with `create_mcp_access: true` again to confirm the idempotent guard no-ops on a second run.
- [ ] Confirmed unauthenticated request to `mcp.goldshore.ai` now gets an Access challenge instead of serving content directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_