### PR TITLE
Repair lockfile and newsletter route builds

### DIFF
--- a/apps/gs-web/src/pages/newsletter/confirm.astro
+++ b/apps/gs-web/src/pages/newsletter/confirm.astro
@@ -1,38 +1,49 @@
 ---
 import MarketingLayout from '../../layouts/MarketingLayout.astro';
 
-export const prerender = false;
+export const prerender = true;
 
-const token = Astro.url.searchParams.get('token') ?? '';
-const manage = Astro.url.searchParams.get('manage') ?? '';
-const runtimeEnv = Astro.locals.runtime?.env as { PUBLIC_API?: string } | undefined;
-const apiBase = (runtimeEnv?.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
-let confirmed = false;
-let message = 'This confirmation link is invalid.';
-
-if (token) {
-  const target = new URL(`${apiBase}/v1/forms/newsletter/confirm`);
-  target.searchParams.set('token', token);
-  if (manage) target.searchParams.set('manage', manage);
-  try {
-    const response = await fetch(target);
-    confirmed = response.ok;
-    message = confirmed
-      ? 'Your subscription is confirmed. A welcome email is on its way.'
-      : 'This confirmation link is invalid, expired, or already inactive.';
-  } catch {
-    message = 'Confirmation is temporarily unavailable. Please try again.';
-  }
-}
+const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
 ---
 
 <MarketingLayout title="Newsletter confirmation | GoldShore" description="Confirm your GoldShore newsletter subscription.">
   <main class="gs-section" style="min-height: 60vh;">
-    <div class="gs-container gs-stack" style="max-width: 42rem;">
+    <div class="gs-container gs-stack" style="max-width: 42rem;" data-newsletter-confirm data-api-base={apiBase}>
       <p class="gs-kicker">Newsletter</p>
-      <h1>{confirmed ? 'Subscription confirmed' : 'Unable to confirm'}</h1>
-      <p>{message}</p>
+      <h1 data-result-title>Confirming subscription</h1>
+      <p data-result-message>Please wait while we confirm your email address.</p>
       <a class="gs-button" href="/">Return home</a>
     </div>
   </main>
 </MarketingLayout>
+
+<script>
+  const container = document.querySelector<HTMLElement>('[data-newsletter-confirm]');
+  const title = container?.querySelector<HTMLElement>('[data-result-title]');
+  const message = container?.querySelector<HTMLElement>('[data-result-message]');
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get('token');
+  const manage = params.get('manage');
+
+  const showResult = (heading: string, detail: string) => {
+    if (title) title.textContent = heading;
+    if (message) message.textContent = detail;
+  };
+
+  if (!container || !token) {
+    showResult('Unable to confirm', 'This confirmation link is invalid.');
+  } else {
+    const target = new URL(`${container.dataset.apiBase}/v1/forms/newsletter/confirm`);
+    target.searchParams.set('token', token);
+    if (manage) target.searchParams.set('manage', manage);
+
+    fetch(target)
+      .then((response) => {
+        if (!response.ok) throw new Error('confirmation rejected');
+        showResult('Subscription confirmed', 'Your subscription is confirmed. A welcome email is on its way.');
+      })
+      .catch(() => {
+        showResult('Unable to confirm', 'This confirmation link is invalid, expired, or temporarily unavailable.');
+      });
+  }
+</script>

--- a/apps/gs-web/src/pages/newsletter/unsubscribe.astro
+++ b/apps/gs-web/src/pages/newsletter/unsubscribe.astro
@@ -1,36 +1,46 @@
 ---
 import MarketingLayout from '../../layouts/MarketingLayout.astro';
 
-export const prerender = false;
+export const prerender = true;
 
-const token = Astro.url.searchParams.get('token') ?? '';
-const runtimeEnv = Astro.locals.runtime?.env as { PUBLIC_API?: string } | undefined;
-const apiBase = (runtimeEnv?.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
-let removed = false;
-let message = 'This unsubscribe link is invalid.';
-
-if (token) {
-  const target = new URL(`${apiBase}/v1/forms/newsletter/unsubscribe`);
-  target.searchParams.set('token', token);
-  try {
-    const response = await fetch(target);
-    removed = response.ok;
-    message = removed
-      ? 'You have been unsubscribed and will not receive future newsletter campaigns.'
-      : 'This unsubscribe link is invalid or already inactive.';
-  } catch {
-    message = 'The unsubscribe service is temporarily unavailable. Please try again.';
-  }
-}
+const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
 ---
 
 <MarketingLayout title="Newsletter preferences | GoldShore" description="Manage your GoldShore newsletter subscription.">
   <main class="gs-section" style="min-height: 60vh;">
-    <div class="gs-container gs-stack" style="max-width: 42rem;">
+    <div class="gs-container gs-stack" style="max-width: 42rem;" data-newsletter-unsubscribe data-api-base={apiBase}>
       <p class="gs-kicker">Newsletter</p>
-      <h1>{removed ? 'Unsubscribed' : 'Unable to update'}</h1>
-      <p>{message}</p>
+      <h1 data-result-title>Updating preferences</h1>
+      <p data-result-message>Please wait while we update your subscription.</p>
       <a class="gs-button" href="/">Return home</a>
     </div>
   </main>
 </MarketingLayout>
+
+<script>
+  const container = document.querySelector<HTMLElement>('[data-newsletter-unsubscribe]');
+  const title = container?.querySelector<HTMLElement>('[data-result-title]');
+  const message = container?.querySelector<HTMLElement>('[data-result-message]');
+  const token = new URLSearchParams(window.location.search).get('token');
+
+  const showResult = (heading: string, detail: string) => {
+    if (title) title.textContent = heading;
+    if (message) message.textContent = detail;
+  };
+
+  if (!container || !token) {
+    showResult('Unable to update', 'This unsubscribe link is invalid.');
+  } else {
+    const target = new URL(`${container.dataset.apiBase}/v1/forms/newsletter/unsubscribe`);
+    target.searchParams.set('token', token);
+
+    fetch(target)
+      .then((response) => {
+        if (!response.ok) throw new Error('unsubscribe rejected');
+        showResult('Unsubscribed', 'You have been unsubscribed and will not receive future newsletter campaigns.');
+      })
+      .catch(() => {
+        showResult('Unable to update', 'This unsubscribe link is invalid, already inactive, or temporarily unavailable.');
+      });
+  }
+</script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6500,6 +6500,11 @@ snapshots:
       '@emnapi/runtime': 1.11.1
     optional: true
 
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
   '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.1
@@ -6762,9 +6767,9 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
-  '@playwright/test@1.61.1':
+  '@playwright/test@1.62.0':
     dependencies:
-      playwright: 1.61.1
+      playwright: 1.62.0
 
   '@poppinss/colors@4.1.6':
     dependencies:


### PR DESCRIPTION
Merge strategy: squash

Repairs the missing @img/sharp-wasm32 snapshot generated by a conflicted lockfile. Also prerenders the newsletter confirmation and unsubscribe shells and processes their tokens client-side so the required built routes exist.

Validated with a frozen pnpm 9.15.4 install, gs-web production build, and the release quality gate.