### PR TITLE
Stop the admin dashboard trapping operators on the admin host

### DIFF
--- a/apps/gs-web/src/components/Sidebar.astro
+++ b/apps/gs-web/src/components/Sidebar.astro
@@ -33,6 +33,12 @@ const governanceLinks: Array<{ href: string; label: string }> = [
 const { logo, permissions = [] } = Astro.props;
 const can = (permission: string) => permissions.includes(permission);
 
+// Send operators back to the public site on the same TLD they administer, so
+// admin.goldshore.org returns to goldshore.org rather than goldshore.ai.
+const PUBLIC_SITE_ORIGIN = Astro.url.hostname.toLowerCase().endsWith('goldshore.org')
+  ? 'https://goldshore.org'
+  : 'https://goldshore.ai';
+
 const isActive = (href: string) => {
   const currentPath = Astro.url.pathname;
   const cleanCurrent = currentPath.endsWith('/') ? currentPath.slice(0, -1) : currentPath;
@@ -127,6 +133,15 @@ const isActive = (href: string) => {
     </a>
 
     <div class="gs-sidebar-footer">
+      <!--
+        Absolute URL on purpose. Every relative path on the admin hostname is
+        resolved against that host and then folded back to the dashboard by
+        getAdminHostRewritePath, so a relative "/" here would trap the operator
+        on admin.goldshore.ai with no way back to the public site.
+      -->
+      <a href={PUBLIC_SITE_ORIGIN} class="gs-nav-block gs-public-site-btn" rel="noopener">
+        ← Public site
+      </a>
       <a href="/logout" class="gs-nav-block gs-logout-btn">
         Logout
       </a>

--- a/apps/gs-web/src/pages/admin/api-status.astro
+++ b/apps/gs-web/src/pages/admin/api-status.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminAuthError, getAdminRouteRule } from '../../utils/admin-access';
 
 export const prerender = false;
@@ -77,7 +77,7 @@ if (!authError) {
 const formatDate = (value: string | null | undefined) => (value ? new Date(value).toLocaleString() : '—');
 ---
 
-<BaseLayout title="API Status | GoldShore Admin" description="gs-api routes, health, and runtime config">
+<AdminLayout title="API Status | GoldShore Admin">
   <section class="gs-section">
     <div class="gs-grid columns-2">
       <div>
@@ -177,4 +177,4 @@ const formatDate = (value: string | null | undefined) => (value ? new Date(value
       </>
     )}
   </section>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/admin/crawler/index.astro
+++ b/apps/gs-web/src/pages/admin/crawler/index.astro
@@ -1,11 +1,11 @@
 ---
 export const prerender = false;
 
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import AdminLayout from "../../../layouts/AdminLayout.astro";
 import { GSButton } from '@goldshore/ui';
 ---
 
-<BaseLayout title="Web Crawler | GoldShore Admin" description="Admin crawler queue for lead discovery">
+<AdminLayout title="Web Crawler | GoldShore Admin">
   <div class="max-w-7xl mx-auto p-8 space-y-8">
     <div class="flex items-center justify-between">
       <div>
@@ -246,4 +246,4 @@ import { GSButton } from '@goldshore/ui';
       setInterval(loadJobs, 30000); // Refresh every 30 seconds
     });
   </script>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/admin/deploy.astro
+++ b/apps/gs-web/src/pages/admin/deploy.astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = false;
 
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminAuthError, getAdminRouteRule } from '../../utils/admin-access';
 
 const env = Astro.locals.runtime?.env as Env | undefined;
@@ -17,7 +17,7 @@ if (!rule) {
 }
 ---
 
-<BaseLayout title="Deploy Assistant | GoldShore Admin" description="Search Cloudflare-native templates, stream ranked recommendations, and stage dry-run deployments.">
+<AdminLayout title="Deploy Assistant | GoldShore Admin">
   <section class="gs-section deploy-assistant" data-api-base={apiBase}>
     <div class="gs-grid columns-2">
       <div>
