### PR TITLE
fix(ci): repair dashboard-only Cloudflare workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Validate GitHub workflow structure
+        run: pnpm check:workflows
+
       - name: Enforce banproof production bindings
         if: ${{ vars.ENABLE_BANPROOF_BINDINGS_CHECK == 'true' }}
         run: pnpm check:banproof-bindings

--- a/.github/workflows/deploy-gs-api.yml
+++ b/.github/workflows/deploy-gs-api.yml
@@ -1,11 +1,17 @@
-name: Inventory gs-api configuration
+name: Verify gs-api build and inventory
 
-# Read-only drift inventory. Cloudflare production configuration is changed only
-# by an approved human in the dashboard; this workflow has no Cloudflare credentials.
+# Cloudflare production deployment and configuration are owned by the Workers
+# Builds integration and the dashboard. This workflow is deliberately read-only.
 on:
   pull_request:
     paths:
       - 'apps/gs-api/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.node-version'
+      - '.nvmrc'
       - 'scripts/export-cloudflare-inventory.py'
       - 'infra/Cloudflare/dashboard-inventory.json'
       - '.github/workflows/deploy-gs-api.yml'
@@ -19,26 +25,23 @@ on:
       - 'pnpm-workspace.yaml'
       - '.node-version'
       - '.nvmrc'
-      - '.github/actions/**'
-      - '.github/workflows/deploy-gs-api.yml'
-  workflow_dispatch:
-
-concurrency:
-  group: deploy-gs-api-${{ github.ref }}
-  cancel-in-progress: false
       - 'scripts/export-cloudflare-inventory.py'
       - 'infra/Cloudflare/dashboard-inventory.json'
       - '.github/workflows/deploy-gs-api.yml'
   workflow_dispatch:
