### PR TITLE
Keep Cloudflare tokens in secrets

### DIFF
--- a/.github/workflows/manage-cf-tokens.yml
+++ b/.github/workflows/manage-cf-tokens.yml
@@ -19,18 +19,6 @@ on:
         description: 'Comma-separated permissions for create (e.g. "workers_scripts:edit,d1:edit")'
         required: false
         type: string
-      cf_user_token:
-        description: 'CF API Token with User→API Tokens:Edit (overrides CF_USER_TOKEN secret)'
-        required: false
-        type: string
-      cf_auth_email:
-        description: 'Cloudflare account email for Global API Key auth (overrides CF_AUTH_EMAIL secret)'
-        required: false
-        type: string
-      cf_auth_key:
-        description: 'Cloudflare Global API Key (use with cf_auth_email; overrides CF_AUTH_KEY secret)'
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -40,9 +28,9 @@ jobs:
     name: Manage CF Tokens (${{ inputs.action }})
     runs-on: ubuntu-latest
     env:
-      CF_USER_TOKEN: ${{ inputs.cf_user_token != '' && inputs.cf_user_token || secrets.CF_USER_TOKEN }}
-      CF_AUTH_EMAIL: ${{ inputs.cf_auth_email != '' && inputs.cf_auth_email || secrets.CF_AUTH_EMAIL }}
-      CF_AUTH_KEY: ${{ inputs.cf_auth_key != '' && inputs.cf_auth_key || secrets.CF_AUTH_KEY }}
+      CF_USER_TOKEN: ${{ secrets.CF_USER_TOKEN }}
+      CF_AUTH_EMAIL: ${{ secrets.CF_AUTH_EMAIL }}
+      CF_AUTH_KEY: ${{ secrets.CF_AUTH_KEY }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
     steps:
@@ -62,7 +50,7 @@ jobs:
               headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
               method  = "API Token (Bearer)"
           else:
-              raise SystemExit("No credentials. Provide cf_user_token OR (cf_auth_email + cf_auth_key).")
+              raise SystemExit("No credentials. Configure CF_USER_TOKEN or both CF_AUTH_EMAIL and CF_AUTH_KEY as GitHub secrets.")
 
           req = urllib.request.Request("https://api.cloudflare.com/client/v4/user", headers=headers)
           try:
@@ -83,7 +71,7 @@ jobs:
       - name: List tokens
         if: inputs.action == 'list'
         env:
-          CF_USER_TOKEN: ${{ inputs.cf_user_token != '' && inputs.cf_user_token || secrets.CF_USER_TOKEN }}
+          CF_USER_TOKEN: ${{ secrets.CF_USER_TOKEN }}
         run: |
           python3 - <<'PY'
           import json, os, urllib.request, urllib.error
@@ -92,10 +80,17 @@ jobs:
           email = os.environ.get("CF_AUTH_EMAIL", "").strip()
           key   = os.environ.get("CF_AUTH_KEY",   "").strip()
 
+          if email and key:
+              headers = {"X-Auth-Email": email, "X-Auth-Key": key, "Content-Type": "application/json"}
+          elif token:
+              headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+          else:
+              raise SystemExit("No credentials. Configure CF_USER_TOKEN or both CF_AUTH_EMAIL and CF_AUTH_KEY as GitHub secrets.")
+
           def cf_get(path):
               req = urllib.request.Request(
                   f"https://api.cloudflare.com/client/v4/{path}",
-                  headers={"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"},
+                  headers=headers,
               )
               try:
                   with urllib.request.urlopen(req) as r:
@@ -118,7 +113,7 @@ jobs:
       - name: Create token
         if: inputs.action == 'create'
         env:
-          CF_USER_TOKEN: ${{ inputs.cf_user_token != '' && inputs.cf_user_token || secrets.CF_USER_TOKEN }}
+          CF_USER_TOKEN: ${{ secrets.CF_USER_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TOKEN_NAME: ${{ inputs.token_name }}
           TOKEN_PERMISSIONS: ${{ inputs.token_permissions }}
@@ -194,7 +189,7 @@ jobs:
       - name: Delete token
         if: inputs.action == 'delete'
         env:
-          CF_USER_TOKEN: ${{ inputs.cf_user_token != '' && inputs.cf_user_token || secrets.CF_USER_TOKEN }}
+          CF_USER_TOKEN: ${{ secrets.CF_USER_TOKEN }}
           TOKEN_NAME: ${{ inputs.token_name }}
         run: |
           python3 - <<'PY'


### PR DESCRIPTION
Merge Strategy: Squash

Remove workflow_dispatch token override inputs so Cloudflare account credentials only come from GitHub secrets.

Also fix list-token authentication header construction while preserving the secret-backed authentication flow.