### PR TITLE
Fix duplicate GET/PUT export in forms/[slug].ts breaking gs-web build

### DIFF
--- a/apps/gs-web/src/pages/api/forms/[slug].ts
+++ b/apps/gs-web/src/pages/api/forms/[slug].ts
@@ -184,7 +184,3 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
     },
   });
 };
-
-export const GET: APIRoute = async ({ request, locals, params }) => proxy(request, locals.runtime?.env as Env | undefined, params.slug);
-export const PUT: APIRoute = async ({ request, locals, params }) => proxy(request, locals.runtime?.env as Env | undefined, params.slug);
-export const PATCH = PUT;


### PR DESCRIPTION
## Summary
- `apps/gs-web/src/pages/api/forms/[slug].ts` had two full implementations of the same route concatenated by a bad merge: a complete implementation (`GET`/`PUT`) reading and writing `form_configs` directly via `PLATFORM_DB`, with auth/CSRF checks — followed by a second, unrelated `GET`/`PUT`/`PATCH` block that calls a `proxy()` function never imported or defined anywhere in this file.
- Astro's build failed outright on every push with `[PARSE_ERROR] Duplicated export 'GET'`, which was also failing the `gs-web-prod` Cloudflare Workers Build and the `lint-test-build` / `gs-web-build` CI checks — confirmed pre-existing on `main`.
- Removed the dead trailing block (the `proxy()`-based one), keeping the complete, working, self-contained implementation.

## Test plan
- [x] `pnpm --filter gs-web build` completes successfully (previously failed with the duplicate-export parse error)
- [ ] CI (`lint-test-build`, `gs-web-build`) and the `gs-web-prod` Workers Build check should now pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_