### PR TITLE
Cloudflare-backed Gold Shore admin control plane

### DIFF
--- a/apps/gs-admin/src/components/Sidebar.astro
+++ b/apps/gs-admin/src/components/Sidebar.astro
@@ -14,21 +14,22 @@ const systemLinks: Array<{ href: string; label: string }> = [
   { href: '/admin/system/pages', label: 'Pages' },
 ];
 
+const operationsLinks: Array<{ href: string; label: string }> = [
+  { href: '/admin/platform', label: 'Control Plane' },
+  { href: '/admin/workflows', label: 'API Workflows' },
+  { href: '/admin/customer-email', label: 'Customer Email' },
+  { href: '/admin/subscribe', label: 'Subscribe CTA' },
+  { href: '/admin/contact-forms', label: 'Contact Forms' },
+  { href: '/admin/pages', label: 'Custom Pages' },
+];
+
 const { logo, permissions = [] } = Astro.props;
 
-// Enhanced active state detection for nested routes
 const isActive = (href: string) => {
   const currentPath = Astro.url.pathname;
-
-  // Clean trailing slashes for consistent comparison
   const cleanCurrent = currentPath.endsWith('/') ? currentPath.slice(0, -1) : currentPath;
   const cleanHref = href.endsWith('/') ? href.slice(0, -1) : href;
-
-  // Exact match
   if (cleanCurrent === cleanHref) return true;
-
-  // Nested match (e.g., /admin/system/details starts with /admin/system)
-  // Ensure we don't partial match distinct roots (e.g. /admin/user vs /admin/users)
   return cleanCurrent.startsWith(cleanHref + '/');
 };
 ---
