### PR TITLE
Restore reconcile-dns.yml after repeated concurrent-merge corruption

### DIFF
--- a/.github/workflows/reconcile-dns.yml
+++ b/.github/workflows/reconcile-dns.yml
@@ -46,88 +46,6 @@ on:
         type: boolean
 
 jobs:
-  diagnostic-mcp-portal:
-    name: DIAGNOSTIC -- mcp.goldshore.ai DNS + Access app type (throwaway, read-only, no PR)
-  apply-safe-dns-fixes:
-    name: 'THROWAWAY -- check whether signals.goldshore.ai is already live via Workers Custom Domain (read-only, no PR)'
-    runs-on: ubuntu-latest
-    permissions: {}
-    env:
-      CF_API: https://api.cloudflare.com/client/v4
-      CF_ACCOUNT: f77de112d2019e5456a3198a8bb50bd2
-      CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    steps:
-      - name: Check account-level Workers Custom Domains for signals.goldshore.ai
-        shell: bash
-        run: |
-          set -euo pipefail
-          auth=(-H "Authorization: Bearer $CF_TOKEN")
-          curl -sS "$CF_API/accounts/$CF_ACCOUNT/workers/domains" "${auth[@]}" \
-            | jq '[.result[]? | select(.hostname == "signals.goldshore.ai")]'
-
-      - name: OLD -- apply www.goldshore.ai, admin-preview.goldshore.ai, mcp.goldshore.ai (already applied, kept for reference)
-        if: false
-        shell: bash
-        run: |
-          set -euo pipefail
-          auth=(-H "Authorization: Bearer $CF_TOKEN")
-
-          api_call() {
-            local method="$1" url="$2" data="${3:-}" resp status body
-            if [ -n "$data" ]; then
-              resp=$(curl -sS -w '\n%{http_code}' -X "$method" "$url" "${auth[@]}" -H 'Content-Type: application/json' --data "$data")
-            else
-              resp=$(curl -sS -w '\n%{http_code}' -X "$method" "$url" "${auth[@]}")
-            fi
-            status="${resp##*$'\n'}"
-            body="${resp%$'\n'*}"
-            if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
-              echo "::error::$method $url failed (HTTP $status): $body" >&2
-              exit 1
-            fi
-            echo "$body"
-          }
-
-          ZID=$(api_call GET "$CF_API/zones?name=goldshore.ai" | jq -r '.result[0].id')
-          test -n "$ZID"
-          echo "goldshore.ai zone: $ZID"
-
-          update_record() {
-            local name="$1" content="$2" proxied="$3" id body
-            id=$(api_call GET "$CF_API/zones/$ZID/dns_records?name=$name&type=CNAME" | jq -r '.result[0].id // empty')
-            if [ -z "$id" ]; then
-              echo "::error::No existing CNAME found for $name -- expected an UPDATE target, not a CREATE. Skipping."
-              return 1
-            fi
-            body=$(jq -nc --arg t CNAME --arg n "$name" --arg c "$content" --argjson p "$proxied" '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
-            api_call PUT "$CF_API/zones/$ZID/dns_records/$id" "$body" >/dev/null
-            echo "Updated $name -> $content [proxied=$proxied]"
-          }
-
-          create_record() {
-            local name="$1" content="$2" proxied="$3" existing body
-            existing=$(api_call GET "$CF_API/zones/$ZID/dns_records?name=$name&type=CNAME" | jq -r '.result[0].id // empty')
-            if [ -n "$existing" ]; then
-              echo "$name already exists ($existing) -- skipping create."
-              return 0
-            fi
-            body=$(jq -nc --arg t CNAME --arg n "$name" --arg c "$content" --argjson p "$proxied" '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
-            api_call POST "$CF_API/zones/$ZID/dns_records" "$body" >/dev/null
-            echo "Created $name -> $content [proxied=$proxied]"
-          }
-
-          update_record "www.goldshore.ai" "goldshore-org.goldshore.workers.dev" true
-          update_record "admin-preview.goldshore.ai" "gs-web-prod.goldshore.workers.dev" false
-          update_record "mcp.goldshore.ai" "goldshore-mcp-prod.goldshore.workers.dev" true
-          create_record "signals.goldshore.ai" "gs-signals-prod.goldshore.workers.dev" true
-
-          echo ""
-          echo "== verifying =="
-          for name in www.goldshore.ai admin-preview.goldshore.ai mcp.goldshore.ai signals.goldshore.ai; do
-            api_call GET "$CF_API/zones/$ZID/dns_records?name=$name&type=CNAME" | \
-              jq -r --arg n "$name" '.result[0] | "\($n): \(.content) [proxied=\(.proxied)]"'
-          done
-
   diagnostic-access-apps:
     name: DIAGNOSTIC -- full Access apps + domains + MCP policy re-check (throwaway, read-only, no PR)
     runs-on: ubuntu-latest
@@ -347,12 +265,10 @@ jobs:
     permissions: {}
     env:
       CF_API: https://api.cloudflare.com/client/v4
-      CF_ACCOUNT: f77de112d2019e5456a3198a8bb50bd2
-      CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_BUILD_API_TOKEN: ${{ secrets.CLOUDFLARE_BUILD_API_TOKEN }}
     steps:
-      - name: Normalize Cloudflare build token
+      - name: Normalize Cloudflare token
         shell: bash
         run: |
           normalize_token() {
@@ -367,23 +283,6 @@ jobs:
           token = token.replace(/^[\`'"]+|[\`'",;}]+$/g, "").replace(/\s/g, "");
           process.stdout.write(token);
           NODE
-          )"
-          if [ -n "$token" ]; then
-            echo "::add-mask::$token"
-            echo "CF_BUILD_TOKEN=$token" >> "$GITHUB_ENV"
-          fi
-
-      - name: Check mcp.goldshore.ai DNS record
-        run: |
-          set -euo pipefail
-          ZID=$(curl -sS "$CF_API/zones?name=goldshore.ai" -H "Authorization: Bearer $CF_TOKEN" | jq -r '.result[0].id // empty')
-          echo "== raw DNS records matching mcp.goldshore.ai =="
-          curl -sS "$CF_API/zones/$ZID/dns_records?name=mcp.goldshore.ai" -H "Authorization: Bearer $CF_TOKEN" | jq '.result'
-
-          echo "== account-level Workers Custom Domains matching mcp =="
-          curl -sS "$CF_API/accounts/$CF_ACCOUNT/workers/domains" -H "Authorization: Bearer $CF_TOKEN" \
-            | jq '[.result[]? | select(.hostname | test("mcp"))]'
-
           }
 
           for source in CLOUDFLARE_API_TOKEN CLOUDFLARE_BUILD_API_TOKEN; do
@@ -508,8 +407,6 @@ jobs:
           curl -sS "$CF_API/accounts/$CF_ACCOUNT/access/apps?per_page=100" \
             -H "Authorization: Bearer $CF_BUILD_TOKEN" \
             | jq '[.result[]? | select((.domain // "" | test("mcp")) or (.name | test("MCP"; "i"))) | {id, name, type, domain, self_hosted_domains}]'
-
-jobs:
   reconcile:
     name: Reconcile DNS records
     runs-on: ubuntu-latest
@@ -528,31 +425,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Extract desired DNS records
-        uses: actions/checkout@v4
-
-      - name: DIAGNOSTIC -- check goldshore-jobs queue consumers and backlog (throwaway, read-only, no PR)
-        run: |
-          set -euo pipefail
-          ACCOUNT_ID="f77de112d2019e5456a3198a8bb50bd2"
-
-          echo "== all Queues in account =="
-          QUEUES=$(curl -sS "$CF_API/accounts/$ACCOUNT_ID/queues" -H "Authorization: Bearer $CF_TOKEN")
-          echo "$QUEUES" | jq '[.result[] | {queue_id, queue_name}]'
-
-          QID=$(echo "$QUEUES" | jq -r '.result[] | select(.queue_name=="goldshore-jobs") | .queue_id')
-          if [ -z "$QID" ]; then
-            echo "::error::Could not find queue_id for goldshore-jobs"
-            exit 0
-          fi
-          echo "goldshore-jobs queue_id: $QID"
-
-          echo "== goldshore-jobs queue detail (consumers, producers) =="
-          curl -sS "$CF_API/accounts/$ACCOUNT_ID/queues/$QID" -H "Authorization: Bearer $CF_TOKEN" | jq '.'
-
-          echo "== goldshore-jobs consumers list =="
-          curl -sS "$CF_API/accounts/$ACCOUNT_ID/queues/$QID/consumers" -H "Authorization: Bearer $CF_TOKEN" | jq '.'
 
       - name: Extract desired DNS records (excluding goldshore.org)
         run: |
@@ -618,13 +490,6 @@ jobs:
           # with code 81062 ("A DNS record managed by Workers already exists
           # on that host"). Skip CREATE for both rather than let every run log
           # a false MISSING/warning pair.
-          # preview.goldshore.ai reports as MISSING via a type=CNAME query
-          # despite being live and working today -- it's provisioned through
-          # a real Workers Custom Domain that doesn't show up as a plain
-          # CNAME through this API. Confirmed: Cloudflare rejected a real
-          # CREATE attempt with code 81062 ("A DNS record managed by Workers
-          # already exists on that host"). Skip CREATE rather than let every
-          # run log a false MISSING/warning pair.
           #
           # goldshore.ai (apex) and api.goldshore.ai are deliberately NOT in
           # this list: verified via the raw Cloudflare API that both have
@@ -650,12 +515,6 @@ jobs:
 
             LIST_RESP=$(curl -sS -w '\n%{http_code}' \
               "$CF_API/zones/$ZID/dns_records?name=$FULL_NAME&type=$TYPE" \
-            TYPE=$(echo "$rec" | jq -r '.type')
-            CONTENT=$(echo "$rec" | jq -r '.content')
-            PROXIED=$(echo "$rec" | jq -r '.proxied')
-
-            LIST_RESP=$(curl -sS -w '\n%{http_code}' \
-              "$CF_API/zones/$ZID_AI/dns_records?name=$FULL_NAME&type=$TYPE" \
               -H "Authorization: Bearer $CF_TOKEN")
             LIST_STATUS="${LIST_RESP##*$'\n'}"
             LIST_BODY="${LIST_RESP%$'\n'*}"
@@ -697,7 +556,6 @@ jobs:
                 '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
               CREATE_RESP=$(echo "$BODY" | curl -sS -w '\n%{http_code}' -X POST \
                 "$CF_API/zones/$ZID/dns_records" \
-                "$CF_API/zones/$ZID_AI/dns_records" \
                 -H "Authorization: Bearer $CF_TOKEN" \
                 -H "Content-Type: application/json" \
                 --data @-)
@@ -726,7 +584,6 @@ jobs:
               '{type:$t,name:$n,content:$c,proxied:$p,ttl:1}')
             UPDATE_RESP=$(echo "$BODY" | curl -sS -w '\n%{http_code}' -X PUT \
               "$CF_API/zones/$ZID/dns_records/$EXISTING_ID" \
-              "$CF_API/zones/$ZID_AI/dns_records/$EXISTING_ID" \
               -H "Authorization: Bearer $CF_TOKEN" \
               -H "Content-Type: application/json" \
               --data @-)


### PR DESCRIPTION
## Summary
Since #5953 merged, further concurrent merges reintroduced the exact same bash syntax error in the "Reconcile records" step (the unresolved `$ZID`/`$ZID_AI` merge conflict from before), plus new damage:

- A duplicated top-level `jobs:` key. `yaml.safe_load` silently keeps only the last occurrence, so a plain YAML check showed only the `reconcile` job existing — a second, larger `jobs:` block full of other jobs sat above it and was being discarded entirely.
- A broken job stub with no fields (`diagnostic-mcp-portal`).
- Steps from the `reconcile-routes` and `harden-tls` jobs scrambled together mid-step, including a stray orphaned `}`.
- Doubled comment blocks.

## Fix
Restored the known-good, already end-to-end validated file from the #5953 merge commit (`35d6e76`) as the base, then removed two throwaway jobs that had also gotten merged in and already served their one-time purpose:
- the `signals.goldshore.ai` Workers Custom Domain check (confirmed live, done)
- a `goldshore-jobs` queue diagnostic step nested inside the `reconcile` job

## Test plan
- [x] Single `jobs:` key confirmed
- [x] Every `run:` block passes `bash -n`
- [x] No leftover `$ZID_AI` or undefined function references
- [ ] Dispatch `reconcile-dns.yml` with `dry_run=true` on this branch to confirm the `reconcile` job runs end-to-end again


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_