@@ -343,7 +343,7 @@ if (!rule) {
 
     loadRecommendations().catch((error) => setText('assistant-summary', error.message || 'Initial search failed'));
   </script>
-</BaseLayout>
+</AdminLayout>
 
 <style>
   .deploy-flow {

--- a/apps/gs-web/src/pages/admin/goldclaw.astro
+++ b/apps/gs-web/src/pages/admin/goldclaw.astro
@@ -1,16 +1,15 @@
 ---
 export const prerender = false;
 
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 
 const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
 ---
 
-<BaseLayout
+<AdminLayout
   title="GoldClaw Control | GoldShore Admin"
-  description="GoldClaw monetization, marketing, SEO, and agent integration control surface"
 >
-  <main class="goldclaw-page" data-api-base={apiBase}>
+  <div class="goldclaw-page" data-api-base={apiBase}>
     <header class="goldclaw-header">
       <div>
         <p class="goldclaw-kicker">GoldShore Labs</p>
@@ -77,7 +76,7 @@ const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').repla
       </div>
       <div id="goldclaw-plan" class="goldclaw-plan"></div>
     </section>
-  </main>
+  </div>
 
   <script is:inline>
     const page = document.querySelector('.goldclaw-page');
@@ -184,7 +183,7 @@ const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').repla
       if (target) target.innerHTML = `<p class="goldclaw-error">${error.message}</p>`;
     });
   </script>
-</BaseLayout>
+</AdminLayout>
 
 <style>
   .goldclaw-page {

--- a/apps/gs-web/src/pages/admin/integrations/all.astro
+++ b/apps/gs-web/src/pages/admin/integrations/all.astro
@@ -1,16 +1,15 @@
 ---
 export const prerender = false;
 
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import AdminLayout from "../../../layouts/AdminLayout.astro";
 
 const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').replace(/\/$/, '');
 ---
 
-<BaseLayout
+<AdminLayout
   title="Integrations | GoldShore Admin"
-  description="Connect and manage business integrations and LLM providers from the consolidated GoldShore web app."
 >
-  <main class="integrations-page" data-api-base={apiBase}>
+  <div class="integrations-page" data-api-base={apiBase}>
 
   <div class="integrations-shell">
     <div class="flex items-center justify-between">
@@ -270,8 +269,8 @@ const apiBase = (import.meta.env.PUBLIC_API || 'https://api.goldshore.ai').repla
   </script>
 
 
-  </main>
-</BaseLayout>
+  </div>
+</AdminLayout>
 
 <style>
   .integrations-page { min-height: 100vh; background: #050507; color: #f5f3ec; padding: 40px clamp(20px,4vw,56px); }

--- a/apps/gs-web/src/pages/admin/integrations/keys.astro
+++ b/apps/gs-web/src/pages/admin/integrations/keys.astro
@@ -1,11 +1,11 @@
 ---
 export const prerender = false;
 
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import AdminLayout from "../../../layouts/AdminLayout.astro";
 import { GSButton } from '@goldshore/ui';
 ---
 
-<BaseLayout title="API Keys | GoldShore Admin" description="Secure integration API key management">
+<AdminLayout title="API Keys | GoldShore Admin">
   <div class="max-w-7xl mx-auto p-8 space-y-8">
     <!-- Header -->
     <div class="flex items-center justify-between">
@@ -627,4 +627,4 @@ import { GSButton } from '@goldshore/ui';
     // Refresh commands every 30 seconds (for nanny mode WhatsApp reactions)
     setInterval(loadPendingCommands, 30000);
   </script>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/admin/lead-submissions.astro
+++ b/apps/gs-web/src/pages/admin/lead-submissions.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 
 export const prerender = false;
 
@@ -60,7 +60,7 @@ const buildMailto = (email: string | null, name: string | null) => {
 };
 ---
 
-<BaseLayout title="Lead Submissions | GoldShore" description="Admin review for inbound leads">
+<AdminLayout title="Lead Submissions | GoldShore">
   <section class="gs-section">
     <div class="gs-grid columns-2">
       <div>
@@ -155,4 +155,4 @@ const buildMailto = (email: string | null, name: string | null) => {
       </div>
     )}
   </section>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/admin/monetization.astro
+++ b/apps/gs-web/src/pages/admin/monetization.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminAuthError, getAdminRouteRule } from '../../utils/admin-access';
 
 export const prerender = false;
