### PR TITLE
fix: guard CF Access rotation for Ops and Preview

### DIFF
--- a/.github/workflows/setup-cf-agent-access.yml
+++ b/.github/workflows/setup-cf-agent-access.yml
@@ -50,7 +50,7 @@ jobs:
       #    have Service Token scope but lack Apps/Policies edit permission.
       #    A partial-permission failure here aborts BEFORE any revocation.
       # ------------------------------------------------------------------ #
-      - name: Verify CF token has Access scope
+      - name: Verify CF token can edit Access apps and policies before rotation
         env:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
@@ -855,8 +855,14 @@ jobs:
           upsert_full_access "GoldShore-Trading-ZT" "trading.goldshore.ai" \
             '["dashboard.goldshore.ai","dash.goldshore.ai"]' "" \
             '["GoldShore Trading","Goldshore Trading","Trading"]'
+          # Rotation-critical surfaces: both ops automation and preview smoke
+          # checks consume the credentials propagated below. Keep these apps in
+          # the same rotation as the rest of the managed Access surfaces, then
+          # verify both human and service-token policies before publishing the
+          # replacement credentials.
           # Goldshore Ops: ops.goldshore.ai (Gate 5c)
           upsert_full_access "Goldshore Ops"     "ops.goldshore.ai"
+          assert_full_access_policies "Goldshore Ops" "ops.goldshore.ai"
           # Signals: .ai canonical + .org alias + workers.dev default host
           upsert_full_access "Signals"           "signals.goldshore.ai" \
             '["signals.goldshore.org","gs-signals-prod.goldshore.workers.dev"]'
@@ -916,6 +922,7 @@ jobs:
             '["gateway.goldshore.ai","agent.goldshore.ai"]'
           # GoldShore-Web-Preview: preview.goldshore.ai (INFRASTRUCTURE.md Gate 5)
           upsert_full_access "GoldShore-Web-Preview" "preview.goldshore.ai"
+          assert_full_access_policies "GoldShore-Web-Preview" "preview.goldshore.ai"
 
           if [ "$MISSING_REQUIRED_APPS" -ne 0 ]; then
             echo "::error::One or more required Access apps were missing while skip_apps=true. Policies were not updated for those apps, so new credentials were not propagated."


### PR DESCRIPTION
Merge Strategy: Squash

### Motivation
- Prevent a destructive token rotation when `CLOUDFLARE_API_TOKEN` lacks Access `apps`/`policies` edit scope by validating write capabilities before revoking the old service token.
- Ensure all rotation-critical Access applications that consume the rotated credentials are included and verified in the same rotation, specifically `Goldshore Ops` and `GoldShore-Web-Preview` which were previously omitted or not asserted.

### Description
- Rename the pre-rotation step to clarify intent and rely on the existing probe that creates a temporary app and policy to confirm the token can create/edit Access apps and policies (no destructive action until that succeeds). 
- Add `assert_full_access_policies` checks immediately after `upsert_full_access` for `Goldshore Ops` and `GoldShore-Web-Preview` so both the human `Owner access` and `Goldshore agents` service-token policies are present before propagating replacement credentials.
- Update comments around the Ops/Preview entries to document that these are rotation-critical surfaces and must be verified before publishing new secrets.

### Testing
- Ran `git diff --check` with no reported issues and committed the change successfully. 
- Parsed the workflow YAML using `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/setup-cf-agent-access.yml", aliases: true)'` which returned successfully indicating the workflow YAML remains valid. 
- Verified repository status with `git status --short --branch` showing the workflow commit and only an unrelated `pnpm-lock.yaml` modification remaining.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b3fd9b384833194215970fba5da4b)