+
+concurrency:
+  group: verify-gs-api-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   gs-api-build:
+    name: Build gs-api
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -48,202 +51,21 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Build gs-api
-        run: pnpm --filter @goldshore/gs-api build
-
-  deploy:
-    needs: gs-api-build
-  inventory:
-    name: Export redacted expected state
-    runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
-    permissions:
-      contents: read
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      TARGET_ENV: ${{ github.ref == 'refs/heads/main' && 'prod' || 'preview' }}
-      HEALTH_ORIGIN: ${{ github.ref == 'refs/heads/main' && 'https://api.goldshore.ai' || 'https://api-preview.goldshore.ai' }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/check-lockfile-conflicts
-        id: lockfile-check
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 9.15.4
-
-      - uses: actions/setup-node@v7.0.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - uses: ./.github/actions/normalize-cf-token
-        id: cf-token
-        with:
-          raw_token: ${{ secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN }}
-          token_name: 'CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN'
-
-      - name: Verify Cloudflare secrets
-        env:
-          CF_TOKEN: ${{ steps.cf-token.outputs.token }}
-        run: |
-          test -n "$CLOUDFLARE_ACCOUNT_ID" || (echo "::error::Missing CLOUDFLARE_ACCOUNT_ID" && exit 1)
-          test -n "$CF_TOKEN" || (echo "::error::Missing CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN" && exit 1)
-          echo "CLOUDFLARE_API_TOKEN=$CF_TOKEN" >> "$GITHUB_ENV"
-
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @goldshore/gs-api build
 
-      - name: Apply newsletter subscriber schema
-        if: github.ref == 'refs/heads/main'
-        working-directory: apps/gs-api
-        run: pnpm exec wrangler d1 execute gs_platform_db --remote --file=db/migrations/0004_newsletter_subscribers.sql --env prod
-
-      - name: Provision gs-api Worker secrets
-        working-directory: apps/gs-api
-        env:
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          ACCESS_CLIENT_SECRET: ${{ secrets.ACCESS_CLIENT_SECRET }}
-          CONTROL_SYNC_TOKEN: ${{ secrets.CONTROL_SYNC_TOKEN }}
-          INTEGRATION_MASTER_KEY: ${{ secrets.INTEGRATION_MASTER_KEY }}
-          MAILCHANNELS_SENDER_EMAIL: ${{ secrets.MAILCHANNELS_SENDER_EMAIL }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_GEMINI }}
-        run: |
-          set -euo pipefail
-          trap 'rm -f worker-secrets.json' EXIT
-          
-          node <<'NODE' > worker-secrets.json
-          const names = [
-            'JWT_SECRET',
-            'ACCESS_CLIENT_SECRET',
-            'CONTROL_SYNC_TOKEN',
-            'INTEGRATION_MASTER_KEY',
-            'MAILCHANNELS_SENDER_EMAIL',
-            'OPENAI_API_KEY',
-            'GEMINI_API_KEY',
-          ];
-          const secrets = Object.fromEntries(
-            names.map((name) => [name, process.env[name]]).filter(([, value]) => value),
-          );
-          const required = ['JWT_SECRET', 'ACCESS_CLIENT_SECRET', 'CONTROL_SYNC_TOKEN'];
-          const missing = required.filter((name) => !secrets[name]);
-          if (missing.length) throw new Error(`Missing required GitHub secrets: ${missing.join(', ')}`);
-          process.stdout.write(JSON.stringify(secrets));
-          NODE
-          
-          pnpm exec wrangler secret bulk worker-secrets.json --env ${{ github.ref == 'refs/heads/main' && 'prod' || 'preview' }}
-
-      - run: pnpm --filter @goldshore/gs-api run deploy -- --env=${{ github.ref == 'refs/heads/main' && 'prod' || 'preview' }}
-
-      - name: Health check (gs-api)
-        if: github.ref == 'refs/heads/main'
-        run: |
-          set -euo pipefail
-          max_retries=5
-          retry=0
-          
-          while [ $retry -lt $max_retries ]; do
-            echo "Health check attempt $((retry + 1))/$max_retries..."
-            if curl -fsS https://api.goldshore.ai/health >/dev/null 2>&1; then
-              echo "✅ gs-api is healthy"
-              exit 0
-            fi
-            retry=$((retry + 1))
-            sleep 10
-          done
-          
-          echo "::error::gs-api failed health check after $max_retries attempts"
-          exit 1
+  inventory:
+    name: Export redacted expected state
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Export binding names, routes, Access IDs, and secret names
+        run: python3 scripts/export-cloudflare-inventory.py cloudflare-inventory.json
+      - name: Display redacted inventory
+        run: jq . cloudflare-inventory.json
+      - name: Upload drift-review artifact
+        uses: actions/upload-artifact@v7
+        with:
           name: cloudflare-inventory-${{ github.run_id }}-deploy-gs-api
           path: cloudflare-inventory.json
           retention-days: 30
