### PR TITLE
Add reusable Gold Shore Astro page template

### DIFF
--- a/apps/gs-web/src/components/GoldShorePageTemplate.astro
+++ b/apps/gs-web/src/components/GoldShorePageTemplate.astro
@@ -1,5 +1,6 @@
 ---
 import WebLayout from '../layouts/WebLayout.astro';
+import VibrantHeroField from './hero/VibrantHeroField.astro';
 
 interface Props {
   title: string;
@@ -8,6 +9,7 @@ interface Props {
   eyebrow?: string;
   heading: string;
   intro?: string;
+  heroMotion?: 'none' | 'starfield' | 'parallax';
 }
 
 const {
@@ -17,6 +19,7 @@ const {
   eyebrow,
   heading,
   intro,
+  heroMotion = 'none',
 } = Astro.props;
 
 const hasActions = Astro.slots.has('actions');
@@ -26,6 +29,7 @@ const hasAside = Astro.slots.has('aside');
 <WebLayout {title} {description} {canonicalPath}>
   <article class="gs-template">
     <header class:list={['gs-template__hero', 'gs-shell-section', 'gs-column-grid', { 'has-aside': hasAside }]}>
+      {heroMotion !== 'none' && <VibrantHeroField mode={heroMotion} />}
       <div class="gs-template__hero-copy">
         {eyebrow && <p class="gs-template__eyebrow">{eyebrow}</p>}
         <h1>{heading}</h1>
@@ -50,6 +54,7 @@ const hasAside = Astro.slots.has('aside');
   }
 
   .gs-template__hero {
+    position: relative;
     align-items: end;
     min-height: clamp(30rem, 72vh, 48rem);
     padding-block: clamp(6rem, 13vw, 10rem) clamp(4rem, 8vw, 7rem);
@@ -57,6 +62,8 @@ const hasAside = Astro.slots.has('aside');
   }
 
   .gs-template__hero-copy {
+    position: relative;
+    z-index: 1;
     grid-column: 1 / span 8;
     min-width: 0;
   }
@@ -99,6 +106,8 @@ const hasAside = Astro.slots.has('aside');
   }
 
   .gs-template__aside {
+    position: relative;
+    z-index: 1;
     grid-column: 9 / -1;
     min-width: 0;
     padding: clamp(1.25rem, 3vw, 2rem);

--- a/apps/gs-web/src/components/GoldShorePageTemplate.astro
+++ b/apps/gs-web/src/components/GoldShorePageTemplate.astro
@@ -1,0 +1,143 @@
+---
+import WebLayout from '../layouts/WebLayout.astro';
+
+interface Props {
+  title: string;
+  description: string;
+  canonicalPath?: string;
+  eyebrow?: string;
+  heading: string;
+  intro?: string;
+}
+
+const {
+  title,
+  description,
+  canonicalPath,
+  eyebrow,
+  heading,
+  intro,
+} = Astro.props;
+
+const hasActions = Astro.slots.has('actions');
+const hasAside = Astro.slots.has('aside');
+---
+
+<WebLayout {title} {description} {canonicalPath}>
+  <article class="gs-template">
+    <header class:list={['gs-template__hero', 'gs-shell-section', 'gs-column-grid', { 'has-aside': hasAside }]}>
+      <div class="gs-template__hero-copy">
+        {eyebrow && <p class="gs-template__eyebrow">{eyebrow}</p>}
+        <h1>{heading}</h1>
+        {intro && <p class="gs-template__intro">{intro}</p>}
+        {hasActions && <div class="gs-template__actions"><slot name="actions" /></div>}
+      </div>
+
+      {hasAside && <aside class="gs-template__aside"><slot name="aside" /></aside>}
+    </header>
+
+    <div class="gs-template__body">
+      <slot />
+    </div>
+  </article>
+</WebLayout>
+
+<style>
+  .gs-template {
+    --template-rule: rgba(217, 106, 50, 0.28);
+    min-width: 0;
+    overflow: clip;
+  }
+
+  .gs-template__hero {
+    align-items: end;
+    min-height: clamp(30rem, 72vh, 48rem);
+    padding-block: clamp(6rem, 13vw, 10rem) clamp(4rem, 8vw, 7rem);
+    border-bottom: 1px solid var(--template-rule);
+  }
+
+  .gs-template__hero-copy {
+    grid-column: 1 / span 8;
+    min-width: 0;
+  }
+
+  .gs-template__eyebrow {
+    margin: 0 0 1.25rem;
+    color: var(--gs-primary);
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    max-width: 12ch;
+    margin: 0;
+    color: var(--gs-text);
+    font-family: 'Space Grotesk', 'Inter', system-ui, sans-serif;
+    font-size: clamp(3.25rem, 7.8vw, 7.5rem);
+    font-weight: 700;
+    letter-spacing: -0.055em;
+    line-height: 0.9;
+    overflow-wrap: anywhere;
+    text-transform: uppercase;
+  }
+
+  .gs-template__intro {
+    max-width: 62ch;
+    margin: clamp(1.75rem, 4vw, 3rem) 0 0;
+    color: var(--gs-text-dim);
+    font-size: clamp(1rem, 1.5vw, 1.24rem);
+    line-height: 1.75;
+  }
+
+  .gs-template__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    margin-top: 2rem;
+  }
+
+  .gs-template__aside {
+    grid-column: 9 / -1;
+    min-width: 0;
+    padding: clamp(1.25rem, 3vw, 2rem);
+    border: 1px solid var(--template-rule);
+    background: rgba(13, 13, 19, 0.82);
+  }
+
+  .gs-template__body {
+    display: grid;
+  }
+
+  @media (max-width: 900px) {
+    .gs-template__hero-copy,
+    .gs-template__aside {
+      grid-column: 1 / -1;
+    }
+
+    .gs-template__hero {
+      align-content: end;
+      row-gap: 2.5rem;
+    }
+
+    h1 {
+      font-size: clamp(2.75rem, 13vw, 5.5rem);
+    }
+  }
+
+  @media (max-width: 560px) {
+    .gs-template__hero {
+      min-height: auto;
+      padding-top: 5rem;
+    }
+
+    .gs-template__actions {
+      display: grid;
+    }
+
+    .gs-template__actions :global(*) {
+      width: 100%;
+    }
+  }
+</style>

