### PR TITLE
ci(gs-web): run the unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Build all
         run: pnpm -r --sequential build
 
+      # gs-web's "test" script runs Playwright only, so tests/unit never ran in
+      # CI on either this workflow or the pull-request gate. Invoke test:unit
+      # explicitly so pushes to main are covered as well.
+      - name: Test gs-web (unit)
+        run: pnpm --dir apps/gs-web test:unit
+
       - name: Detect gs-web release-impact changes
         id: gs-web-changes
         shell: bash

--- a/.github/workflows/required-merge-checks.yml
+++ b/.github/workflows/required-merge-checks.yml
@@ -57,6 +57,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build gs-web
         run: pnpm --dir apps/gs-web build
+      # gs-web's "test" script runs Playwright only, so tests/unit never ran in
+      # CI. That let a syntax error disable a whole unit-test file unnoticed.
+      # Invoke test:unit explicitly; the e2e suite needs a served build and is
+      # covered by the release quality gate below.
+      - name: Test gs-web (unit)
+        run: pnpm --dir apps/gs-web test:unit
       - name: Detect gs-web release-impact changes
         id: gs-web-changes
         shell: bash


### PR DESCRIPTION
`gs-web`'s `test` script is `playwright test`, so `tests/unit` has never executed in CI. Nothing invoked it:

- `required-merge-checks.yml` has a `gs-web-build` job that only builds — while `gs-api-build-test`, its sibling, builds **and** tests.
- `ci.yml`'s job is named `lint-test-build` but runs no tests at all.

## Why it matters

That gap hid real failures on `main`:

- An unterminated `test` block in `tests/unit/admin-access.test.ts` was a **syntax error that disabled the entire file** — 13 tests silently not running.
- A stale assertion in the same file checked the `viewer` role against a hand-copied list of three permissions, when the role now carries eighteen.

Neither turned a check red, because no check ran them.

## Change

Adds an explicit `pnpm --dir apps/gs-web test:unit` step in two places:

| Workflow | Job | Runs on |
|---|---|---|
| `required-merge-checks.yml` | `gs-web-build` | pull requests — gates merges |
| `ci.yml` | `lint-test-build` | pull requests **and** push to `main` |

The job name in `required-merge-checks.yml` is deliberately left unchanged: it's a required status check, and renaming it would break the branch-protection rule.

`test:unit` is invoked directly rather than folded into the `test` script — the e2e suite needs a served build and browsers, and is already covered by the release quality gate.

## Verification

I checked the step actually **gates** rather than merely running, since a check that cannot fail is the exact problem being fixed:

```
exit code with a deliberately broken page: 1
exit code when green:                      0
```

Workflow validation passes for all 28 files; suite is 35/35.

---

## Separate finding: production is serving a stale build

While confirming this, I checked `admin.goldshore.ai/app/dashboard`, which returns **Page Not Found**. That is not a code defect — the route builds correctly from `main` (`^\/app\/dashboard\/?$` is present in the manifest). `gs-web-prod` is running a build predating recent work. The live HTML still contains:

- `gs-shell-v284` and `GoldShoreShell.BfJqzjUs.css` — but `GoldShoreShell` was deleted from the repo, and a regression test on `main` asserts it is gone
- both `Dashboard →` and `Admin →` nav links — consolidated into a single link on `main`
- `/.well-known/gs-release.json` 404s, though it builds

A fresh build from `main` emits `WebLayout.css` / `AdminLayout.css` and the single "Dashboard access" link, and no shell CSS at all.

`deploy-gs-web.yml` is build-verification only and states deploys happen through the Cloudflare Workers Builds git integration — configured in the dashboard, with no credentials in CI. So this needs a human to trigger or repair that integration; I have not touched any Cloudflare configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yod3DWL29qZf9vGboDiwR

---
_Generated by [Claude Code](https://claude.ai/code/session_013yod3DWL29qZf9vGboDiwR)_