-      - name: Stamp release identity into the selected environment
-        working-directory: apps/gs-api
-        env:
-          DEPLOY_ENV: ${{ github.ref == 'refs/heads/main' && 'prod' || 'preview' }}
-        run: |
-          node <<'NODE'
-          const fs = require('node:fs');
-          const path = 'wrangler.toml';
-          const source = fs.readFileSync(path, 'utf8');
-          const marker = `[env.${process.env.DEPLOY_ENV}.vars]\n`;
-          if (!source.includes(marker)) throw new Error(`Missing ${marker.trim()} in ${path}`);
-          const identity = `API_VERSION = "${process.env.GITHUB_SHA}"\nDEPLOY_SHA = "${process.env.GITHUB_SHA}"\n`;
-          fs.writeFileSync(path, source.replace(marker, marker + identity));
-          NODE
-
-      - run: pnpm --filter @goldshore/gs-api run deploy -- --env=${{ github.ref == 'refs/heads/main' && 'prod' || 'preview' }}
-
-      - name: Verify production API aliases
-        if: github.ref == 'refs/heads/main'
-        env:
-          CORS_ORIGIN: https://goldshore.ai
-        run: |
-          set -euo pipefail
-          tmp_dir=$(mktemp -d)
-          trap 'rm -rf "$tmp_dir"' EXIT
-
-          request() {
-            local host=$1 path=$2 name=$3
-            for attempt in 1 2 3 4 5; do
-              if curl --fail-with-body --silent --show-error \
-                --dump-header "$tmp_dir/$name.headers" \
-                --output "$tmp_dir/$name.body" \
-                "https://$host$path"; then return 0; fi
-              echo "Retrying $host$path ($attempt/5)"
-              sleep 10
-            done
-            return 1
-          }
-
-          for host in api.goldshore.ai api.goldshore.org; do
-            key=${host//./_}
-            request "$host" /health "$key-health"
-            jq -e '.status == "ok" and .service == "gs-api"' "$tmp_dir/$key-health.body"
-
-            request "$host" /version "$key-version"
-            jq -e --arg sha "$GITHUB_SHA" \
-              '.service == "gs-api" and .version == $sha and .deploySha == $sha' \
-              "$tmp_dir/$key-version.body"
-
-            auth_status=$(curl --silent --show-error --output "$tmp_dir/$key-auth.body" \
-              --dump-header "$tmp_dir/$key-auth.headers" --write-out '%{http_code}' \
-              "https://$host/system/status")
-            case "$auth_status" in
-              401) jq -e '.error == "Unauthorized"' "$tmp_dir/$key-auth.body" ;;
-              302|303|307)
-                tr -d '\r' < "$tmp_dir/$key-auth.headers" \
-                  | grep -Eqi '^location: https://[^/]*cloudflareaccess\.com/'
-                ;;
-              *) echo "::error::Unexpected authentication challenge status $auth_status from $host"; exit 1 ;;
-            esac
-
-            cors_status=$(curl --silent --show-error --output /dev/null \
-              --dump-header "$tmp_dir/$key-cors.headers" --write-out '%{http_code}' \
-              -X OPTIONS -H "Origin: $CORS_ORIGIN" \
-              -H 'Access-Control-Request-Method: POST' \
-              "https://$host/v1/forms/contact/submissions")
-            test "$cors_status" = 204
-            tr -d '\r' < "$tmp_dir/$key-cors.headers" | grep -Fqi "access-control-allow-origin: $CORS_ORIGIN"
-            tr -d '\r' < "$tmp_dir/$key-cors.headers" | grep -Eqi 'access-control-allow-methods:.*POST'
-          done
-
-          header_value() {
-            tr -d '\r' < "$1" | awk -F': *' -v wanted="$2" \
-              'tolower($1) == tolower(wanted) { value=$2 } END { print value }'
-          }
-          for header in x-gs-api-version x-gs-deploy-sha; do
-            ai_value=$(header_value "$tmp_dir/api_goldshore_ai-version.headers" "$header")
-            org_value=$(header_value "$tmp_dir/api_goldshore_org-version.headers" "$header")
-            test -n "$ai_value" && test "$ai_value" = "$GITHUB_SHA"
-            test "$ai_value" = "$org_value" || {
-              echo "::error::$header differs between production API domains"
-              exit 1
-            }
-          done

--- a/.github/workflows/infrastructure-guard.yml
+++ b/.github/workflows/infrastructure-guard.yml
@@ -54,6 +54,8 @@ jobs:
           import re
 
           inventory_workflows = (
+              Path('.github/workflows/deploy-gs-api.yml'),
+              Path('.github/workflows/deploy-gs-web.yml'),
               Path('.github/workflows/setup-cf-agent-access.yml'),
               Path('.github/workflows/reconcile-dns.yml'),
           )

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:docs-consistency": "node scripts/check-doc-consistency.mjs",
     "check:pr-triage": "node --test scripts/pr-triage-rules.test.mjs",
     "check:theme-exports": "node scripts/check-theme-exports.mjs",
+    "check:workflows": "node scripts/validate-workflows.mjs",
     "check:naming": "node scripts/lint-naming.mjs",
     "check:workspace-protocol": "node scripts/check-workspace-protocol.mjs",
     "validate:structure": "tsx scripts/validate-worker-structure.ts",

--- a/scripts/check-cloudflare-token-policy.sh
+++ b/scripts/check-cloudflare-token-policy.sh
@@ -10,13 +10,10 @@ if rg -n 'CLOUDFLARE_(BUILD_)?API_TOKEN:\s*\$\{\{[^}]*\|\|[^}]*\}\}' "$workflows
   exit 1
 fi
 
