### PR TITLE
fix(api): restore production startup preflight

### DIFF
--- a/apps/gs-api/src/index.test.ts
+++ b/apps/gs-api/src/index.test.ts
@@ -8,10 +8,23 @@ const requiredRuntimeEnv = {
   GS_ASSETS: {} as any,
   AI: {} as any,
   JWT_SECRET: 'test-jwt-secret',
-  STRIPE_API_KEY: 'test-stripe-key',
-  SENDGRID_API_KEY: 'test-sendgrid-key',
   ACCESS_CLIENT_SECRET: 'test-access-client-secret',
 };
+
+test('keeps shallow production health independent of optional provider secrets', async () => {
+  const response = await app.request(
+    '/health',
+    {},
+    {
+      ...requiredRuntimeEnv,
+      ENV: 'production',
+      CLOUDFLARE_ACCESS_AUDIENCE: 'test-audience',
+      CONTROL_SYNC_TOKEN: 'test-control-token',
+    } as any,
+  );
+
+  assert.equal(response.status, 200);
+});
 
 test('allows documented preview goldshore.ai origins', () => {
   assert.equal(isPreviewOrigin('https://feature-123-preview.goldshore.ai'), true);

--- a/apps/gs-api/src/index.ts
+++ b/apps/gs-api/src/index.ts
@@ -56,12 +56,6 @@ const app = new Hono<{
 
 const requiredBindings = ['PLATFORM_DB', 'GS_ASSETS', 'AI'] as const;
 const expectedD1Binding = 'PLATFORM_DB' as const;
-const requiredSecrets = [
-  'JWT_SECRET',
-  'STRIPE_API_KEY',
-  'SENDGRID_API_KEY',
-  'ACCESS_CLIENT_SECRET',
-] as const;
 
 const DEFAULT_ALLOWED_ORIGINS = [...APPROVED_API_ORIGINS];
 
@@ -132,7 +126,7 @@ app.use('*', async (c, next) => {
       `CRITICAL_MISSING_D1_BINDING: Expected D1 binding "${expectedD1Binding}" is undefined. Verify [[d1_databases]] binding in wrangler.toml.`,
     );
   }
-  for (const key of [...requiredBindings, ...requiredSecrets]) {
+  for (const key of requiredBindings) {
     if (!c.env[key]) {
       throw new Error(`CRITICAL_MISSING: ${key}. Terminating.`);
     }


### PR DESCRIPTION
Merge Strategy: Squash

## Summary
- keep canonical security-secret validation in one preflight
- stop treating optional Stripe and SendGrid provider keys as global startup requirements
- add a production health regression case without optional provider secrets

## Verification
- API lint: passed
- API route/lib suite: 94/96 passed; two existing Wrangler route-contract failures remain because main's route expectations do not match its TOML files
- production dry run: resolves KV, D1, R2, AI, queues, workflow, vars, and secrets

## Production incident
The active gs-api-prod version had lost repository-declared resource bindings. The clean main configuration has been uploaded; this patch is required to clear the remaining global startup 500 caused by absent optional provider keys.

[agent:codex] [env:production] [status:ready]

@Jules-Bot [review-request]