### PR TITLE
Declare agent API DNS alias

### DIFF
--- a/infra/Cloudflare/desired-state.yaml
+++ b/infra/Cloudflare/desired-state.yaml
@@ -61,6 +61,10 @@ cloudflare:
         type: CNAME
         content: "gs-api-prod.goldshore.workers.dev"
         proxied: true
+      - name: "agent"
+        type: CNAME
+        content: "gs-api-prod.goldshore.workers.dev"
+        proxied: true
 
       # D. API Worker
       # No DNS record previously existed for api.goldshore.ai at all -- the


### PR DESCRIPTION
Merge strategy: squash

Add the missing proxied agent.goldshore.ai CNAME to the authoritative Cloudflare desired state. Its Access policy and gs-api-prod Worker route already exist.

Checks:
- desired-state YAML parse
- git diff --check