-echo "Checking canonical deploy token wiring..."
-if ! rg -n 'RAW_CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN\s*\}\}' "$workflows_dir/deploy-gs-api.yml" >/dev/null; then
-  echo "deploy-gs-api.yml must normalize secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN before use"
-  exit 1
-fi
-if ! rg -n 'RAW_CLOUDFLARE_API_TOKEN:\s*\$\{\{\s*secrets\.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN\s*\}\}' "$workflows_dir/deploy-gs-web.yml" >/dev/null; then
-  echo "deploy-gs-web.yml must normalize secrets.CLOUDFLARE_GOLDSHORE_AI_DEPLOY_TOKEN before use"
+echo "Checking dashboard-owned deploy workflows are credential-free and read-only..."
+if rg -n 'CLOUDFLARE_(?:API_TOKEN|API_KEY|BUILD_API_TOKEN)|\bCF_API\b|wrangler\s+(?:deploy|delete|secret|kv|d1|r2|queue|workflow)\b' \
+  "$workflows_dir/deploy-gs-api.yml" "$workflows_dir/deploy-gs-web.yml"; then
+  echo "Canonical deploy workflow files must not contain Cloudflare credentials or mutation commands."
   exit 1
 fi
 

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import YAML from 'yaml';
+
+const workflowDirectory = resolve('.github/workflows');
+const workflowFiles = readdirSync(workflowDirectory)
+  .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+  .sort();
+
+const failures = [];
+
+for (const filename of workflowFiles) {
+  const path = resolve(workflowDirectory, filename);
+  let workflow;
+
+  try {
+    workflow = YAML.parse(readFileSync(path, 'utf8'), { uniqueKeys: true });
+  } catch (error) {
+    failures.push(`${filename}: invalid YAML: ${error.message}`);
+    continue;
+  }
+
+  if (!workflow || typeof workflow !== 'object') {
+    failures.push(`${filename}: workflow must be a mapping`);
+    continue;
+  }
+  if (typeof workflow.name !== 'string' || !workflow.name.trim()) {
+    failures.push(`${filename}: missing workflow name`);
+  }
+  if (!Object.hasOwn(workflow, 'on')) {
+    failures.push(`${filename}: missing on trigger`);
+  }
+  if (!workflow.jobs || typeof workflow.jobs !== 'object' || Array.isArray(workflow.jobs)) {
+    failures.push(`${filename}: jobs must be a non-empty mapping`);
+    continue;
+  }
+
+  const jobs = Object.entries(workflow.jobs);
+  if (jobs.length === 0) failures.push(`${filename}: jobs must not be empty`);
+
+  for (const [jobName, job] of jobs) {
+    if (!job || typeof job !== 'object' || Array.isArray(job)) {
+      failures.push(`${filename}: job ${jobName} must be a mapping`);
+      continue;
+    }
+
+    const reusable = typeof job.uses === 'string' && job.uses.trim();
+    const runnable = typeof job['runs-on'] === 'string' || Array.isArray(job['runs-on']);
+    if (!reusable && !runnable) {
+      failures.push(`${filename}: job ${jobName} requires runs-on or uses`);
+    }
+    if (runnable && (!Array.isArray(job.steps) || job.steps.length === 0)) {
+      failures.push(`${filename}: job ${jobName} requires at least one step`);
+    }
+  }
+}
+
+if (failures.length) {
+  console.error('Workflow validation failed:\n' + failures.map((item) => `- ${item}`).join('\n'));
+  process.exit(1);
+}
+
+console.log(`Validated ${workflowFiles.length} workflow files.`);


### PR DESCRIPTION
Merge Strategy: Squash

Summary:
- Restore deploy-gs-api.yml as a valid build plus redacted-inventory workflow.
- Remove GitHub-side Cloudflare deployment, D1 migration, and secret mutation paths from that canonical workflow.
- Enforce credential-free read-only behavior for both canonical Cloudflare workflow files.
- Add semantic validation for every active workflow job so merge splices without runs-on or uses fail CI.

Verification:
- pnpm check:workflows (28 workflows)
- pnpm check:naming
- scripts/check-cloudflare-token-policy.sh
- pnpm lint
- pnpm check:pr-triage (6/6)
- pnpm validate
- gs-api dry-run build
- gs-api tests (94/94)
- git diff --check

[agent:codex] [env:local] [status:ready]

No Cloudflare configuration or deployment was performed. Production remains owned by the Cloudflare dashboard and Workers Builds integration.