### PR TITLE
Fix homepage mobile overflow and access link behavior

### DIFF
--- a/apps/gs-web/src/pages/index.astro
+++ b/apps/gs-web/src/pages/index.astro
@@ -383,7 +383,7 @@ export async function verifyAccess(req, env) {
         <strong>MCP</strong>
         <span>Model Context Protocol</span>
       </a>
-      <a href="https://api.goldshore.ai" class="modal-card" rel="noopener noreferrer" target="_blank">
+      <a href="https://api.goldshore.ai" class="modal-card">
         <span class="modal-icon">◉</span>
         <strong>API</strong>
         <span>Developer access</span>

--- a/apps/gs-web/src/styles/home-theme.css
+++ b/apps/gs-web/src/styles/home-theme.css
@@ -646,7 +646,10 @@ h2 {
 
 /* ── Marquee ──────────────────────────────────────────────────────────────── */
 .marquee {
-  overflow: hidden;
+  width: 100%;
+  max-width: 100vw;
+  overflow: clip;
+  contain: inline-size;
   border-block: 1px solid var(--b1);
   background: var(--ox-dim);
 }


### PR DESCRIPTION
Merge strategy: squash

Constrain the animated homepage marquee so its max-content track cannot expand the mobile document width. Keep the API access destination in the current tab, consistent with the rest of the login CTA.