--- a/apps/gs-web/src/components/GoldShoreSection.astro
+++ b/apps/gs-web/src/components/GoldShoreSection.astro
@@ -1,0 +1,144 @@
+---
+interface Props {
+  id?: string;
+  eyebrow?: string;
+  heading?: string;
+  intro?: string;
+  columns?: 1 | 2 | 3 | 4;
+  tone?: 'default' | 'surface' | 'accent';
+  compact?: boolean;
+}
+
+const {
+  id,
+  eyebrow,
+  heading,
+  intro,
+  columns = 1,
+  tone = 'default',
+  compact = false,
+} = Astro.props;
+---
+
+<section
+  {id}
+  class:list={[
+    'gs-template-section',
+    `gs-template-section--${tone}`,
+    { 'gs-template-section--compact': compact },
+  ]}
+>
+  <div class="gs-shell-section gs-column-grid">
+    {(eyebrow || heading || intro) && (
+      <header class="gs-template-section__header">
+        {eyebrow && <p>{eyebrow}</p>}
+        {heading && <h2>{heading}</h2>}
+        {intro && <div>{intro}</div>}
+      </header>
+    )}
+
+    <div class={`gs-template-section__content columns-${columns}`}>
+      <slot />
+    </div>
+  </div>
+</section>
+
+<style>
+  .gs-template-section {
+    padding-block: clamp(4.5rem, 9vw, 8rem);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  }
+
+  .gs-template-section--compact {
+    padding-block: clamp(3rem, 6vw, 5rem);
+  }
+
+  .gs-template-section--surface {
+    background: rgba(13, 13, 19, 0.76);
+  }
+
+  .gs-template-section--accent {
+    background:
+      linear-gradient(110deg, rgba(217, 106, 50, 0.13), transparent 56%),
+      rgba(10, 10, 14, 0.92);
+  }
+
+  .gs-template-section__header {
+    grid-column: 1 / span 5;
+    min-width: 0;
+  }
+
+  .gs-template-section__header p {
+    margin: 0 0 1rem;
+    color: var(--gs-primary);
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 0.66rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+
+  .gs-template-section__header h2 {
+    margin: 0;
+    color: var(--gs-text);
+    font-family: 'Space Grotesk', 'Inter', system-ui, sans-serif;
+    font-size: clamp(2.25rem, 5vw, 4.7rem);
+    letter-spacing: -0.045em;
+    line-height: 0.98;
+    overflow-wrap: anywhere;
+    text-transform: uppercase;
+  }
+
+  .gs-template-section__header div {
+    max-width: 48ch;
+    margin-top: 1.5rem;
+    color: var(--gs-text-dim);
+    line-height: 1.75;
+  }
+
+  .gs-template-section__content {
+    grid-column: 6 / -1;
+    min-width: 0;
+    display: grid;
+    gap: clamp(1rem, 2vw, 1.5rem);
+  }
+
+  .columns-1 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .columns-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .columns-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .columns-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  @media (max-width: 900px) {
+    .gs-template-section__header,
+    .gs-template-section__content {
+      grid-column: 1 / -1;
+    }
+
+    .gs-template-section__content {
+      margin-top: 2.5rem;
+    }
+
+    .columns-3,
+    .columns-4 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 620px) {
+    .columns-2,
+    .columns-3,
+    .columns-4 {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+</style>

--- a/apps/gs-web/src/components/hero/VibrantHeroField.astro
+++ b/apps/gs-web/src/components/hero/VibrantHeroField.astro
@@ -1,0 +1,172 @@
+---
+interface Props {
+  mode?: 'starfield' | 'parallax';
+}
+
+const { mode = 'starfield' } = Astro.props;
+---
+
+<div class="vibrant-field" data-vibrant-field={mode} aria-hidden="true">
+  <canvas></canvas>
+  <div class="vibrant-field__grid"></div>
+  <div class="vibrant-field__glow"></div>
+</div>
+
+<script>
+  type Particle = {
+    x: number;
+    y: number;
+    radius: number;
+    alpha: number;
+    depth: number;
+    copper: boolean;
+  };
+
+  const instances = new WeakMap<Element, () => void>();
+
+  const mountField = (root: HTMLElement) => {
+    if (instances.has(root)) return;
+
+    const canvas = root.querySelector('canvas');
+    const context = canvas?.getContext('2d');
+    if (!canvas || !context) return;
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const parallax = root.dataset.vibrantField === 'parallax' && !reducedMotion;
+    const pointer = { x: 0, y: 0 };
+    const smooth = { x: 0, y: 0 };
+    let particles: Particle[] = [];
+    let width = 0;
+    let height = 0;
+    let frame = 0;
+    let scroll = window.scrollY;
+
+    const createParticles = () => {
+      const count = Math.max(54, Math.min(150, Math.round((width * height) / 10500)));
+      particles = Array.from({ length: count }, (_, index) => ({
+        x: Math.random() * width,
+        y: Math.random() * height,
+        radius: 0.45 + Math.random() * 1.35,
+        alpha: 0.12 + Math.random() * 0.5,
+        depth: 0.25 + Math.random() * 0.75,
+        copper: index % 7 === 0,
+      }));
+    };
+
+    const resize = () => {
+      const rect = root.getBoundingClientRect();
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+      width = rect.width;
+      height = rect.height;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      createParticles();
+    };
+
+    const draw = (time = 0) => {
+      context.clearRect(0, 0, width, height);
+
+      smooth.x += (pointer.x - smooth.x) * 0.04;
+      smooth.y += (pointer.y - smooth.y) * 0.04;
+
+      for (const particle of particles) {
+        const drift = reducedMotion ? 0 : Math.sin(time * 0.00022 + particle.x) * 5 * particle.depth;
+        const offsetX = parallax ? smooth.x * 18 * particle.depth : 0;
+        const offsetY = parallax ? (smooth.y * 12 - scroll * 0.035) * particle.depth : drift;
+        const x = (particle.x + offsetX + width) % width;
+        const y = (particle.y + offsetY + height) % height;
+
+        context.beginPath();
+        context.arc(x, y, particle.radius, 0, Math.PI * 2);
+        context.fillStyle = particle.copper
+          ? `rgba(217, 106, 50, ${particle.alpha})`
+          : `rgba(236, 234, 228, ${particle.alpha})`;
+        context.fill();
+      }
+
+      if (!reducedMotion) frame = window.requestAnimationFrame(draw);
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      const rect = root.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / Math.max(rect.width, 1) - 0.5) * 2;
+      pointer.y = ((event.clientY - rect.top) / Math.max(rect.height, 1) - 0.5) * 2;
+    };
+    const onScroll = () => { scroll = window.scrollY; };
+    const observer = new ResizeObserver(resize);
+
+    observer.observe(root);
+    window.addEventListener('pointermove', onPointerMove, { passive: true });
+    window.addEventListener('scroll', onScroll, { passive: true });
+    resize();
+    draw();
+
+    const cleanup = () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('scroll', onScroll);
+      instances.delete(root);
+    };
+
+    instances.set(root, cleanup);
+  };
+
+  const mountFields = () => {
+    document.querySelectorAll<HTMLElement>('[data-vibrant-field]').forEach(mountField);
+  };
+
+  const cleanupFields = () => {
+    document.querySelectorAll('[data-vibrant-field]').forEach((root) => instances.get(root)?.());
+  };
+
+  document.addEventListener('astro:page-load', mountFields);
+  document.addEventListener('astro:before-swap', cleanupFields);
+  document.readyState === 'loading'
+    ? document.addEventListener('DOMContentLoaded', mountFields, { once: true })
+    : mountFields();
+</script>
+
+<style>
+  .vibrant-field,
+  .vibrant-field canvas,
+  .vibrant-field__grid,
+  .vibrant-field__glow {
+    position: absolute;
+    inset: 0;
+  }
+
+  .vibrant-field {
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .vibrant-field canvas {
+    width: 100%;
+    height: 100%;
+  }
+
+  .vibrant-field__grid {
+    opacity: 0.16;
+    background:
+      linear-gradient(rgba(217, 106, 50, 0.16) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(217, 106, 50, 0.16) 1px, transparent 1px);
+    background-size: 84px 84px;
+    mask-image: linear-gradient(to bottom, transparent, black 38%, transparent);
+  }
+
+  .vibrant-field__glow {
+    background:
+      radial-gradient(circle at 18% 50%, rgba(217, 106, 50, 0.12), transparent 34%),
+      radial-gradient(circle at 82% 62%, rgba(217, 106, 50, 0.07), transparent 30%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .vibrant-field canvas {
+      opacity: 0.72;
+    }
+  }
+</style>

--- a/apps/gs-web/src/pages/templates/index.astro
+++ b/apps/gs-web/src/pages/templates/index.astro
@@ -19,6 +19,7 @@ const primitives = [
   eyebrow="Gold Shore · Astro system"
   heading="Build once. Extend everywhere."
   intro="A composable page contract for new platform, service, editorial, and campaign routes—using the established black, white, and copper Vibrant visual system."
+  heroMotion="parallax"
 >
   <div slot="actions" class="template-actions">
     <a href="/contact/" class="template-button template-button--primary">Start a page</a>

--- a/apps/gs-web/src/pages/templates/index.astro
+++ b/apps/gs-web/src/pages/templates/index.astro
@@ -1,89 +1,189 @@
 ---
-import MarketingLayout from '../../layouts/MarketingLayout.astro';
-import DocsSearch from '../../components/DocsSearch.astro';
-import { GSButton } from '@goldshore/ui';
+import GoldShorePageTemplate from '../../components/GoldShorePageTemplate.astro';
+import GoldShoreSection from '../../components/GoldShoreSection.astro';
 
 export const prerender = true;
 
-const featureBlocks = [
-  {
-    title: 'Navigation + Menus',
-    description: 'Primary navigation and menus stay in the shared layout, so content pages focus on storytelling.'
-  },
-  {
-    title: 'Responsive Layouts',
-    description: 'Use grid utilities and section spacing to keep desktop, tablet, and mobile layouts consistent.'
-  },
-  {
-    title: 'Search Module',
-    description: 'Drop in the DocsSearch component anywhere you need a site-level search experience.'
-  },
-  {
-    title: 'CTA + Marketing',
-    description: 'Reusable buttons and cards keep conversion flows consistent for marketing and ecommerce.'
-  }
+const primitives = [
+  ['01', 'Page shell', 'Metadata, sticky navigation, footer, hero hierarchy, actions, and an optional supporting panel.'],
+  ['02', 'Column system', 'One shared 12-column axis controls widths and alignment from the header through every section.'],
+  ['03', 'Section rhythm', 'Default, surface, accent, and compact variants create hierarchy without one-off page CSS.'],
+  ['04', 'Responsive rules', 'Column counts collapse predictably while typography and controls remain readable.'],
 ];
 ---
 
-<MarketingLayout
-  title="Web Template"
-  description="Template layout that keeps navigation, menus, and search modular for GoldShore web pages."
+<GoldShorePageTemplate
+  title="Astro Page Template | Gold Shore"
+  description="The reusable Gold Shore Astro page and section primitives."
+  canonicalPath="/templates/"
+  eyebrow="Gold Shore · Astro system"
+  heading="Build once. Extend everywhere."
+  intro="A composable page contract for new platform, service, editorial, and campaign routes—using the established black, white, and copper Vibrant visual system."
 >
-  <section class="gs-hero gs-hero--center">
-    <div class="gs-hero__inner">
-      <p class="gs-eyebrow">Template Page</p>
-      <h1>Composable marketing layout</h1>
-      <p class="gs-lead">
-        This page demonstrates how the GoldShore web templates keep navbars, menus, containers, and search
-        components modular so they can plug into any marketing or documentation page.
-      </p>
-      <div class="gs-button-row">
-        <GSButton href="/" variant="primary">Return to Home</GSButton>
-        <GSButton href="/developer" variant="secondary">Developer Hub</GSButton>
-      </div>
-    </div>
-  </section>
+  <div slot="actions" class="template-actions">
+    <a href="/contact/" class="template-button template-button--primary">Start a page</a>
+    <a href="/developer/" class="template-button">Developer hub</a>
+  </div>
 
-  <section class="gs-section gs-section--padded">
-    <div class="gs-grid columns-2">
-      {featureBlocks.map((block) => (
-        <article class="gs-card">
-          <h3>{block.title}</h3>
-          <p>{block.description}</p>
-        </article>
-      ))}
-    </div>
-  </section>
+  <div slot="aside" class="template-aside">
+    <span>Template contract</span>
+    <strong>12 columns</strong>
+    <p>Shared shell, responsive sections, explicit variants, and named content slots.</p>
+  </div>
 
-  <section class="gs-section gs-section--padded">
-    <div class="gs-grid columns-2">
-      <div>
-        <h2>Search stays independent</h2>
-        <p>
-          Keep the search component in <code>src/components</code> so it can be embedded in marketing pages,
-          documentation, or logged-in portals without rewriting the UI.
-        </p>
-      </div>
-      <div class="gs-card gs-card--surface">
-        <DocsSearch />
-      </div>
-    </div>
-  </section>
+  <GoldShoreSection
+    eyebrow="Core primitives"
+    heading="A stable page-building method"
+    intro="Use the page template once, then compose content with section variants. New routes inherit navigation, width, spacing, responsive behavior, and visual tokens."
+    columns={2}
+  >
+    {primitives.map(([number, title, description]) => (
+      <article class="template-card">
+        <span>{number}</span>
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </article>
+    ))}
+  </GoldShoreSection>
 
-  <section class="gs-section gs-section--padded">
-    <div class="gs-grid columns-2">
-      <div>
-        <h2>Template slots for campaigns</h2>
-        <p>
-          Use the marketing layout for campaigns, partner launches, and pricing updates. Components from the
-          UI kit keep CTA blocks and content containers consistent across campaigns.
-        </p>
-      </div>
-      <div class="gs-card">
-        <h3>Example CTA</h3>
-        <p>Launch a new AI service or stock market data integration with a consistent call to action.</p>
-        <GSButton href="/contact" variant="primary">Talk to GoldShore</GSButton>
-      </div>
+  <GoldShoreSection
+    eyebrow="Composition"
+    heading="Slots where content belongs"
+    intro="The template controls structure without constraining each page’s story. Astro content and components remain code-native."
+    tone="surface"
+  >
+    <pre class="template-code"><code>{`<GoldShorePageTemplate
+  title="Page title"
+  description="Search description"
+  heading="Visible page heading"
+>
+  <GoldShoreSection
+    heading="Section heading"
+    columns={2}
+  >
+    <!-- Astro components or content -->
+  </GoldShoreSection>
+</GoldShorePageTemplate>`}</code></pre>
+  </GoldShoreSection>
+
+  <GoldShoreSection
+    heading="Ready for the next route"
+    intro="Start with the shared template and spend implementation time on the page’s actual content—not rebuilding its shell."
+    tone="accent"
+    compact
+  >
+    <div class="template-final">
+      <p>Page-specific CSS should describe the content module only. The template owns the site geometry.</p>
+      <a href="/contact/" class="template-button template-button--primary">Request briefing</a>
     </div>
-  </section>
-</MarketingLayout>
+  </GoldShoreSection>
+</GoldShorePageTemplate>
+
+<style>
+  .template-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+  }
+
+  .template-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 3.25rem;
+    padding: 0.8rem 1.25rem;
+    border: 1px solid rgba(217, 106, 50, 0.42);
+    color: var(--gs-text);
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.11em;
+    text-decoration: none;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .template-button--primary {
+    background: #d96a32;
+    color: #08080b;
+  }
+
+  .template-aside span,
+  .template-card > span {
+    color: var(--gs-primary);
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: 0.65rem;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+  }
+
+  .template-aside strong {
+    display: block;
+    margin-top: 1rem;
+    color: var(--gs-text);
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: clamp(2rem, 4vw, 3.6rem);
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .template-aside p,
+  .template-card p,
+  .template-final p {
+    color: var(--gs-text-dim);
+    line-height: 1.7;
+  }
+
+  .template-card {
+    min-width: 0;
+    padding: 1.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.018);
+  }
+
+  .template-card h3 {
+    margin: 1.5rem 0 0.6rem;
+    color: var(--gs-text);
+    font-size: 1.15rem;
+  }
+
+  .template-card p {
+    margin: 0;
+  }
+
+  .template-code {
+    min-width: 0;
+    max-width: 100%;
+    margin: 0;
+    padding: clamp(1rem, 3vw, 2rem);
+    overflow: auto;
+    border: 1px solid rgba(217, 106, 50, 0.28);
+    color: var(--gs-text);
+    background: #08080b;
+    font-family: 'DM Mono', ui-monospace, monospace;
+    font-size: clamp(0.72rem, 1.3vw, 0.9rem);
+    line-height: 1.75;
+  }
+
+  .template-final {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+  }
+
+  .template-final p {
+    max-width: 48ch;
+    margin: 0;
+  }
+
+  @media (max-width: 620px) {
+    .template-actions,
+    .template-final {
+      display: grid;
+    }
+
+    .template-button {
+      width: 100%;
+    }
+  }
+</style>

--- a/apps/gs-web/tests/unit/web-layout-regression.test.ts
+++ b/apps/gs-web/tests/unit/web-layout-regression.test.ts
@@ -24,3 +24,29 @@ test('WebLayout retains the established public theme contract', async () => {
     assert.ok(source.includes(contract), `WebLayout must retain ${contract}`);
   }
 });
+
+test('Gold Shore page templates compose the shared shell and column contract', async () => {
+  const [pageTemplate, sectionTemplate] = await Promise.all([
+    readFile(new URL('components/GoldShorePageTemplate.astro', sourceRoot), 'utf8'),
+    readFile(new URL('components/GoldShoreSection.astro', sourceRoot), 'utf8'),
+  ]);
+
+  for (const contract of [
+    "import WebLayout from '../layouts/WebLayout.astro'",
+    "Astro.slots.has('actions')",
+    "Astro.slots.has('aside')",
+    "'gs-shell-section'",
+    "'gs-column-grid'",
+  ]) {
+    assert.ok(pageTemplate.includes(contract), `Page template must retain ${contract}`);
+  }
+
+  for (const contract of [
+    'columns?: 1 | 2 | 3 | 4',
+    "tone?: 'default' | 'surface' | 'accent'",
+    'class="gs-shell-section gs-column-grid"',
+    'repeat(4, minmax(0, 1fr))',
+  ]) {
+    assert.ok(sectionTemplate.includes(contract), `Section template must retain ${contract}`);
+  }
+});

--- a/apps/gs-web/tests/unit/web-layout-regression.test.ts
+++ b/apps/gs-web/tests/unit/web-layout-regression.test.ts
@@ -37,6 +37,8 @@ test('Gold Shore page templates compose the shared shell and column contract', a
     "Astro.slots.has('aside')",
     "'gs-shell-section'",
     "'gs-column-grid'",
+    "heroMotion?: 'none' | 'starfield' | 'parallax'",
+    '<VibrantHeroField mode={heroMotion} />',
   ]) {
     assert.ok(pageTemplate.includes(contract), `Page template must retain ${contract}`);
   }


### PR DESCRIPTION
Merge Strategy: Squash

@claude [review-request] [agent:claude] [env:preview] [status:ready]

## What changed
- Adds a reusable GoldShorePageTemplate for metadata, hero, named action and aside slots, and the shared WebLayout shell.
- Adds GoldShoreSection with 12-column alignment, responsive 1-4 column variants, tones, and compact spacing.
- Rebuilds /templates as the canonical usage example in the approved black, white, and copper Vibrant system.
- Adds regression coverage for the template contract.

## Review focus
Please review Astro slot/scoped-style behavior, accessibility, responsive layout, maintainability, and consistency with the shared 12-column design system.

## Checks
- pnpm --dir apps/gs-web test:unit
- pnpm build:pages
- Browser QA at 1280px and 390x844