### PR TITLE
fix(gs-api): bind real PAPER_DB/TRADING_KV for paper trading

### DIFF
--- a/apps/gs-api/db/migrations/0004_paper_trading.sql
+++ b/apps/gs-api/db/migrations/0004_paper_trading.sql
@@ -1,0 +1,71 @@
+-- Migration: 0004_paper_trading
+-- Target database: PAPER_DB (goldshore-paper-trading), NOT PLATFORM_DB.
+-- Ported from apps/gs-trading/migrations/001_paper_trading.sql now that
+-- apps/gs-api's trading routes are bound directly to goldshore-paper-trading
+-- instead of falling back to PLATFORM_DB (which has no matching schema).
+
+-- Paper positions ledger
+CREATE TABLE IF NOT EXISTS paper_positions (
+  id TEXT PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  quantity REAL NOT NULL,
+  avg_cost REAL NOT NULL,
+  side TEXT CHECK(side IN ('long','short')) NOT NULL,
+  opened_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- Paper orders (state machine)
+CREATE TABLE IF NOT EXISTS paper_orders (
+  id TEXT PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  side TEXT CHECK(side IN ('buy','sell')) NOT NULL,
+  quantity REAL NOT NULL,
+  order_type TEXT CHECK(order_type IN ('market','limit','stop')) NOT NULL,
+  limit_price REAL,
+  status TEXT CHECK(status IN ('pending','open','filled','cancelled','rejected')) NOT NULL DEFAULT 'pending',
+  fill_price REAL,
+  fill_quantity REAL DEFAULT 0,
+  source TEXT CHECK(source IN ('manual','agent')) NOT NULL DEFAULT 'manual',
+  agent_recommendation_id TEXT,
+  approved_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- Closed positions archive
+CREATE TABLE IF NOT EXISTS paper_closed_positions (
+  id TEXT PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  quantity REAL NOT NULL,
+  avg_cost REAL NOT NULL,
+  close_price REAL NOT NULL,
+  side TEXT NOT NULL,
+  realized_pnl REAL NOT NULL,
+  opened_at INTEGER NOT NULL,
+  closed_at INTEGER NOT NULL
+);
+
+-- Agent recommendations (pending human approval)
+CREATE TABLE IF NOT EXISTS agent_recommendations (
+  id TEXT PRIMARY KEY,
+  agent TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  action TEXT CHECK(action IN ('buy','sell','hold')) NOT NULL,
+  quantity REAL,
+  rationale TEXT,
+  confidence REAL,
+  status TEXT CHECK(status IN ('pending','approved','rejected','expired')) DEFAULT 'pending',
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+-- Notification log
+CREATE TABLE IF NOT EXISTS notification_log (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  channel TEXT CHECK(channel IN ('email','webhook','sms')) NOT NULL,
+  payload TEXT NOT NULL,
+  sent_at INTEGER NOT NULL,
+  success INTEGER NOT NULL DEFAULT 1
+);

--- a/apps/gs-api/src/routes/wrangler-config.test.ts
+++ b/apps/gs-api/src/routes/wrangler-config.test.ts
@@ -83,6 +83,26 @@ describe('gs-api wrangler env bindings', () => {
         new RegExp(`\\[env\\.${envName}\\.ai\\][\\s\\S]*?binding = "AI"`),
       );
     });
+
+    it(`binds the real paper-trading KV and D1 store for ${envName}`, () => {
+      // Regression guard: trading/routes/trading.ts falls back to
+      // `env.KV`/`env.PLATFORM_DB` when these are absent, which silently
+      // sends paper-trading reads/writes to a database with no matching
+      // schema. These bindings must point at the actual
+      // goldshore-paper-trading D1 + its KV namespace.
+      assert.match(
+        wranglerToml,
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.kv_namespaces\\]\\][\\s\\S]*?binding = "TRADING_KV"[\\s\\S]*?id = "`,
+        ),
+      );
+      assert.match(
+        wranglerToml,
+        new RegExp(
+          `\\[\\[env\\.${envName}\\.d1_databases\\]\\][\\s\\S]*?binding = "PAPER_DB"[\\s\\S]*?database_name = "goldshore-paper-trading"`,
+        ),
+      );
+    });
   }
 
   it('keeps top-level bindings safe for Cloudflare Workers Builds version uploads', () => {

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -29,6 +29,13 @@ id = "a52e94cb331c4e3db08f2aa507e6df09"
 binding = "RISK_RADAR_CACHE"
 id = "0b56873b6d7b451f9279481920a15447"
 
+# TRADING_KV: the real namespace previously owned by the now route-free
+# apps/gs-trading Worker. Trading feature flags, Schwab/Robinhood OAuth
+# tokens, and agent orchestration state live here.
+[[kv_namespaces]]
+binding = "TRADING_KV"
+id = "9b3314c3b7af40a284a8c9b6e2990709"
+
 [[r2_buckets]]
 binding = "GS_ASSETS"
 bucket_name = "gs-assets"
@@ -65,6 +72,18 @@ database_id = "b0bf3b0e-a7d0-49ae-ac82-4f19450b2ce2"
 binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
+
+# PAPER_DB: the real paper-trading ledger previously owned by the now
+# route-free apps/gs-trading Worker (paper_orders, paper_positions,
+# paper_closed_positions, agent_recommendations, notification_log — schema in
+# db/migrations/0004_paper_trading.sql). trading/routes/trading.ts's
+# `env.PAPER_DB ?? env.PLATFORM_DB` fallback exists only so the Worker doesn't
+# crash if this binding is ever removed; PLATFORM_DB has no matching schema
+# and must not be used for paper-trading data.
+[[d1_databases]]
+binding = "PAPER_DB"
+database_name = "goldshore-paper-trading"
+database_id = "af94f483-b98b-41c5-aa23-3fbed2764b52"
 
 [ai]
 binding = "AI"
@@ -140,6 +159,11 @@ id = "a52e94cb331c4e3db08f2aa507e6df09"
 binding = "RISK_RADAR_CACHE"
 id = "0b56873b6d7b451f9279481920a15447"
 
+# TRADING_KV: see top-level default-env comment above.
+[[env.prod.kv_namespaces]]
+binding = "TRADING_KV"
+id = "9b3314c3b7af40a284a8c9b6e2990709"
+
 # ── R2 ────────────────────────────────────────────────────────────────────────────
 [[env.prod.r2_buckets]]
 binding = "GS_ASSETS"
@@ -188,6 +212,12 @@ database_id = "b0bf3b0e-a7d0-49ae-ac82-4f19450b2ce2"
 binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
+
+# PAPER_DB: see top-level default-env comment above.
+[[env.prod.d1_databases]]
+binding = "PAPER_DB"
+database_name = "goldshore-paper-trading"
+database_id = "af94f483-b98b-41c5-aa23-3fbed2764b52"
 
 # ── AI ──────────────────────────────────────────────────────────────────────────────────────
 [env.prod.ai]
@@ -279,6 +309,12 @@ id = "09e43cb8bd4749fdaaed0dc9d4ff2284"
 binding = "RISK_RADAR_CACHE"
 id = "0b56873b6d7b451f9279481920a15447"
 
+# TRADING_KV: dedicated preview namespace (also owned by the now route-free
+# apps/gs-trading Worker previously).
+[[env.preview.kv_namespaces]]
+binding = "TRADING_KV"
+id = "2c14b79b76e6453ab57c6dde6116a11d"
+
 # ── R2 ────────────────────────────────────────────────────────────────────────────
 [[env.preview.r2_buckets]]
 binding = "GS_ASSETS"
@@ -321,6 +357,16 @@ database_id = "b0bf3b0e-a7d0-49ae-ac82-4f19450b2ce2"
 binding = "JOBS_DB"
 database_name = "gs_jobs_db"
 database_id = "750c469c-788d-49e8-9254-77231cffd70f"
+
+# PAPER_DB: no dedicated preview copy of goldshore-paper-trading exists yet
+# (same situation as RISK_RADAR_DB/RISK_RADAR_CACHE/RISK_RADAR_R2 above), so
+# preview reuses the live prod database. Acceptable for now since paper
+# trading is not a customer-money-moving system; revisit if preview writes
+# should stop touching production paper-trading data.
+[[env.preview.d1_databases]]
+binding = "PAPER_DB"
+database_name = "goldshore-paper-trading"
+database_id = "af94f483-b98b-41c5-aa23-3fbed2764b52"
 
 # ── AI ──────────────────────────────────────────────────────────────────────────────────────
 [env.preview.ai]


### PR DESCRIPTION
## Summary

This is blocker #4 from the platform-wide build/deploy audit: `apps/gs-api`'s trading routes never bound the real paper-trading D1/KV, so `routes/trading.ts`'s `env.PAPER_DB ?? env.PLATFORM_DB` / `env.TRADING_KV ?? env.KV` fallback silently pointed paper-trading traffic at the wrong stores. `PLATFORM_DB` has no `paper_orders`/`paper_positions`/etc. schema, so any `/trading/paper/*` or order-touching `/trading/api/agents/*` call fails in production today.

- Binds `PAPER_DB` (→ the real `goldshore-paper-trading` D1, `af94f483-b98b-41c5-aa23-3fbed2764b52`) and `TRADING_KV` (→ `9b3314c3b7af40a284a8c9b6e2990709`, preview `2c14b79b76e6453ab57c6dde6116a11d`) in `apps/gs-api/wrangler.toml`'s default, `env.prod`, and `env.preview` blocks — these are the exact resources previously owned by the now route-free `apps/gs-trading` Worker.
- Ports `apps/gs-trading/migrations/001_paper_trading.sql` to `apps/gs-api/db/migrations/0004_paper_trading.sql` (schema for `paper_positions`, `paper_orders`, `paper_closed_positions`, `agent_recommendations`, `notification_log`) so `PAPER_DB` actually has the tables the trading routes query.
- Adds regression coverage to `wrangler-config.test.ts` asserting both bindings exist in `env.prod`/`env.preview`.

Verified with `wrangler deploy --env prod --dry-run` — bindings table confirms `env.TRADING_KV` and `env.PAPER_DB (goldshore-paper-trading)` are present in the bundle.

## Follow-up (not in this PR)

- The `0004_paper_trading.sql` migration needs to actually be applied against the live `goldshore-paper-trading` D1 (`wrangler d1 migrations apply` with real Cloudflare credentials) — no CI automation applies gs-api migrations today (0001–0003 appear to have been applied manually too).
- Once confirmed working, `apps/gs-trading` can be archived — it's already route-free and its source is otherwise byte-identical to `apps/gs-api/src/trading`.

## Test plan

- [x] `wrangler-config.test.ts` passes (10/10, including the 2 new assertions)
- [x] `apps/gs-api/wrangler.toml` validated as parseable TOML
- [x] `wrangler deploy --env prod --dry-run` shows both bindings in the resulting bundle
- [ ] Apply `0004_paper_trading.sql` against the live `goldshore-paper-trading` D1 (requires Cloudflare credentials not available in this session)
- [ ] Manual smoke test of `/trading/paper/*` endpoints post-deploy


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi17J5P2yJzo8ZWZnCFjMo)_