@@ -52,6 +53,17 @@ const isActive = (href: string) => {
     >
       Dashboard
     </a>
+
+    <div class="gs-nav-group-label">Operations</div>
+    {operationsLinks.map((link) => (
+      <a
+        class={`gs-nav-block gs-nav-block--sub ${isActive(link.href) ? 'active' : ''}`}
+        href={link.href}
+        aria-current={isActive(link.href) ? 'page' : undefined}
+      >
+        {link.label}
+      </a>
+    ))}
 
     <div class="gs-nav-group-label">Workers</div>
     {workerLinks.map((link) => (

--- a/apps/gs-admin/src/pages/admin/[manager].astro
+++ b/apps/gs-admin/src/pages/admin/[manager].astro
@@ -1,0 +1,96 @@
+---
+import AdminLayout from '../../layouts/AdminLayout.astro';
+
+const managers = {
+  workflows: {
+    title: 'API Workflows',
+    description: 'Design, trigger, observe, retry, and audit multi-step operations across gs-api and Cloudflare Workflows.',
+    primary: 'Create workflow',
+    items: ['Customer onboarding', 'Contact-form dispatch', 'Subscription activation', 'R2 export generation'],
+    fields: ['Trigger', 'Worker route', 'Retry policy', 'Timeout', 'Audit destination'],
+  },
+  'customer-email': {
+    title: 'Customer Email',
+    description: 'Manage transactional templates, delivery routes, suppression controls, and customer-message history.',
+    primary: 'Create template',
+    items: ['Welcome email', 'Contact confirmation', 'Subscription receipt', 'Support follow-up'],
+    fields: ['Sender identity', 'Reply-to', 'Template key', 'Delivery worker', 'Retention policy'],
+  },
+  subscribe: {
+    title: 'Subscribe CTA',
+    description: 'Configure public subscription calls to action, plan destinations, consent language, and conversion tracking.',
+    primary: 'Create CTA',
+    items: ['Homepage hero', 'Service-page footer', 'Customer portal upgrade', 'Newsletter signup'],
+    fields: ['Headline', 'Supporting copy', 'Button label', 'Destination', 'Analytics event'],
+  },
+  'contact-forms': {
+    title: 'Contact Forms',
+    description: 'Build customer intake forms backed by gs-api, D1, spam controls, email dispatch, and audit records.',
+    primary: 'Create form',
+    items: ['General inquiry', 'Managed infrastructure', 'API consultation', 'Customer support'],
+    fields: ['Schema', 'API endpoint', 'D1 table', 'Notification route', 'Retention window'],
+  },
+  pages: {
+    title: 'Custom Pages',
+    description: 'Create reusable pages with content blocks, routes, metadata, publishing state, and R2-hosted media.',
+    primary: 'Create page',
+    items: ['Landing page', 'Service page', 'Campaign page', 'Legal page'],
+    fields: ['Route', 'Template', 'SEO metadata', 'Content source', 'Publish target'],
+  },
+} as const;
+
+type ManagerKey = keyof typeof managers;
+
+export function getStaticPaths() {
+  return Object.keys(managers).map((manager) => ({ params: { manager } }));
+}
+
+const { manager } = Astro.params as { manager: ManagerKey };
+const config = managers[manager];
+---
+
+<AdminLayout title={config.title}>
+  <header class="page-header">
+    <div>
+      <a href="/admin/platform">← Control Plane</a>
+      <p class="eyebrow">Manager template</p>
+      <h1>{config.title}</h1>
+      <p>{config.description}</p>
+    </div>
+    <button type="button">{config.primary}</button>
+  </header>
+
+  <section class="grid">
+    <article class="panel inventory">
+      <div class="heading"><h2>Configured items</h2><span>{config.items.length}</span></div>
+      <div class="list">
+        {config.items.map((item, index) => (
+          <button class="item" type="button">
+            <span><strong>{item}</strong><small>Draft configuration</small></span>
+            <code>#{String(index + 1).padStart(2, '0')}</code>
+          </button>
+        ))}
+      </div>
+    </article>
+
+    <article class="panel editor">
+      <div class="heading"><h2>Configuration editor</h2><span class="status">Template</span></div>
+      <form>
+        {config.fields.map((field) => (
+          <label>{field}<input name={field.toLowerCase().replaceAll(' ', '-')} placeholder={`Configure ${field.toLowerCase()}`} /></label>
+        ))}
+        <label>Notes<textarea rows="5" placeholder="Operational notes, ownership, and rollout details"></textarea></label>
+        <div class="actions"><button type="button" class="secondary">Save draft</button><button type="button">Publish configuration</button></div>
+      </form>
+    </article>
+  </section>
+
+  <section class="panel architecture">
+    <div class="heading"><h2>Default Cloudflare flow</h2><span class="status">Reference</span></div>
+    <div class="flow"><code>admin.goldshore.org</code><span>→</span><code>gs-api</code><span>→</span><code>D1 / R2 / Workflows</code><span>→</span><code>Audit + customer email</code></div>
+  </section>
+</AdminLayout>
+
+<style>
+  .page-header{display:flex;align-items:flex-end;justify-content:space-between;gap:2rem;padding:2.25rem}.page-header>a,.page-header a{color:#7cc7ff;text-decoration:none}.page-header h1{font-size:clamp(2.2rem,5vw,4rem);line-height:1;margin:.35rem 0}.page-header p{max-width:780px;color:#97a9bd}.eyebrow{text-transform:uppercase;letter-spacing:.14em;font-size:.7rem;color:#f59e0b;font-weight:800}.grid{display:grid;grid-template-columns:minmax(280px,.75fr) minmax(420px,1.25fr);gap:1rem;margin:0 2.25rem 1rem}.panel{border:1px solid #1d3148;border-radius:1rem;background:#081522;padding:1.2rem}.architecture{margin:0 2.25rem 2.25rem}.heading,.actions,.flow{display:flex;align-items:center}.heading{justify-content:space-between;border-bottom:1px solid #1d3148;padding-bottom:.8rem;margin-bottom:1rem}.heading h2{margin:0;font-size:1rem}.heading>span,.status{color:#94cfff;font-size:.72rem;border:1px solid #294c6d;border-radius:999px;padding:.2rem .5rem}.list{display:grid;gap:.65rem}.item{display:flex;justify-content:space-between;text-align:left;width:100%;padding:.9rem;border:1px solid #203a54;border-radius:.7rem;background:#07111d;color:#e8f1fb;cursor:pointer}.item small{display:block;color:#7f93aa;margin-top:.25rem}.item code{color:#f59e0b}form{display:grid;gap:.8rem}label{display:grid;gap:.35rem;color:#9eb0c4;font-size:.78rem}input,textarea{box-sizing:border-box;width:100%;border:1px solid #29425f;background:#07111d;color:#edf5ff;border-radius:.55rem;padding:.72rem;font:inherit}button{border:1px solid #f59e0b;background:#d97706;color:#07111d;border-radius:.65rem;padding:.75rem 1rem;font:inherit;font-weight:750;cursor:pointer}.actions{justify-content:flex-end;gap:.75rem}.secondary{background:#0b1b2b;border-color:#29425f;color:#dce8f5}.flow{justify-content:center;gap:1rem;flex-wrap:wrap;padding:1rem}.flow code{border:1px solid #29425f;border-radius:.55rem;padding:.6rem;color:#f4b455;background:#07111d}@media(max-width:850px){.page-header{align-items:flex-start;flex-direction:column;padding:1.25rem}.grid{grid-template-columns:1fr;margin:0 1.25rem 1rem}.architecture{margin:0 1.25rem 1.25rem}}
+</style>

--- a/apps/gs-admin/src/pages/admin/platform.astro
+++ b/apps/gs-admin/src/pages/admin/platform.astro
@@ -1,0 +1,133 @@
+---
+import AdminLayout from '../../layouts/AdminLayout.astro';
+
+const services = [
+  { name: 'gs-web', kind: 'Pages', host: 'goldshore.org', status: 'Connected', href: 'https://goldshore.org' },
+  { name: 'gs-api', kind: 'Worker', host: 'api.goldshore.ai', status: 'Connected', href: 'https://api.goldshore.ai' },
+  { name: 'Admin', kind: 'Access app', host: 'admin.goldshore.org', status: 'Protected', href: 'https://admin.goldshore.org' },
+  { name: 'Admin AI', kind: 'Access app', host: 'admin.goldshore.ai', status: 'Protected', href: 'https://admin.goldshore.ai' },
+];
+
+const modules = [
+  { title: 'Settings', description: 'Environment variables, secrets, domains, Access policy, notifications, and runtime compatibility.', href: '/admin/settings', action: 'Open settings' },
+  { title: 'API workflows', description: 'Inspect endpoints, gateway routes, triggers, retries, queues, and orchestration state.', href: '/admin/workflows', action: 'Manage workflows' },
+  { title: 'Customer email', description: 'Templates, transactional delivery, suppression state, inbound routing, and campaign handoff.', href: '/admin/customer-email', action: 'Manage email' },
+  { title: 'Subscribe CTA', description: 'Configure plan copy, CTA placement, checkout target, consent text, and conversion events.', href: '/admin/subscribe', action: 'Edit CTA' },
+  { title: 'Contact forms', description: 'Form schema, spam controls, routing, notifications, retention, and CRM dispatch.', href: '/admin/contact-forms', action: 'Manage forms' },
+  { title: 'Custom pages', description: 'Create and publish reusable landing, service, legal, campaign, and customer pages.', href: '/admin/pages', action: 'Open page manager' },
+];
+
+const resources = [
+  { name: 'D1', purpose: 'Customers, forms, subscriptions, content metadata, audit records', binding: 'DB' },
+  { name: 'R2', purpose: 'Uploads, exports, customer assets, generated documents, page media', binding: 'ASSETS' },
+  { name: 'Jobs', purpose: 'Scheduled maintenance, email dispatch, cleanup, reporting', binding: 'JOBS' },
+  { name: 'Workflows', purpose: 'Durable multi-step API and customer operations', binding: 'WORKFLOWS' },
+  { name: 'Pipelines', purpose: 'Event ingestion, transformation, analytics, and downstream delivery', binding: 'PIPELINES' },
+];
+---
+
+<AdminLayout title="Cloudflare Control Plane">
+  <header class="hero">
+    <div>
+      <p class="eyebrow">Gold Shore Admin</p>
+      <h1>Cloudflare control plane</h1>
+      <p class="lede">One protected workspace for gs-web, gs-api, identity, customer operations, storage, automation, and custom publishing.</p>
+    </div>
+    <div class="hero-actions">
+      <a class="button primary" href="https://admin.goldshore.org/dashboard">Open production dashboard</a>
+      <a class="button" href="https://admin.goldshore.ai">Open admin.goldshore.ai</a>
+    </div>
+  </header>
+
+  <section class="panel">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Identity and routing</p>
+        <h2>Cloudflare Access entry points</h2>
+      </div>
+      <span class="badge">IDP protected</span>
+    </div>
+    <div class="route-flow">
+      <div class="route-node"><strong>goldshore.org/login</strong><span>Public login gateway</span></div>
+      <span class="arrow">→</span>
+      <div class="route-node"><strong>Cloudflare Access</strong><span>Identity provider + policy</span></div>
+      <span class="arrow">→</span>
+      <div class="route-node"><strong>Admin dashboard</strong><span>admin.goldshore.org/dashboard</span></div>
+    </div>
+    <p class="note">Allowlisted destinations: admin.goldshore.org, admin.goldshore.org/dashboard, and admin.goldshore.ai. Cloudflare Access should enforce authentication at the admin hostnames rather than trusting a client-side session.</p>
+  </section>
+
+  <section class="service-grid" aria-label="Connected services">
+    {services.map((service) => (
+      <a class="service-card" href={service.href} target="_blank" rel="noreferrer">
+        <div class="service-top"><span>{service.kind}</span><span class="status">{service.status}</span></div>
+        <h2>{service.name}</h2>
+        <code>{service.host}</code>
+      </a>
+    ))}
+  </section>
+
+  <section class="panel">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Application managers</p>
+        <h2>Operational workspace</h2>
+      </div>
+    </div>
+    <div class="module-grid">
+      {modules.map((module) => (
+        <article class="module-card">
+          <h3>{module.title}</h3>
+          <p>{module.description}</p>
+          <a href={module.href}>{module.action} →</a>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="panel">
+    <div class="section-heading">
+      <div>
+        <p class="eyebrow">Cloudflare resources</p>
+        <h2>Bindings and execution</h2>
+      </div>
+      <a class="text-link" href="/admin/system/storage">View storage</a>
+    </div>
+    <div class="resource-table" role="table" aria-label="Cloudflare resources">
+      <div class="resource-row header" role="row"><span>Resource</span><span>Purpose</span><span>Binding</span></div>
+      {resources.map((resource) => (
+        <div class="resource-row" role="row">
+          <strong>{resource.name}</strong><span>{resource.purpose}</span><code>{resource.binding}</code>
+        </div>
+      ))}
+    </div>
+  </section>
+
+  <section class="split">
+    <article class="panel">
+      <p class="eyebrow">Customer acquisition</p>
+      <h2>Subscribe CTA template</h2>
+      <div class="preview-card">
+        <span class="badge">Gold Shore</span>
+        <h3>Turn infrastructure into an operating system.</h3>
+        <p>Subscribe for managed automation, secure customer workflows, and a unified Cloudflare-backed control plane.</p>
+        <button type="button">Subscribe</button>
+      </div>
+    </article>
+    <article class="panel">
+      <p class="eyebrow">Inbound operations</p>
+      <h2>Contact form template</h2>
+      <form class="form-preview">
+        <label>Name<input name="name" autocomplete="name" placeholder="Customer name" /></label>
+        <label>Email<input name="email" type="email" autocomplete="email" placeholder="name@example.com" /></label>
+        <label>Request type<select name="type"><option>General inquiry</option><option>API workflow</option><option>Managed infrastructure</option><option>Support</option></select></label>
+        <label>Message<textarea name="message" rows="4" placeholder="Describe the request"></textarea></label>
+        <button type="button">Send to gs-api</button>
+      </form>
+    </article>
+  </section>
+</AdminLayout>
+
+<style>
+  .hero,.section-heading,.service-top,.route-flow,.hero-actions{display:flex;align-items:center}.hero{justify-content:space-between;gap:2rem;padding:2.25rem}.hero h1{font-size:clamp(2rem,5vw,4.5rem);line-height:.95;margin:.4rem 0 1rem}.lede{max-width:760px;color:#9fb0c6;font-size:1.05rem}.hero-actions{gap:.75rem;flex-wrap:wrap}.button,button{border:1px solid #29425f;background:#0b1726;color:#e8f0fb;border-radius:.7rem;padding:.75rem 1rem;text-decoration:none;font:inherit;cursor:pointer}.button.primary,button{background:#d97706;border-color:#f59e0b;color:#070b10;font-weight:700}.panel{margin:0 2.25rem 1.25rem;padding:1.35rem;border:1px solid #1d3148;border-radius:1rem;background:linear-gradient(145deg,rgba(12,24,39,.96),rgba(6,14,24,.96))}.section-heading{justify-content:space-between;gap:1rem;margin-bottom:1rem}.section-heading h2,.panel h2{margin:.2rem 0}.eyebrow{text-transform:uppercase;letter-spacing:.14em;font-size:.72rem;color:#f59e0b;font-weight:700}.badge,.status{border:1px solid #34516f;border-radius:999px;padding:.25rem .55rem;font-size:.72rem;color:#a8d4ff}.route-flow{gap:1rem;justify-content:center;flex-wrap:wrap;padding:1rem}.route-node{min-width:210px;padding:1rem;border:1px solid #29425f;border-radius:.8rem;background:#07111d}.route-node span{display:block;color:#8ea3bb;font-size:.78rem;margin-top:.35rem}.arrow{color:#f59e0b;font-size:1.5rem}.note{color:#8ea3bb;font-size:.84rem}.service-grid,.module-grid,.split{display:grid;gap:1rem}.service-grid{grid-template-columns:repeat(4,minmax(0,1fr));margin:0 2.25rem 1.25rem}.service-card,.module-card{border:1px solid #1d3148;border-radius:1rem;background:#091522;padding:1.1rem;text-decoration:none;color:inherit}.service-card:hover,.module-card:hover{border-color:#d97706}.service-top{justify-content:space-between;color:#8ea3bb;font-size:.75rem}.service-card h2{margin:1rem 0 .3rem}.service-card code,.resource-row code{color:#f5b85b}.module-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.module-card p{color:#8ea3bb;min-height:4.2rem}.module-card a,.text-link{color:#7cc7ff;text-decoration:none}.resource-table{display:grid}.resource-row{display:grid;grid-template-columns:140px 1fr 140px;gap:1rem;padding:.85rem;border-top:1px solid #1d3148;align-items:center}.resource-row.header{border-top:0;color:#7990aa;font-size:.72rem;text-transform:uppercase}.split{grid-template-columns:1fr 1fr;margin:0 0 2.25rem}.split .panel{margin-bottom:0}.preview-card{border:1px solid #29425f;border-radius:.9rem;padding:1.25rem;background:radial-gradient(circle at top right,rgba(217,119,6,.16),transparent 45%),#07111d}.preview-card h3{font-size:1.65rem;margin:.8rem 0}.preview-card p{color:#9fb0c6}.form-preview{display:grid;gap:.85rem}.form-preview label{display:grid;gap:.35rem;color:#9fb0c6;font-size:.78rem}.form-preview input,.form-preview select,.form-preview textarea{width:100%;box-sizing:border-box;border:1px solid #29425f;background:#07111d;color:#e8f0fb;border-radius:.55rem;padding:.7rem;font:inherit}@media(max-width:1050px){.service-grid{grid-template-columns:repeat(2,1fr)}.module-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:720px){.hero{align-items:flex-start;flex-direction:column;padding:1.25rem}.panel,.service-grid{margin-left:1.25rem;margin-right:1.25rem}.service-grid,.module-grid,.split{grid-template-columns:1fr}.resource-row{grid-template-columns:1fr}.resource-row.header{display:none}}
+</style>

--- a/apps/gs-web/src/pages/login.astro
+++ b/apps/gs-web/src/pages/login.astro
@@ -1,0 +1,38 @@
+---
+const requested = Astro.url.searchParams.get('to') ?? 'dashboard';
+const destinations: Record<string, string> = {
+  dashboard: 'https://admin.goldshore.org/dashboard',
+  admin: 'https://admin.goldshore.org',
+  ai: 'https://admin.goldshore.ai',
+};
+const destination = destinations[requested] ?? destinations.dashboard;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta http-equiv="refresh" content={`2;url=${destination}`} />
+    <title>Gold Shore Admin Login</title>
+  </head>
+  <body>
+    <main>
+      <div class="mark" aria-hidden="true">GS</div>
+      <p class="eyebrow">Gold Shore Identity Gateway</p>
+      <h1>Continue to the protected admin workspace.</h1>
+      <p>Cloudflare Access will verify your identity before loading the dashboard.</p>
+      <a href={destination}>Continue with Cloudflare Access</a>
+      <nav aria-label="Admin destinations">
+        <a href="https://admin.goldshore.org/dashboard">Dashboard</a>
+        <a href="https://admin.goldshore.org">Admin</a>
+        <a href="https://admin.goldshore.ai">Admin AI</a>
+      </nav>
+    </main>
+  </body>
+</html>
+
+<style>
+  :root{color-scheme:dark;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#050b14;color:#eef5ff}body{margin:0;min-height:100vh;display:grid;place-items:center;background:radial-gradient(circle at 70% 20%,rgba(245,158,11,.13),transparent 35%),linear-gradient(145deg,#050b14,#091827)}main{width:min(620px,calc(100% - 3rem));padding:clamp(1.5rem,5vw,3.5rem);border:1px solid #213b58;border-radius:1.4rem;background:rgba(7,17,29,.9);box-shadow:0 30px 100px rgba(0,0,0,.35)}.mark{width:3.5rem;height:3.5rem;display:grid;place-items:center;border-radius:.9rem;background:#d97706;color:#07101a;font-weight:900;letter-spacing:-.08em}.eyebrow{margin-top:2rem;text-transform:uppercase;letter-spacing:.16em;font-size:.72rem;color:#f3a62c;font-weight:800}h1{font-size:clamp(2rem,7vw,4.5rem);line-height:.95;letter-spacing:-.05em;margin:.65rem 0 1.1rem}p{color:#9db0c5;line-height:1.6}main>a{display:inline-block;margin-top:1rem;padding:.85rem 1rem;border-radius:.7rem;background:#d97706;color:#08111c;text-decoration:none;font-weight:800}nav{display:flex;gap:1rem;flex-wrap:wrap;margin-top:2rem;padding-top:1rem;border-top:1px solid #213b58}nav a{color:#8dccff;text-decoration:none;font-size:.82rem}
+</style>


### PR DESCRIPTION
## Summary
- adds `/login` to `gs-web` as a safe allowlisted gateway into Cloudflare Access
- adds `/admin/platform` as the unified gs-web / gs-api / identity / storage / automation control-plane template
- adds reusable manager templates for API workflows, customer email, subscribe CTAs, contact forms, and custom pages
- exposes the new operations managers in the gs-admin sidebar

## Cloudflare configuration expected
- protect `admin.goldshore.org/*` and `admin.goldshore.ai/*` with Cloudflare Access
- configure the chosen IdP and Access allow policy
- bind D1, R2, Workflows, Jobs/cron, and Pipelines to the appropriate Worker/Pages runtime
- route form and manager actions through gs-api rather than trusting browser-side state

## Notes
The uploaded Cloudflare dashboard shows gs-web building from the monorepo with `apps/gs-web/dist`, `PUBLIC_API=https://api.goldshore.ai`, and `PUBLIC_GATEWAY=https://gw.goldshore.ai`; this implementation follows that topology.