@@ -16,7 +16,7 @@ if (!rule) {
 }
 ---
 
-<BaseLayout title="Monetization | GoldShore Admin" description="AdSense earnings and other revenue streams">
+<AdminLayout title="Monetization | GoldShore Admin">
   <section class="gs-section">
     <div class="gs-grid columns-2">
       <div>
@@ -135,4 +135,4 @@ if (!rule) {
     document.getElementById('refresh-adsense')?.addEventListener('click', loadAdSenseData);
     loadAdSenseData();
   </script>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/admin/products/index.astro
+++ b/apps/gs-web/src/pages/admin/products/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import AdminLayout from "../../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminRouteRule } from '../../../utils/admin-access';
 
 export const prerender = false;
@@ -74,9 +74,8 @@ const fmtPrice = (price: number, currency: string, interval: string) => {
 };
 ---
 
-<BaseLayout
+<AdminLayout
   title="Product Catalog | GoldShore Admin"
-  description="Manage product offerings, plans, and settings"
 >
   <section class="gs-section">
     <div class="gs-grid columns-2">
@@ -231,7 +230,7 @@ const fmtPrice = (price: number, currency: string, interval: string) => {
       });
     });
   </script>
-</BaseLayout>
+</AdminLayout>
 
 <style>
   .gs-select {

--- a/apps/gs-web/src/pages/admin/search-console.astro
+++ b/apps/gs-web/src/pages/admin/search-console.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminAuthError, getAdminRouteRule } from '../../utils/admin-access';
 
 export const prerender = false;
@@ -16,7 +16,7 @@ if (!rule) {
 }
 ---
 
-<BaseLayout title="Search Console | GoldShore Admin" description="Organic search performance from Google Search Console">
+<AdminLayout title="Search Console | GoldShore Admin">
   <section class="gs-section">
     <div class="gs-grid columns-2">
       <div>
@@ -158,4 +158,4 @@ if (!rule) {
     document.getElementById('refresh-gsc')?.addEventListener('click', loadSearchConsoleData);
     loadSearchConsoleData();
   </script>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/admin/services/index.astro
+++ b/apps/gs-web/src/pages/admin/services/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import AdminLayout from "../../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminRouteRule } from '../../../utils/admin-access';
 
 export const prerender = false;
@@ -81,9 +81,8 @@ const fmt = (value: string | null | undefined) =>
   value ? new Date(value).toLocaleString() : '—';
 ---
 
-<BaseLayout
+<AdminLayout
   title="Service Workflows | GoldShore Admin"
-  description="Manage service inquiries and approval workflows"
 >
   <section class="gs-section">
     <div class="gs-grid columns-2">
@@ -284,7 +283,7 @@ const fmt = (value: string | null | undefined) =>
       });
     });
   </script>
-</BaseLayout>
+</AdminLayout>
 
 <style>
   .gs-card--active {

--- a/apps/gs-web/src/pages/admin/subscribers.astro
+++ b/apps/gs-web/src/pages/admin/subscribers.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 
 export const prerender = false;
 
@@ -43,7 +43,7 @@ const exportUrl = `/api/admin/subscribers?format=csv${status ? `&status=${encode
 const formatDate = (value: string | null) => value ? new Date(value).toLocaleString() : '—';
 ---
 
-<BaseLayout title="Newsletter Subscribers | GoldShore" description="Review newsletter subscriptions and consent">
+<AdminLayout title="Newsletter Subscribers | GoldShore">
   <section class="gs-section">
     <div class="gs-grid columns-2">
       <div>
@@ -111,4 +111,4 @@ const formatDate = (value: string | null) => value ? new Date(value).toLocaleStr
       </div>
     )}
   </section>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/app/dashboard.astro
