### PR TITLE
Fix navigation and dynamic slug page display

### DIFF
--- a/apps/gs-web/src/layouts/GoldShoreShell.astro
+++ b/apps/gs-web/src/layouts/GoldShoreShell.astro
@@ -1,48 +1,14 @@
 ---
 import '../styles/global.css';
 import '../styles/public-theme.css';
+import { primaryNavLinks, platformLinks, serviceLinks, companyLinks } from '../config/navigation';
 
-const navLinks = [
-  { href: '/platform/', label: 'Platform' },
-  { href: '/risk-radar/', label: 'Risk Radar' },
-  { href: '/services/', label: 'Services' },
-  { href: '/developer/', label: 'Developer' },
-  { href: '/about/', label: 'About' },
-  { href: '/team/', label: 'Team' },
-  { href: '/contact/', label: 'Contact' },
-];
+const navLinks = primaryNavLinks;
 
 const footerColumns = [
-  {
-    title: 'Platform',
-    links: [
-      { href: '/risk-radar/', label: 'Risk Radar' },
-      { href: '/platform/financial-signals', label: 'Financial Signals' },
-      { href: '/platform/workflow-engine', label: 'Workflow Engine' },
-      { href: '/platform/sentinel', label: 'Sentinel' },
-      { href: '/platform/ai-oracle', label: 'AI Oracle' },
-    ],
-  },
-  {
-    title: 'Services',
-    links: [
-      { href: '/services/digital-strategy', label: 'Digital Strategy' },
-      { href: '/services/ai-implementation', label: 'AI Implementation' },
-      { href: '/services/systems-integration', label: 'Systems Integration' },
-      { href: '/services/design-dev', label: 'Design & Development' },
-      { href: '/services/consulting', label: 'Enterprise Consulting' },
-    ],
-  },
-  {
-    title: 'Company',
-    links: [
-      { href: '/about/', label: 'About' },
-      { href: '/team/', label: 'Team' },
-      { href: '/developer/', label: 'Developer Hub' },
-      { href: '/status/', label: 'Status' },
-      { href: '/contact/', label: 'Contact' },
-    ],
-  },
+  { title: 'Platform', links: platformLinks },
+  { title: 'Services', links: serviceLinks },
+  { title: 'Company', links: companyLinks },
 ];
 
 const {
@@ -55,8 +21,17 @@ const {
 
 const canonicalUrl = new URL(canonicalPath, 'https://goldshore.ai').toString();
 const socialImageUrl = new URL('/logo.png', 'https://goldshore.ai').toString();
-const activePath = Astro.url.pathname.endsWith('/') ? Astro.url.pathname : `${Astro.url.pathname}/`;
-const isCurrent = (href: string) => activePath === href;
+const normalizePath = (path: string) => {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return normalized === '/' ? '/' : `${normalized.replace(/\/+$/, '')}/`;
+};
+const activePath = normalizePath(Astro.url.pathname);
+const isCurrent = (href: string) => {
+  const normalizedHref = normalizePath(href);
+  return normalizedHref === '/'
+    ? activePath === '/'
+    : activePath === normalizedHref || activePath.startsWith(normalizedHref);
+};
 ---
 
 <html lang="en">

--- a/apps/gs-web/src/pages/[...path].astro
+++ b/apps/gs-web/src/pages/[...path].astro
@@ -35,23 +35,34 @@ if (slug) {
 
 {page ? (
   page.status === 'disabled' ? (
-    <BaseLayout title={`Page Disabled | GoldShore`}>
-      <section class="max-w-4xl mx-auto py-24 px-6 text-center">
-        <h1 class="text-4xl gs-heading mb-6" style="color: var(--gs-brand-gold);">Page Disabled</h1>
-        <p class="text-lg text-[var(--gs-text-secondary)] mb-8">
-          This page is currently disabled. Please check back later or contact support.
-        </p>
-        <a href="/" class="text-[var(--gs-brand-gold)] hover:underline">Return to GoldShore Home</a>
+    <BaseLayout
+      title="Page Disabled | GoldShore"
+      description="This GoldShore page is currently unavailable."
+      canonicalPath={`/${slug}/`}
+    >
+      <section class="gs-section gs-slug-page gs-slug-page--message" aria-labelledby="disabled-page-title">
+        <div class="gs-slug-page__inner">
+          <p class="gs-eyebrow">GoldShore</p>
+          <h1 id="disabled-page-title">Page Disabled</h1>
+          <p class="page-intro">This page is currently disabled. Please check back later or contact support.</p>
+          <a href="/" class="gs-slug-page__action">Return to GoldShore Home</a>
+        </div>
       </section>
     </BaseLayout>
   ) : (
-    <BaseLayout title={`${page.title} | GoldShore`}>
-      <section class="max-w-5xl mx-auto py-16 px-6">
-        <header class="mb-10">
-          <p class="text-sm uppercase tracking-[0.3em] text-[var(--gs-text-tertiary)]">GoldShore</p>
-          <h1 class="text-4xl gs-heading mt-3">{page.title}</h1>
-        </header>
-        <article class="prose prose-invert max-w-none" set:html={page.body} />
+    <BaseLayout
+      title={`${page.title} | GoldShore`}
+      description={`GoldShore information page: ${page.title}`}
+      canonicalPath={`/${page.slug || slug}/`}
+    >
+      <section class="gs-section gs-slug-page" aria-labelledby="slug-page-title">
+        <div class="gs-slug-page__inner">
+          <header class="gs-slug-page__header">
+            <p class="gs-eyebrow">GoldShore</p>
+            <h1 id="slug-page-title">{page.title}</h1>
+          </header>
+          <article class="gs-rich-content" set:html={page.body} />
+        </div>
       </section>
     </BaseLayout>
   )

--- a/apps/gs-web/src/styles/public-theme.css
+++ b/apps/gs-web/src/styles/public-theme.css
@@ -15,7 +15,7 @@
 }
 
 .gs-shell-v284 .gs-page-content {
-  overflow: clip;
+  overflow-x: clip;
   isolation: isolate;
 }
 
@@ -34,6 +34,10 @@
 .gs-shell-v284 :is(.gs-hero, .gs-section, .page-shell) {
   width: min(calc(100% - 2rem), var(--gs-max-width, 1180px));
   margin-inline: auto;
+}
+
+.gs-shell-v284 :is(.gs-hero, .gs-section, .page-shell, .gs-grid, .info-grid, .service-grid) > * {
+  min-width: 0;
 }
 
 .gs-shell-v284 .gs-flow-section {
@@ -106,6 +110,119 @@
   box-shadow: 0 22px 55px rgba(0, 0, 0, 0.22);
 }
 
+.gs-shell-v284 .gs-slug-page {
+  padding-block: clamp(3.5rem, 8vw, 7rem);
+}
+
+.gs-shell-v284 .gs-slug-page__inner {
+  width: min(100%, 900px);
+  margin-inline: auto;
+}
+
+.gs-shell-v284 .gs-slug-page__header {
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
+}
+
+.gs-shell-v284 .gs-slug-page__header h1,
+.gs-shell-v284 .gs-slug-page--message h1 {
+  max-width: 18ch;
+  margin-top: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.gs-shell-v284 .gs-slug-page--message {
+  min-height: 60vh;
+  display: grid;
+  align-items: center;
+  text-align: center;
+}
+
+.gs-shell-v284 .gs-slug-page--message :is(h1, .page-intro) {
+  margin-inline: auto;
+}
+
+.gs-shell-v284 .gs-slug-page__action {
+  display: inline-flex;
+  margin-top: 1.5rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(240, 145, 84, 0.45);
+  color: var(--gs-public-oxide-bright);
+  text-decoration: none;
+}
+
+.gs-shell-v284 .gs-rich-content {
+  max-width: 100%;
+  color: var(--gs-public-text);
+  font-size: 1rem;
+  line-height: 1.75;
+  overflow-wrap: anywhere;
+}
+
+.gs-shell-v284 .gs-rich-content > :first-child {
+  margin-top: 0;
+}
+
+.gs-shell-v284 .gs-rich-content > :last-child {
+  margin-bottom: 0;
+}
+
+.gs-shell-v284 .gs-rich-content :is(p, ul, ol, blockquote, pre, table, figure) {
+  margin-block: 1.25rem;
+}
+
+.gs-shell-v284 .gs-rich-content :is(h2, h3, h4) {
+  margin-top: 2.2rem;
+  margin-bottom: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.gs-shell-v284 .gs-rich-content a {
+  color: var(--gs-public-oxide-bright);
+  text-underline-offset: 0.2em;
+}
+
+.gs-shell-v284 .gs-rich-content img,
+.gs-shell-v284 .gs-rich-content video,
+.gs-shell-v284 .gs-rich-content iframe,
+.gs-shell-v284 .gs-rich-content svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.gs-shell-v284 .gs-rich-content iframe {
+  width: 100%;
+  min-height: min(56vw, 32rem);
+  border: 0;
+}
+
+.gs-shell-v284 .gs-rich-content pre,
+.gs-shell-v284 .gs-rich-content table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.gs-shell-v284 .gs-rich-content pre {
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.gs-shell-v284 .gs-rich-content code {
+  font-family: 'DM Mono', ui-monospace, monospace;
+}
+
+.gs-shell-v284 .gs-rich-content table {
+  display: block;
+  border-collapse: collapse;
+}
+
+.gs-shell-v284 .gs-rich-content :is(th, td) {
+  padding: 0.7rem 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  text-align: left;
+}
+
 .gs-shell-v284 [data-depth]::after {
   content: '';
   position: absolute;
@@ -154,6 +271,10 @@
 
   .gs-shell-v284 h1 {
     font-size: clamp(2.35rem, 14vw, 4rem);
+  }
+
+  .gs-shell-v284 .gs-rich-content :is(pre, table) {
+    margin-inline: -0.25rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- use the canonical navigation configuration in `GoldShoreShell`
- keep parent navigation items active on nested routes
- replace utility-only markup in the dynamic `[...path]` template with existing GoldShore shell classes
- add responsive rich-content styling for generated page bodies, including long text, media, code blocks, and tables
- prevent nested grid and page content from creating horizontal overflow

## Scope
This PR targets pages reachable from the primary navigation and CMS-backed `/$slug` routes without redesigning the existing GoldShore visual system.

## Local verification
Run from the Linux/Debian development environment:

```bash
pnpm --filter @goldshore/gs-web dev --port 4321
```

Then review:
- `/`
- `/platform/` and nested platform routes
- `/services/` and nested service routes
- `/developer/`
- `/about/`
- a CMS-backed dynamic slug route
- mobile widths around 360–640px

## Notes
The branch intentionally leaves unrelated content collection, adapter, lockfile, and Goldclaw naming warnings unchanged.