### PR TITLE
Use dashboard URLs and centralized destination resolver for admin login redirects

### DIFF
--- a/apps/gs-web/src/pages/login.astro
+++ b/apps/gs-web/src/pages/login.astro
@@ -1,18 +1,13 @@
 ---
 import {
-  ALTERNATE_ADMIN_ORIGIN,
-  CANONICAL_ADMIN_ORIGIN,
+  ALTERNATE_ADMIN_DASHBOARD_URL,
+  CANONICAL_ADMIN_DASHBOARD_URL,
+  getAdminLoginDestination,
 } from '../utils/admin-access';
 
 const requested = Astro.url.searchParams.get('to') ?? 'dashboard';
 const loginType = Astro.url.searchParams.get('type') ?? 'admin';
-const destinations: Record<string, string> = {
-  dashboard: CANONICAL_ADMIN_ORIGIN,
-  admin: CANONICAL_ADMIN_ORIGIN,
-  org: ALTERNATE_ADMIN_ORIGIN,
-  ai: CANONICAL_ADMIN_ORIGIN,
-};
-const destination = destinations[requested] ?? CANONICAL_ADMIN_ORIGIN;
+const destination = getAdminLoginDestination(requested);
 const apiOrigin = Astro.locals.PUBLIC_API || import.meta.env.PUBLIC_API || 'https://api.goldshore.ai';
 const redirectUri = `${Astro.url.origin}/auth/callback`;
 ---
@@ -54,9 +49,9 @@ const redirectUri = `${Astro.url.origin}/auth/callback`;
           <p>Cloudflare Access will verify your identity before loading the dashboard.</p>
           <a href={destination} class="button button--primary">Continue with Cloudflare Access</a>
           <nav aria-label="Admin destinations">
-            <a href={CANONICAL_ADMIN_ORIGIN}>Dashboard</a>
-            <a href={CANONICAL_ADMIN_ORIGIN}>Admin AI</a>
-            <a href={ALTERNATE_ADMIN_ORIGIN}>Admin Org</a>
+            <a href={CANONICAL_ADMIN_DASHBOARD_URL}>Dashboard</a>
+            <a href={CANONICAL_ADMIN_DASHBOARD_URL}>Admin AI</a>
+            <a href={ALTERNATE_ADMIN_DASHBOARD_URL}>Admin Org</a>
           </nav>
           <p class="footer-text">
             Or <a href={`/login?type=github`}>sign in with GitHub</a>

--- a/apps/gs-web/tests/unit/admin-access.test.ts
+++ b/apps/gs-web/tests/unit/admin-access.test.ts
@@ -79,6 +79,16 @@ test('sends admin login destinations directly to the dashboard path', () => {
   assert.equal(getAdminLoginDestination('unknown'), CANONICAL_ADMIN_DASHBOARD_URL);
 });
 
+test('login page uses dashboard destinations instead of admin host roots', async () => {
+  const source = await import('node:fs/promises').then(({ readFile }) =>
+    readFile(new URL('../../src/pages/login.astro', import.meta.url), 'utf8'),
+  );
+
+  assert.match(source, /const destination = getAdminLoginDestination\(requested\)/);
+  assert.match(source, /href=\{CANONICAL_ADMIN_DASHBOARD_URL\}/);
+  assert.match(source, /href=\{ALTERNATE_ADMIN_DASHBOARD_URL\}/);
+});
+
 test('maps clean admin hostname URLs into the Astro admin route tree', () => {
   assert.equal(
     getAdminHostRewritePath('/workers/status'),


### PR DESCRIPTION
### Motivation
- Replace root-host admin origins with explicit dashboard URLs and centralize login destination logic so admin login redirects target dashboard routes rather than host roots.

### Description
- In `apps/gs-web/src/pages/login.astro` replace the inline `destinations` map with `const destination = getAdminLoginDestination(requested)` and import `ALTERNATE_ADMIN_DASHBOARD_URL`, `CANONICAL_ADMIN_DASHBOARD_URL`, and `getAdminLoginDestination`.
- Update admin navigation links in `login.astro` to reference `CANONICAL_ADMIN_DASHBOARD_URL` and `ALTERNATE_ADMIN_DASHBOARD_URL` instead of the previous origin constants.
- Add a unit test in `apps/gs-web/tests/unit/admin-access.test.ts` asserting that `login.astro` uses `getAdminLoginDestination` and the new dashboard URL constants, and keep existing tests for `getAdminLoginDestination` mappings.

### Testing
- Ran unit tests with `pnpm test` and all tests, including the new `login page uses dashboard destinations` test, passed.
- The added file-content assertions verify that `login.astro` contains `const destination = getAdminLoginDestination(requested)` and references to `CANONICAL_ADMIN_DASHBOARD_URL` and `ALTERNATE_ADMIN_DASHBOARD_URL`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77f6b5b5848331a7e9c13bb6c896c5)