### PR TITLE
Skip credential-only Cloudflare checks without PR secrets

### DIFF
--- a/.github/workflows/infrastructure-guard.yml
+++ b/.github/workflows/infrastructure-guard.yml
@@ -252,6 +252,9 @@ jobs:
             echo "::add-mask::$token"
             echo "CLOUDFLARE_API_TOKEN=$token" >> "$GITHUB_ENV"
             echo "CLOUDFLARE_BUILD_API_TOKEN=$token" >> "$GITHUB_ENV"
+            echo "CLOUDFLARE_CREDENTIALS_AVAILABLE=true" >> "$GITHUB_ENV"
+          else
+            echo "CLOUDFLARE_CREDENTIALS_AVAILABLE=false" >> "$GITHUB_ENV"
           fi
 
       - name: Verify Cloudflare credentials
@@ -269,6 +272,7 @@ jobs:
           fi
 
       - name: Audit live Cloudflare state against manifest
+        if: env.CLOUDFLARE_CREDENTIALS_AVAILABLE == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/preview-gs-api.yml
+++ b/.github/workflows/preview-gs-api.yml
@@ -51,10 +51,15 @@ jobs:
           process.stdout.write(token);
           NODE
           )"
-          test -n "$token" || (echo "Missing: CLOUDFLARE_BUILD_API_TOKEN" && exit 1)
+          if [ -z "$token" ]; then
+            echo "::warning::Cloudflare credentials are unavailable; skipping authenticated preview dry-run steps."
+            echo "CLOUDFLARE_CREDENTIALS_AVAILABLE=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
           echo "::add-mask::$token"
           echo "CLOUDFLARE_API_TOKEN=$token" >> "$GITHUB_ENV"
           echo "CLOUDFLARE_BUILD_API_TOKEN=$token" >> "$GITHUB_ENV"
+          echo "CLOUDFLARE_CREDENTIALS_AVAILABLE=true" >> "$GITHUB_ENV"
 
       - name: Validate workspace contract
         run: pnpm validate:workspace
@@ -74,9 +79,11 @@ jobs:
           ! grep -Eq '00000000-0000-4000-8000-00000000000[1-9]' apps/gs-api/wrangler.toml
 
       - name: Verify Cloudflare auth
+        if: env.CLOUDFLARE_CREDENTIALS_AVAILABLE == 'true'
         working-directory: apps/gs-api
         run: pnpm exec wrangler whoami
 
       - name: Validate GS API worker preview deploy
+        if: env.CLOUDFLARE_CREDENTIALS_AVAILABLE == 'true'
         working-directory: apps/gs-api
         run: pnpm exec wrangler deploy --env preview --config wrangler.toml --dry-run --outdir=dist-preview


### PR DESCRIPTION
Merge Strategy: Squash

Prevents Dependabot and other secret-restricted pull requests from failing solely because Cloudflare credentials are unavailable.

- keeps workspace, Worker structure, naming, and configuration validation running
- skips only authenticated Wrangler preview and live Cloudflare audit steps when no token is provided
- continues to run and fail authenticated checks when credentials are available but invalid
- performs no deployment or Cloudflare configuration mutation

Validation:
- YAML parsed for both changed workflows
- git diff --check

@Jules-Bot [review-request]
[agent:codex] [env:preview] [status:ready]