+++ b/apps/gs-web/src/pages/app/dashboard.astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = false;
 
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 
 const tools = [
   {
@@ -48,8 +48,8 @@ const quickLinks = [
 ] as const;
 ---
 
-<BaseLayout title="Gold Shore Admin | Dashboard" description="Protected Gold Shore control plane">
-  <main class="admin-dashboard">
+<AdminLayout title="Gold Shore Admin | Dashboard">
+  <div class="admin-dashboard">
     <header class="dashboard-header">
       <div>
         <p class="dashboard-kicker">Gold Shore Admin / Control plane</p>
@@ -125,8 +125,8 @@ const quickLinks = [
         {quickLinks.map(([label, href]) => <a href={href}>{label}<span>↗</span></a>)}
       </nav>
     </section>
-  </main>
-</BaseLayout>
+  </div>
+</AdminLayout>
 
 <style>
   .admin-dashboard {

--- a/apps/gs-web/src/pages/app/logs.astro
+++ b/apps/gs-web/src/pages/app/logs.astro
@@ -1,11 +1,11 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 ---
-<BaseLayout title="Logs | GoldShore">
+<AdminLayout title="Logs | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">
         <h1 class="text-4xl gs-heading mb-4">Activity Logs</h1>
         <p class="text-[var(--gs-text-secondary)]">
             System logs and user event history will be shown here.
         </p>
     </section>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/app/profile.astro
+++ b/apps/gs-web/src/pages/app/profile.astro
@@ -1,11 +1,11 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 ---
-<BaseLayout title="Profile | GoldShore">
+<AdminLayout title="Profile | GoldShore">
     <section class="max-w-4xl mx-auto py-24 px-6">
         <h1 class="text-4xl gs-heading mb-4">Profile Settings</h1>
         <p class="text-[var(--gs-text-secondary)]">
             Account and user configuration options will appear here.
         </p>
     </section>
-</BaseLayout>
+</AdminLayout>

--- a/apps/gs-web/src/pages/app/settings.astro
+++ b/apps/gs-web/src/pages/app/settings.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import AdminLayout from "../../layouts/AdminLayout.astro";
 import { authorizeAdminRequest, getAdminRouteRule } from '../../utils/admin-access';
 
 export const prerender = false;
@@ -48,7 +48,7 @@ if (!authError) {
 }
 ---
 
-<BaseLayout title="Settings | GoldShore Admin" description="Site and platform configuration">
+<AdminLayout title="Settings | GoldShore Admin">
   <section class="gs-section">
     <div class="gs-grid columns-2">
       <div>
@@ -267,7 +267,7 @@ if (!authError) {
       }
     });
   </script>
-</BaseLayout>
+</AdminLayout>
 
 <style>
   .settings-grid {

--- a/apps/gs-web/src/pages/contact.astro
+++ b/apps/gs-web/src/pages/contact.astro
@@ -116,28 +116,6 @@ export const prerender = false;
       </GSButton>
     </form>
 
-    <script>
-      {
-        // Set form action dynamically based on current deployment
-        const form = document.getElementById('contact-form');
-        if (form) {
-          const host = window.location.host;
-          let apiHost = host;
-
-          // Replace goldshore.ai with api.goldshore.ai
-          if (host.includes('goldshore.ai')) {
-            apiHost = host.replace(/^([^.]+\.)?goldshore\.ai$/, 'api.goldshore.ai');
-          }
-          // Replace goldshore-pages.dev preview with corresponding api preview
-          else if (host.includes('goldshore-pages.dev')) {
-            apiHost = host.replace(/\.goldshore-pages\.dev$/, '-api.goldshore-pages.dev');
-          }
-
-          const protocol = window.location.protocol;
-          form.action = `${protocol}//${apiHost}/mail/contact`;
-        }
-      }
-    </script>
   </FlowSection>
 
   <FlowSection>

--- a/apps/gs-web/src/styles/admin.css
+++ b/apps/gs-web/src/styles/admin.css
@@ -220,6 +220,16 @@
   border-top: 1px solid rgba(90, 162, 255, 0.1);
 }
 
+.gs-public-site-btn {
+  color: rgba(90, 162, 255, 0.85) !important;
+  font-size: 0.85rem;
+}
+
+.gs-public-site-btn:hover {
+  color: rgba(226, 232, 240, 0.95) !important;
+  background: rgba(90, 162, 255, 0.08) !important;
+}
+
 .gs-logout-btn {
   color: rgba(148, 163, 184, 0.8) !important;
   font-size: 0.85rem;

--- a/apps/gs-web/src/utils/admin-access.ts
+++ b/apps/gs-web/src/utils/admin-access.ts
@@ -39,6 +39,22 @@ const STATIC_PATH_PREFIXES = [
   '/sitemap',
 ];
 
+/**
+ * Paths that stay reachable on the admin hostname without an admin session.
+ *
+ * The admin host folds every unrecognized path back to the dashboard, and the
+ * dashboard requires a session. Without this exemption the sign-in and
+ * sign-out routes would themselves be rewritten to the dashboard, so an
+ * unauthenticated operator would bounce between /login and /app/dashboard
+ * with no way to authenticate.
+ */
+const ADMIN_HOST_PUBLIC_PATHS = ['/login', '/logout'];
+
+const isAdminHostPublicPath = (pathname: string) =>
+  ADMIN_HOST_PUBLIC_PATHS.some(
+    (candidate) => pathname === candidate || pathname.startsWith(`${candidate}/`),
+  );
+
 const CLEAN_ADMIN_PAGE_PREFIXES = [
   '/api-status',
   '/crawler',
@@ -92,6 +108,7 @@ export const getAdminHostRewritePath = (pathname: string) => {
   const normalizedPath = normalizePathname(pathname);
 
   if (isStaticAssetPath(normalizedPath)) return null;
+  if (isAdminHostPublicPath(normalizedPath)) return null;
   if (normalizedPath === '/') return ADMIN_DASHBOARD_PATH;
 
   if (
@@ -248,7 +265,8 @@ export const getAdminRouteRule = (
   if (
     hostname &&
     isAdminHost(hostname) &&
-    !isStaticAssetPath(normalizedPath)
+    !isStaticAssetPath(normalizedPath) &&
+    !isAdminHostPublicPath(normalizedPath)
   ) {
     return {
       canonicalPath: ADMIN_DASHBOARD_PATH,

--- a/apps/gs-web/tests/unit/admin-access.test.ts
+++ b/apps/gs-web/tests/unit/admin-access.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import * as assert from 'node:assert/strict';
 
+import { ROLE_PERMISSIONS } from '@goldshore/auth';
 import {
   ALTERNATE_ADMIN_DASHBOARD_URL,
   CANONICAL_ADMIN_DASHBOARD_URL,
@@ -98,7 +99,14 @@ test('preserves an explicit supported role from Cloudflare Access claims', () =>
   });
 
   assert.deepEqual(session.roles, ['viewer']);
-  assert.deepEqual(session.permissions, ['content:read', 'media:read', 'forms:read']);
+
+  // The point of this case is that an explicit role is preserved rather than
+  // escalated to the blanket admin session, so assert against the viewer role
+  // definition instead of a hand-copied permission list.
+  assert.deepEqual(session.permissions, ROLE_PERMISSIONS.viewer);
+  assert.ok(session.permissions.includes('content:read'));
+  assert.ok(!session.permissions.includes('content:write'));
+  assert.ok(!session.permissions.includes('system:write'));
 });
 
 test('login page uses dashboard destinations instead of admin host roots', async () => {
@@ -130,6 +138,38 @@ test('does not rewrite canonical admin, API, or static asset paths', () => {
 
 test('falls unknown admin-host pages back to the dashboard', () => {
   assert.equal(getAdminHostRewritePath('/about'), '/app/dashboard');
+});
+
+test('keeps the sign-in and sign-out routes reachable on the admin host', () => {
+  // These must not fold back to the dashboard: the dashboard requires a
+  // session, so rewriting /login would bounce an unauthenticated operator
+  // between /login and /app/dashboard forever.
+  assert.equal(getAdminHostRewritePath('/login'), null);
+  assert.equal(getAdminHostRewritePath('/logout'), null);
+
+  assert.equal(getAdminRouteRule('/login', 'GET', 'admin.goldshore.ai'), null);
+  assert.equal(getAdminRouteRule('/logout', 'GET', 'admin.goldshore.ai'), null);
+});
+
+test('admin pages use the admin layout rather than the public site chrome', async () => {
+  // BaseLayout renders PublicHeader, whose nav links are relative. On the
+  // admin hostname they resolve against that host and are then folded back to
+  // the dashboard, leaving no route to the public site.
+  const { readdir, readFile } = await import('node:fs/promises');
+  const roots = ['../../src/pages/admin', '../../src/pages/app'];
+  const offenders: string[] = [];
+
+  for (const root of roots) {
+    const dir = new URL(`${root}/`, import.meta.url);
+    for (const entry of await readdir(dir, { recursive: true, withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.astro')) continue;
+      const file = new URL(`${entry.parentPath ?? dir.pathname}/${entry.name}`.replace(/\/+/g, '/'), 'file:');
+      const source = await readFile(file, 'utf8');
+      if (/BaseLayout/.test(source)) offenders.push(entry.name);
+    }
+  }
+
+  assert.deepEqual(offenders, []);
 });
 
 test('middleware routes the admin hostname through its resolved dashboard path', async () => {

--- a/apps/gs-web/tests/unit/admin-access.test.ts
+++ b/apps/gs-web/tests/unit/admin-access.test.ts
@@ -156,6 +156,7 @@ test('admin pages use the admin layout rather than the public site chrome', asyn
   // admin hostname they resolve against that host and are then folded back to
   // the dashboard, leaving no route to the public site.
   const { readdir, readFile } = await import('node:fs/promises');
+  const { join } = await import('node:path');
   const roots = ['../../src/pages/admin', '../../src/pages/app'];
   const offenders: string[] = [];
 
@@ -163,7 +164,7 @@ test('admin pages use the admin layout rather than the public site chrome', asyn
     const dir = new URL(`${root}/`, import.meta.url);
     for (const entry of await readdir(dir, { recursive: true, withFileTypes: true })) {
       if (!entry.isFile() || !entry.name.endsWith('.astro')) continue;
-      const file = new URL(`${entry.parentPath ?? dir.pathname}/${entry.name}`.replace(/\/+/g, '/'), 'file:');
+      const file = join(entry.parentPath, entry.name);
       const source = await readFile(file, 'utf8');
       if (/BaseLayout/.test(source)) offenders.push(entry.name);
     }

--- a/apps/gs-web/tests/unit/runtime-config-binding.test.ts
+++ b/apps/gs-web/tests/unit/runtime-config-binding.test.ts
@@ -25,7 +25,7 @@ test('gs-web README documents indirect runtime configuration until a concrete co
 });
 
 test('gs-web README documents one Worker release and gates a future Pages migration', () => {
-  assert.match(webReadme, /exactly one deployment model: an Astro SSR Cloudflare Worker with\nAssets/);
+  assert.match(webReadme, /exactly one deployment model: an Astro SSR Cloudflare Worker with\r?\nAssets/);
   assert.match(webReadme, /Every dynamic web endpoint/);
   assert.match(webReadme, /must first move into `apps\/gs-api`/);
 });


### PR DESCRIPTION
Merge Strategy: Squash

[agent:codex] [env:local] [status:ready]

Focused main-targeting admin and contact-form repair.

- Render 16 admin and app pages with AdminLayout instead of public marketing chrome.
- Add an absolute public-site escape link that preserves the goldshore.ai or goldshore.org TLD.
- Keep login and logout reachable on admin hostnames to prevent an authentication redirect loop.
- Remove the contact-form override that bypassed the working same-origin API proxy.
- Add regression coverage for admin-host routing and layout usage.
- Make unit test file traversal and line-ending assertions cross-platform.
- Merge current main, including dashboard-only workflow repair #6350.

Verified locally:
- workflow validation: 28/28
- gs-web lint and build
- gs-web unit: 35/35
- gs-api dry-run build
- gs-api tests: 94/94
- git diff --check

No direct Cloudflare configuration or deployment was performed.