### PR TITLE
Fix API Worker secret deployment order

### DIFF
--- a/.github/workflows/deploy-gs-api.yml
+++ b/.github/workflows/deploy-gs-api.yml
@@ -53,6 +53,7 @@ jobs:
           echo "CLOUDFLARE_API_TOKEN=$token" >> "$GITHUB_ENV"
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @goldshore/gs-api build
+      - run: pnpm --filter @goldshore/gs-api run deploy
       - name: Provision gs-api Worker secrets
         working-directory: apps/gs-api
         env:
@@ -84,4 +85,3 @@ jobs:
           NODE
           pnpm exec wrangler secret bulk worker-secrets.json --env prod
           rm worker-secrets.json
-      - run: pnpm --filter @goldshore/gs-api run deploy


### PR DESCRIPTION
Merge strategy: squash

Deploy the latest gs-api Worker version before applying the production secret bundle, as required by Cloudflare Workers Versions (error 10215).

Checks:
- workflow YAML parse
- git diff --check