### PR TITLE
fix(cf): make PRODUCT_CATALOG single-source and clear Cloudflare config drift

### DIFF
--- a/.github/workflows/deploy-gs-web.yml
+++ b/.github/workflows/deploy-gs-web.yml
@@ -34,16 +34,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Build verification only — this job does NOT deploy.
+  #
+  # gs-web is an SSR Astro app (`main = ./src/worker.ts`, `output: server`) whose
+  # entrypoint is emitted to dist/server. It is deployed as the `gs-web-prod`
+  # Worker by the Cloudflare Workers Build git integration, which is the single
+  # authoritative deploy path.
+  #
+  # This job previously also ran `wrangler pages deploy apps/gs-web/dist/client
+  # --project-name=gs-web-pages`. That uploaded only the static client assets —
+  # dist/client contains no _worker.js — so it published a static shell in which
+  # every `prerender = false` route (all of /api/admin/*, [...path].astro, ...)
+  # 404'd, racing the Worker for the same hostnames. Removed rather than fixed:
+  # one app, one deploy path.
   deploy:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
     permissions:
       contents: read
-      deployments: write
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -56,37 +64,8 @@ jobs:
           node-version-file: .node-version
           cache: pnpm
 
-      - name: Normalize Cloudflare token
-        env:
-          RAW_CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
-        run: |
-          token="$(
-            node <<'NODE'
-          const raw = process.env.RAW_CLOUDFLARE_API_TOKEN || "";
-          let token = raw.replace(/[\r\n]/g, "").trim();
-          const bearer = token.match(/(?:authorization\s*:\s*)?bearer\s+([^\s"',;}]+)/i);
-          if (bearer) token = bearer[1];
-          const cfut = token.match(/cfut_[A-Za-z0-9_-]+/);
-          if (cfut) token = cfut[0];
-          token = token.replace(/^[`'"]+|[`'",;}]+$/g, "").replace(/\s/g, "");
-          process.stdout.write(token);
-          NODE
-          )"
-          test -n "$token" || (echo "Missing: CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN" && exit 1)
-          echo "::add-mask::$token"
-          echo "CLOUDFLARE_API_TOKEN=$token" >> "$GITHUB_ENV"
-          echo "CLOUDFLARE_BUILD_API_TOKEN=$token" >> "$GITHUB_ENV"
-
-      - name: Verify Cloudflare secrets
-        run: |
-          test -n "$CLOUDFLARE_ACCOUNT_ID"
-          test -n "$CLOUDFLARE_API_TOKEN"
-
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
       - name: Build gs-web Worker output
         run: pnpm build:pages
-
-      - name: Deploy gs-web to Cloudflare Pages
-        run: pnpm exec wrangler pages deploy apps/gs-web/dist/client --project-name=gs-web-pages --branch=${{ github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,14 @@ For Claude/Codex assistance with Google API integration: provide the API name, s
 - Secrets Store: `INTEGRATION_MASTER_KEY` is bound as a per-secret Secrets Store binding from store `b9824d3280c54573a24137c7e7143b33`. Do not use the historical `SECRETS.get(...)` store-object shape in Wrangler config.
 - Unclear/live Cloudflare note: if the dashboard still shows legacy service bindings such as `AGENT`, `GS_MAIL`, `GS_WEB PROD`, `API_SERVICE`, or `GOLDSHORE_AI`, treat them as stale until a human confirms a live dependency; do not re-add them to repo-managed `gs-api` config without updating this file and `docs/WORKER_CONFIGURATION.md`.
 
+> **`KV` means a different namespace in each app.** In `gs-api` the `KV` binding
+> resolves to `GS_API_KV` (`e0b8b807…`); in `gs-web` it resolves to
+> `GOLDSHORE-AI` (`5f133705…`). The binding name is identical, the store is not.
+> Any key that both apps need — `PRODUCT_CATALOG` is the one that got this wrong —
+> must have exactly one owning app, with the other reaching it over HTTP. Reading
+> or writing the same key from `env.KV` in both apps forks it into two stores that
+> diverge silently, with no error at build or deploy time.
+
 ---
 
 ## Active branch: `claude/risk-radar-fra-epo-2wk5mk`

--- a/apps/gs-api/src/index.ts
+++ b/apps/gs-api/src/index.ts
@@ -16,6 +16,7 @@ import admin from './routes/admin';
 import media from './routes/media';
 import pages from './routes/pages';
 import internal from './routes/internal';
+import products from './routes/products';
 import domains from './routes/domains';
 import sites from './routes/sites';
 import forms from './routes/forms';
@@ -261,6 +262,11 @@ app.route('/admin', admin);
 app.route('/media', media);
 app.route('/pages', pages);
 app.route('/internal', internal);
+// Sole owner of the PRODUCT_CATALOG key. gs-web's /api/admin/products proxies
+// here rather than reading KV directly — its `KV` binding resolves to a
+// different namespace (GOLDSHORE-AI), so a direct read/write there would
+// silently fork the catalog.
+app.route('/products', products);
 
 const v1 = new Hono<{ Bindings: Env }>();
 v1.route('/users', users);
@@ -320,28 +326,6 @@ const readInboxLogs = async (kv: KVNamespace) => {
   } catch {
     return [];
   }
-};
-
-const processQueueMessage = async (message: Message<any>, env: Env): Promise<void> => {
-  const body = message.body;
-  const type = typeof body === 'object' && body && 'type' in body ? String((body as { type?: unknown }).type) : 'unknown';
-  if (type === 'contact' || type === 'checkout') {
-    console.info({ event: 'mail_job_processed', id: message.id, type, timestamp: new Date().toISOString() });
-    message.ack();
-    return;
-  }
-  if (type === 'trading' || type === 'trading-signal' || type === 'order') {
-    console.info({ event: 'trading_job_processed', id: message.id, type, timestamp: new Date().toISOString() });
-    message.ack();
-    return;
-  }
-  if (type === 'signal' || type === 'atc') {
-    console.info({ event: 'core_signal_job_processed', id: message.id, type, timestamp: new Date().toISOString() });
-    message.ack();
-    return;
-  }
-  console.info({ event: 'agent_job_processed', id: message.id, type, timestamp: new Date().toISOString() });
-  message.ack();
 };
 
 const processQueueMessage = async (message: Message<any>, env: Env): Promise<void> => {
@@ -441,5 +425,3 @@ export class AuthSession {
     );
   }
 }
-export { isAllowedOrigin, isPreviewOrigin, parseAllowedOrigins };
-export default app;

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -338,17 +338,12 @@ MAILCHANNELS_SENDER_NAME = "GoldShore"
 # ── KV ────────────────────────────────────────────────────────────────────────────
 [[env.preview.kv_namespaces]]
 binding = "KV"
-id = "20d2c096b673433597d084a562993021"
+id = "d4d20cee39094b999dea3f7e5f4c533a"
 
 [[env.preview.kv_namespaces]]
 binding = "CONTROL_LOGS"
 id = "09e43cb8bd4749fdaaed0dc9d4ff2284"
 
-[[env.preview.kv_namespaces]]
-binding = "RISK_RADAR_CACHE"
-id = "a2315c0e83f27b610c3dfdd30eb0a9ea"
-
-# ── R2 ───────────────────────────────────────────────────────────────────────
 # RISK_RADAR_CACHE: same live "RR_CACHE" resource as env.prod — see the note
 # there. No dedicated preview KV exists for this yet.
 [[env.preview.kv_namespaces]]

--- a/apps/gs-web/src/pages/api/admin/products.ts
+++ b/apps/gs-web/src/pages/api/admin/products.ts
@@ -7,89 +7,18 @@ import {
 
 export const prerender = false;
 
-type ProductStatus = 'active' | 'beta' | 'coming_soon' | 'deprecated';
+/**
+ * Admin UI product catalog endpoint.
+ *
+ * This route is a thin authenticated proxy in front of gs-api's `/products`
+ * routes, which are the sole owner of the PRODUCT_CATALOG key. It deliberately
+ * does NOT touch `env.KV`: gs-web's `KV` binding resolves to the GOLDSHORE-AI
+ * namespace while gs-api's resolves to GS_API_KV, so reading or writing the
+ * catalog here would fork it into two stores that diverge silently.
+ */
 
-type ProductPlan = {
-  id: string;
-  name: string;
-  price: number;
-  currency: string;
-  interval: 'month' | 'year' | 'one_time';
-  features: string[];
-};
-
-type Product = {
-  id: string;
-  name: string;
-  slug: string;
-  status: ProductStatus;
-  description: string;
-  features: string[];
-  plans: ProductPlan[];
-  settings: Record<string, unknown>;
-  updatedAt: string;
-};
-
-const DEFAULT_PRODUCTS: Product[] = [
-  {
-    id: 'risk-radar',
-    name: 'Risk Radar',
-    slug: 'risk-radar',
-    status: 'beta',
-    description: 'Real-time risk assessment and alerting for portfolio positions.',
-    features: [
-      'Sub-28ms signal latency',
-      'Composite risk scoring',
-      'Multi-asset support',
-      'TCG and equity positions',
-    ],
-    plans: [
-      {
-        id: 'risk-radar-basic',
-        name: 'Basic',
-        price: 0,
-        currency: 'USD',
-        interval: 'month',
-        features: ['5 assets monitored', 'Daily reports', 'Email alerts'],
-      },
-      {
-        id: 'risk-radar-pro',
-        name: 'Pro',
-        price: 99,
-        currency: 'USD',
-        interval: 'month',
-        features: ['Unlimited assets', 'Real-time alerts', 'API access'],
-      },
-    ],
-    settings: { signalLatencyTarget: 28, compositeScoringEnabled: true, briefingEnabled: true },
-    updatedAt: new Date().toISOString(),
-  },
-  {
-    id: 'platform',
-    name: 'Platform',
-    slug: 'platform',
-    status: 'active',
-    description: 'Goldshore AI Platform — operational intelligence and automation.',
-    features: ['AI Oracle', 'Financial Signals', 'Workflow Engine', 'Sentinel'],
-    plans: [
-      {
-        id: 'platform-enterprise',
-        name: 'Enterprise',
-        price: 0,
-        currency: 'USD',
-        interval: 'month',
-        features: ['Contact for pricing', 'Custom SLA'],
-      },
-    ],
-    settings: { aiOracleEnabled: true, workflowEngineEnabled: true },
-    updatedAt: new Date().toISOString(),
-  },
-];
-
-const getCatalog = async (env: Env): Promise<{ products: Product[] }> => {
-  const stored = await env.KV?.get('PRODUCT_CATALOG', 'json');
-  return (stored as { products: Product[] } | null) ?? { products: DEFAULT_PRODUCTS };
-};
+const apiBase = (env: Env | undefined) =>
+  (env?.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
 
 const hasPermission = async (
   request: Request,
@@ -115,57 +44,76 @@ const isSameOriginRequest = (request: Request) => {
   return false;
 };
 
+/** Forward only the headers gs-api needs to re-authenticate the caller. */
+const forwardedHeaders = (request: Request) => {
+  const headers = new Headers();
+  for (const name of ['accept', 'authorization', 'cookie', 'cf-access-jwt-assertion']) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  return headers;
+};
+
+const upstream = async (
+  request: Request,
+  env: Env | undefined,
+  path: string,
+  init?: { method?: string; body?: string },
+) => {
+  const headers = forwardedHeaders(request);
+  if (init?.body !== undefined) headers.set('content-type', 'application/json');
+
+  try {
+    const response = await fetch(`${apiBase(env)}${path}`, {
+      method: init?.method ?? 'GET',
+      headers,
+      body: init?.body,
+    });
+
+    const contentType = response.headers.get('content-type') ?? 'application/json';
+    return new Response(response.body, {
+      status: response.status,
+      headers: { 'content-type': contentType },
+    });
+  } catch {
+    return new Response('Unable to reach the product catalog service.', { status: 502 });
+  }
+};
+
 export const GET: APIRoute = async ({ request, locals }) => {
   const env = locals.runtime?.env as Env | undefined;
-  if (!env?.KV) return new Response('Storage unavailable.', { status: 503 });
 
   const ok = await hasPermission(request, env as never, 'system:read');
   if (!ok) return new Response('Unauthorized', { status: 401 });
 
-  const url = new URL(request.url);
-  const id = url.searchParams.get('id');
+  const id = new URL(request.url).searchParams.get('id');
+  const path = id ? `/products/${encodeURIComponent(id)}` : '/products';
 
-  const catalog = await getCatalog(env);
-  if (id) {
-    const product = catalog.products.find((p) => p.id === id || p.slug === id);
-    if (!product) return new Response('Product not found.', { status: 404 });
-    return Response.json({ success: true, product });
-  }
-
-  return Response.json({ success: true, ...catalog });
+  return upstream(request, env, path);
 };
 
 export const PUT: APIRoute = async ({ request, locals }) => {
   const env = locals.runtime?.env as Env | undefined;
-  if (!env?.KV) return new Response('Storage unavailable.', { status: 503 });
 
   if (!isSameOriginRequest(request)) return new Response('Forbidden: CSRF check failed.', { status: 403 });
 
   const ok = await hasPermission(request, env as never, 'system:write');
   if (!ok) return new Response('Unauthorized', { status: 401 });
 
-  const url = new URL(request.url);
-  const id = url.searchParams.get('id');
+  const id = new URL(request.url).searchParams.get('id');
   if (!id) return new Response('id query param required.', { status: 400 });
 
-  const body = await request.json() as Partial<Product>;
-  if (!body) return new Response('Invalid payload.', { status: 400 });
+  const body = await request.text();
 
-  const catalog = await getCatalog(env);
-  const idx = catalog.products.findIndex((p) => p.id === id || p.slug === id);
-  if (idx === -1) return new Response('Product not found.', { status: 404 });
-
-  const updated: Product = {
-    ...catalog.products[idx],
-    ...body,
-    id: catalog.products[idx].id,
-    slug: catalog.products[idx].slug,
-    updatedAt: new Date().toISOString(),
-  };
-  catalog.products[idx] = updated;
-
-  await env.KV.put('PRODUCT_CATALOG', JSON.stringify(catalog));
-  return Response.json({ success: true, product: updated });
+  return upstream(request, env, `/products/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body,
+  });
 };
 
 export const PATCH = PUT;
+
+export const __testing = {
+  isSameOriginRequest,
+  forwardedHeaders,
+};

--- a/apps/gs-web/src/pages/api/forms/[slug].ts
+++ b/apps/gs-web/src/pages/api/forms/[slug].ts
@@ -102,23 +102,14 @@ export const GET: APIRoute = async ({ request, locals, params }) => {
     .bind(slug)
     .all();
 
-const forwardedHeaders = (request: Request) => {
-  const headers = new Headers();
-  for (const name of ['accept', 'authorization', 'cookie', 'cf-connecting-ip', 'user-agent', 'content-type']) {
-    const value = request.headers.get(name);
-    if (value) headers.set(name, value);
+  const row = result?.results?.[0] as Record<string, string> | undefined;
+  if (!row) {
+    return new Response('Form not found.', { status: 404 });
   }
-  return headers;
+
+  return Response.json({ config: normalizeRow(row) });
 };
 
-const proxy = async (request: Request, env: Env | undefined, slug?: string) => {
-  if (!slug) return new Response('Form slug is required.', { status: 400 });
-
-  const target = new URL(`${apiBase(env)}/v1/forms/configs/${encodeURIComponent(slug)}`);
-  const response = await fetch(target, {
-    method: request.method,
-    headers: forwardedHeaders(request),
-    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.text(),
 export const PUT: APIRoute = async ({ request, locals, params }) => {
   const env = locals.runtime?.env as AccessEnv | undefined;
   const slug = params.slug;
@@ -200,12 +191,6 @@ export const PUT: APIRoute = async ({ request, locals, params }) => {
       createdAt: row.created_at,
       updatedAt: now,
     },
-
-  const target = new URL(`${apiBase(env)}/v1/forms/configs/${encodeURIComponent(slug)}`);
-  const response = await fetch(target, {
-    method: request.method,
-    headers: forwardedHeaders(request),
-    body: request.method === 'GET' || request.method === 'HEAD' ? undefined : await request.text(),
   });
 };
 

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -50,7 +50,6 @@ routes = [
   { pattern = "goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "goldshore.org/*", zone_name = "goldshore.org" },
   { pattern = "admin.goldshore.ai/*", zone_name = "goldshore.ai" },
-  { pattern = "admin.goldshore.org/*", zone_name = "goldshore.org" },
   { pattern = "admin-preview.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "admin.goldshore.org/*", zone_name = "goldshore.org" },
   { pattern = "risk.goldshore.ai/*", zone_name = "goldshore.ai" },

--- a/infra/Cloudflare/BINDINGS_MAP.md
+++ b/infra/Cloudflare/BINDINGS_MAP.md
@@ -6,17 +6,28 @@
 
 ---
 
-## Pages Projects
+## Web / Admin front end
 
 ### 1. Web (Public)
 
-- Project: `gs-web`
+`apps/gs-web` is **not** a Pages project. It is an SSR Astro app served by the
+`gs-web-prod` Worker, deployed by the Cloudflare Workers Build git integration.
+Hostnames are attached via the `routes` list in `apps/gs-web/wrangler.toml`, not
+via Pages custom domains.
+
+- Worker: `gs-web-prod`
 - Repo: `goldshore-ai`
 - Root: `apps/gs-web`
-- Custom Domains:
-  - `goldshore.ai`
-  - `www.goldshore.ai`
-  - `preview.goldshore.ai`
+- Routes (see `[env.prod]` in `apps/gs-web/wrangler.toml` for the authoritative list):
+  - `goldshore.ai/*`, `goldshore.org/*`
+  - `admin.goldshore.ai/*`, `admin-preview.goldshore.ai/*`, `admin.goldshore.org/*`
+  - `risk.goldshore.ai/*`, `risk.goldshore.org/*`
+
+A second deploy path — `wrangler pages deploy apps/gs-web/dist/client
+--project-name=gs-web-pages` in `.github/workflows/deploy-gs-web.yml` — was
+removed. It shipped only the static client assets (dist/client has no
+`_worker.js`), so it published a static shell that 404'd every SSR route while
+competing with the Worker for the same hostnames.
 
 **Environment Variables:**
 


### PR DESCRIPTION
## F1 — PRODUCT_CATALOG split across two KV namespaces

The `KV` binding name resolves to a **different namespace in each app**:

| binding | id | live namespace |
|---|---|---|
| gs-api `KV` | `e0b8b807…` | `GS_API_KV` |
| gs-web `KV` | `5f133705…` | `GOLDSHORE-AI` |

`PRODUCT_CATALOG` was read and written from both `apps/gs-api/src/routes/products.ts` and `apps/gs-web/src/pages/api/admin/products.ts`, so the admin UI and the API were editing two unrelated stores that diverged silently — no error at build or deploy time.

`gs-web`'s `/api/admin/products` is now a thin authenticated proxy over gs-api's `/products` routes, which own the key outright. Unchanged: the `authorizeAdminRequest` / `isSameOriginRequest` CSRF guards, the `system:read` / `system:write` permission checks, and the `?id=` query contract `apps/gs-web/src/pages/admin/products/index.astro` depends on. The duplicated `DEFAULT_PRODUCTS` fallback is dropped from gs-web so the two copies cannot drift.

**One finding not in the original audit:** the gs-api products router was dead code — defined but never imported or mounted in `src/index.ts`, so `/products` returned 404. Proxying to it alone would have broken the working admin UI. It is now mounted, behind the existing global Access middleware and its own per-route permission checks. This is also what makes the plan's end-to-end check (`GET api.goldshore.ai/products` reflecting an admin save) possible at all.

`SERVICE_CATALOG` is likewise unmounted dead code in gs-api and has no live writer; `ADMIN_SITE_SETTINGS` is gs-web only. Both left alone.

## F2 — config drift

- **`RISK_RADAR_CACHE` declared twice** under `[env.preview]`. The first id `a2315c0e…` does not exist in the account — checked against all 33 live namespaces. Removed; the live `RR_CACHE` (`0b56873b…`) remains. A misplaced `── R2 ──` separator tangled into the same block went with it.
- **Preview KV id.** Config said `GS_API_KV_PRV` (`20d2c096…`); `CLAUDE.md` and `infra/Cloudflare/gs-api.wrangler.toml` both said `GS_API_KV_PREVIEW` (`d4d20cee…`). `d4d20cee` was the original value since the file was created; the switch came in #5801, a squashed omnibus commit whose message gives no rationale. Restored to `d4d20cee`. Both namespaces are empty (0 keys, per `reports/cloudflare-kv-secret-inventory-2026-07-14.md`), so nothing migrates.
- **Duplicate route.** `apps/gs-web/wrangler.toml` listed `admin.goldshore.org/*` twice in `[env.prod]`, which failed `wrangler-config.test.ts`.
- **Two competing gs-web deploy paths.** `deploy-gs-web.yml` deployed `apps/gs-web/dist/client` to the `gs-web-pages` Pages project while Workers Builds deployed the `gs-web-prod` Worker. gs-web is SSR (`main = ./src/worker.ts`, `output: server`, entry in `dist/server`); `dist/client` holds only static assets and no `_worker.js`, so that path published a shell where every `prerender = false` route — all of `/api/admin/*`, `[...path].astro` — 404'd, while racing the Worker for the same hostnames. Removed, leaving the Worker as the single deploy path, along with the CF token plumbing that only served it. `BINDINGS_MAP.md` still described the older Pages-era topology and is updated.

The workflow's `name:` and job id are deliberately unchanged so any branch-protection check name still resolves; it is now build-verification only and could be renamed once that's confirmed.

## Bad-merge repairs (blocking, pre-existing on main)

Both builds were already broken on `main` before this work, both from `de8f935`:

- `apps/gs-web/src/pages/api/forms/[slug].ts` had a half-written proxy spliced into the middle of its D1 handlers — targeting `/v1/forms/configs`, a route gs-api does not define — leaving unclosed functions and an unreachable `export`. Restored the coherent pre-`de8f935` D1 implementation, which matches its sibling `forms/index.ts`.
- `apps/gs-api/src/index.ts` carried a verbatim duplicate `processQueueMessage` plus stray duplicate exports, including an `export default app` that would have shadowed the real default export and dropped the queue consumer. `a60aa4f` had already fixed this once before `de8f935` reintroduced it.

This likely bears on two things listed as out of scope: gs-api's Workers Build failing on every commit, and `api.goldshore.ai` returning 500 on every route (noted in #6149). gs-api did **not** compile before this change — contrary to the audit's note that local dry-run passed cleanly — so the build integration had nothing valid to ship. Worth re-checking after merge; the dashboard token issue may or may not also be real.

## Verification

- `pnpm --dir apps/gs-web build` and `wrangler deploy --env prod --dry-run` for gs-api both pass.
- `dist/server/wrangler.json` lists `KV`, `SESSION`, `PLATFORM_DB`, `GS_ASSETS` — closing out the earlier report that the gs-web build stripped them, which had been measured against a stale `dist/`.
- gs-api `--env preview --dry-run` resolves `RISK_RADAR_CACHE` to `0b56873b…` and `KV` to `d4d20cee…`, no duplicate-binding warning.
- Exactly one writer of `PRODUCT_CATALOG` remains, in `GS_API_KV`.
- Tests: gs-api 77/77 (was 76/77 on main), gs-web e2e 7/7.
- Every KV id in both `wrangler.toml` files cross-checked against the live namespace list for account `f77de112…`.

**Not verified:** `scripts/validate-cf-resources.mjs` still skips silently — no `CLOUDFLARE_ACCOUNT_ID` or token in this environment, same as during the audit. The live cross-check above was done via the Cloudflare API instead. The post-deploy end-to-end check (save a product in `/admin/products`, confirm `GET api.goldshore.ai/products` reflects it) cannot run until this is deployed.

`pnpm-lock.yaml` is untouched — #6149 merged mid-session and repaired it; `--frozen-lockfile` now succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGuU9wv9t2j7qDTCUsrmEd)_