### PR TITLE
Reconcile consolidated API alias routes

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -221,6 +221,13 @@ jobs:
           reconcile_route goldshore.ai 'admin.goldshore.ai/*' gs-web-prod
           reconcile_route goldshore.ai 'admin-preview.goldshore.ai/*' gs-web-prod
           reconcile_route goldshore.ai 'api.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'agent.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'mail.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'ops.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'trading.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'dashboard.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'dash.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'gw.goldshore.ai/*' gs-api-prod
           reconcile_route goldshore.org 'goldshore.org/*' gs-web-prod
           reconcile_route goldshore.org 'admin.goldshore.org/*' gs-web-prod
           reconcile_route goldshore.org 'api.goldshore.org/*' gs-api-prod
@@ -304,6 +311,13 @@ jobs:
           reconcile_route goldshore.ai 'admin.goldshore.ai/*' gs-web-prod
           reconcile_route goldshore.ai 'admin-preview.goldshore.ai/*' gs-web-prod
           reconcile_route goldshore.ai 'api.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'agent.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'mail.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'ops.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'trading.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'dashboard.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'dash.goldshore.ai/*' gs-api-prod
+          reconcile_route goldshore.ai 'gw.goldshore.ai/*' gs-api-prod
           reconcile_route goldshore.org 'goldshore.org/*' gs-web-prod
           reconcile_route goldshore.org 'admin.goldshore.org/*' gs-web-prod
           reconcile_route goldshore.org 'api.goldshore.org/*' gs-api-prod


### PR DESCRIPTION
Merge strategy: squash

Transfer every consolidated backend hostname to gs-api-prod through the existing route reconciliation workflow. This resolves Cloudflare route conflicts with retired Workers before the canonical API deployment.

Checks:
- workflow YAML parse
- git diff --check