### PR TITLE
fix(deps): repair pnpm-lock.yaml corruption breaking every CI install

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5859,7 +5859,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260714.1':
@@ -6637,17 +6637,12 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nodelib/fs.scandir@2.1.5':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
Designated lockfile update, opened on its own branch per `.github/workflows/lockfile-guard.yml`, which funnels lockfile changes away from feature PRs.

## Problem

`main` cannot install. `pnpm install --frozen-lockfile` aborts before running any project code:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken:
duplicated mapping key (6652:3)
 6652 |   '@nodelib/fs.scandir@2.1.5':
```

Every branch cut from `main` since the breakage fails `workspace-install`, `lint-test-build`, `repo-health` and the `Workers Builds: gs-{api,web,gateway}-prod` checks, with `gs-web-build` / `gs-api-build-test` / `deployment-dry-run` reported `skipped` because they depend on `workspace-install`.

## Cause

535ade58 ("Fix post-merge regressions in gs-web and gs-api", #6125) mis-merged the `snapshots:` section, leaving three defects:

1. `'@nodelib/fs.scandir@2.1.5'`, `fs.stat` and `fs.walk` appear twice in `snapshots:` — this is the duplicated mapping key pnpm's YAML parser rejects.
2. That duplicate block overwrote the `'@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)'` snapshot entry, dropping it; only the `@emnapi/runtime@1.11.1` peer variant survived.
3. `'@cloudflare/workerd-darwin-64'` was left at `1.20260722.1` in `snapshots:` while `packages:` — and the `arm64` sibling — still declared `1.20260714.1`.

## Fix

The complete delta between the last known-good lockfile (ae03ecb8) and `main` is exactly those two corrupting hunks, and no `package.json` in the workspace changed in that range. So this restores `pnpm-lock.yaml` to ae03ecb8's content: **6 insertions, 11 deletions**, no dependency versions moved.

A full `pnpm install --lockfile-only` was tried first and produced ~2000 changed lines (bumping `@cloudflare/workerd-*` to `1.20260730.1`, dropping the `@napi-rs/wasm-runtime` peer variants, and more). That is a dependency update in disguise, not a repair, so it was discarded in favour of the surgical restore.

## Verification

Locally:

- `pnpm install --frozen-lockfile` → exit 0 across all 15 workspace projects.
- `'@nodelib/fs.scandir@2.1.5'` now appears twice total — once in `packages:`, once in `snapshots:`, as expected.
- Both `@napi-rs/wasm-runtime@1.1.6` peer variants (`@emnapi/runtime@1.11.1` and `@1.11.2`) present again.
- `@cloudflare/workerd-darwin-64` agrees at `1.20260714.1` in both sections, matching `arm64`.

On CI, against the same checks that were red on `main`:

- `workspace-install` ✅, `Preview` ✅, `prevent-lockfile-changes` ✅, GitGuardian ✅
- `Workers Builds: gs-web-prod` ✅ and `gs-gateway-prod` ✅ — both were failing instantly before this change.
- `Workers Builds: gs-api-prod` ❌ — this one is unrelated and pre-existing: it also fails on #6140, which is branched from ae03ecb8 and therefore has a healthy lockfile. Not addressed here.

Found while working #6145; every other open PR against `main` is blocked on this too.