### PR TITLE
feat(admin): add SHA-locked PR merge cockpit

### DIFF
--- a/.github/workflows/admin-merge-cockpit.yml
+++ b/.github/workflows/admin-merge-cockpit.yml
@@ -1,0 +1,50 @@
+name: Admin Merge Cockpit
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to salvage
+        required: true
+        type: string
+      expected_base_sha:
+        description: Immutable main SHA observed by the cockpit
+        required: true
+        type: string
+      expected_head_sha:
+        description: Immutable PR head SHA observed by the cockpit
+        required: true
+        type: string
+      resolutions_json:
+        description: Reviewed current/incoming decisions keyed by path
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: merge-cockpit-pr-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  create-salvage-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Re-verify SHAs and create reviewed salvage branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_API_TOKEN || github.token }}
+          MERGE_COCKPIT_PR_NUMBER: ${{ inputs.pr_number }}
+          MERGE_COCKPIT_BASE_SHA: ${{ inputs.expected_base_sha }}
+          MERGE_COCKPIT_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          MERGE_COCKPIT_RESOLUTIONS: ${{ inputs.resolutions_json }}
+        run: node scripts/merge-cockpit-salvage.mjs

--- a/apps/gs-api/src/lib/merge-cockpit.test.ts
+++ b/apps/gs-api/src/lib/merge-cockpit.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildConflictFiles, checksAreGreen, classifyMergeRisk, validateResolutions } from './merge-cockpit';
+
+test('flags files changed on current main and the incoming branch as semantic conflicts', () => {
+  const files = buildConflictFiles(['apps/gs-web/src/middleware.ts', 'README.md'], [
+    'apps/gs-web/src/middleware.ts', '.github/workflows/ci.yml',
+  ]);
+  assert.equal(files.find((file) => file.filename === 'apps/gs-web/src/middleware.ts')?.semanticConflict, true);
+  assert.equal(files.find((file) => file.filename === 'README.md')?.semanticConflict, false);
+  assert.equal(files.find((file) => file.filename === '.github/workflows/ci.yml')?.risk, 'critical');
+});
+
+test('classifies routing and deployment contracts conservatively', () => {
+  assert.equal(classifyMergeRisk('apps/gs-api/wrangler.toml'), 'critical');
+  assert.equal(classifyMergeRisk('apps/gs-api/src/routes/admin.ts'), 'high');
+  assert.equal(classifyMergeRisk('docs/guide.md'), 'normal');
+});
+
+test('requires every reported check to be completed and acceptable', () => {
+  assert.equal(checksAreGreen([]), false);
+  assert.equal(checksAreGreen([{ name: 'CI', status: 'completed', conclusion: 'success' }]), true);
+  assert.equal(checksAreGreen([{ name: 'Cloudflare', status: 'completed', conclusion: 'failure' }]), false);
+  assert.equal(checksAreGreen([{ name: 'CI', status: 'in_progress', conclusion: null }]), false);
+});
+
+test('rejects resolutions outside the reviewed conflict set', () => {
+  assert.deepEqual(validateResolutions({ 'a.ts': 'current' }, ['a.ts']), { 'a.ts': 'current' });
+  assert.equal(validateResolutions({ 'other.ts': 'incoming' }, ['a.ts']), null);
+  assert.equal(validateResolutions({ 'a.ts': 'combine' }, ['a.ts']), null);
+});

--- a/apps/gs-api/src/lib/merge-cockpit.ts
+++ b/apps/gs-api/src/lib/merge-cockpit.ts
@@ -1,0 +1,69 @@
+export type MergeCockpitFile = {
+  filename: string;
+  currentChanged: boolean;
+  incomingChanged: boolean;
+  semanticConflict: boolean;
+  risk: 'critical' | 'high' | 'normal';
+};
+
+const CRITICAL_PATHS = [
+  /^\.github\/workflows\//,
+  /^apps\/[^/]+\/wrangler\.(?:toml|jsonc)$/,
+  /(?:^|\/)migrations\//,
+  /^pnpm-lock\.yaml$/,
+  /^pnpm-workspace\.yaml$/,
+  /^AGENTS\.md$/,
+];
+
+const HIGH_RISK_PATHS = [
+  /^apps\/gs-api\/src\/(?:index|auth|types)\.ts$/,
+  /^apps\/gs-web\/src\/(?:middleware|utils\/admin-access)\.ts$/,
+  /^infra\/Cloudflare\//,
+  /(?:^|\/)routes\//,
+];
+
+export const classifyMergeRisk = (filename: string): MergeCockpitFile['risk'] => {
+  if (CRITICAL_PATHS.some((pattern) => pattern.test(filename))) return 'critical';
+  if (HIGH_RISK_PATHS.some((pattern) => pattern.test(filename))) return 'high';
+  return 'normal';
+};
+
+export const buildConflictFiles = (currentFiles: string[], incomingFiles: string[]) => {
+  const current = new Set(currentFiles);
+  const incoming = new Set(incomingFiles);
+  return [...new Set([...currentFiles, ...incomingFiles])]
+    .sort()
+    .map<MergeCockpitFile>((filename) => ({
+      filename,
+      currentChanged: current.has(filename),
+      incomingChanged: incoming.has(filename),
+      semanticConflict: current.has(filename) && incoming.has(filename),
+      risk: classifyMergeRisk(filename),
+    }));
+};
+
+export type MergeCheck = {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  url?: string | null;
+};
+
+export const checksAreGreen = (checks: MergeCheck[]) =>
+  checks.length > 0 && checks.every((check) =>
+    check.status === 'completed' && ['success', 'neutral', 'skipped'].includes(check.conclusion ?? '')
+  );
+
+export const isSha = (value: unknown): value is string =>
+  typeof value === 'string' && /^[a-f0-9]{40}$/i.test(value);
+
+export const validateResolutions = (value: unknown, allowedFiles: string[]) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const allowed = new Set(allowedFiles);
+  const result: Record<string, 'current' | 'incoming' | 'defer'> = {};
+  for (const [filename, resolution] of Object.entries(value)) {
+    if (!allowed.has(filename) || !['current', 'incoming', 'defer'].includes(String(resolution))) return null;
+    result[filename] = resolution as 'current' | 'incoming' | 'defer';
+  }
+  return result;
+};

--- a/apps/gs-api/src/routes/admin.ts
+++ b/apps/gs-api/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { getActor, logAdminAction, requirePermission } from "../auth";
 import { Env, Variables } from "../types";
 import deploy from "./admin/index";
 import repoHealth from "./admin/repo-health";
+import mergeCockpit from "./admin/merge-cockpit";
 
 type UserRow = {
   id: string; email: string; display_name: string | null; status: string;
@@ -186,5 +187,6 @@ admin.route("/deploy", deploy);
 
 // Mount repo health routes
 admin.route("/repo-health", repoHealth);
+admin.route("/merge-cockpit", mergeCockpit);
 
 export default admin;

--- a/apps/gs-api/src/routes/admin/merge-cockpit.ts
+++ b/apps/gs-api/src/routes/admin/merge-cockpit.ts
@@ -1,0 +1,236 @@
+import { Hono } from 'hono';
+import { getActor, logAdminAction, requirePermission } from '../../auth';
+import type { Env, Variables } from '../../types';
+import {
+  buildConflictFiles,
+  checksAreGreen,
+  isSha,
+  validateResolutions,
+  type MergeCheck,
+} from '../../lib/merge-cockpit';
+
+const OWNER = 'marzton';
+const REPO = 'goldshore-ai';
+const API = `https://api.github.com/repos/${OWNER}/${REPO}`;
+const WORKFLOW = 'admin-merge-cockpit.yml';
+
+type GitHubPull = {
+  number: number;
+  title: string;
+  html_url: string;
+  draft: boolean;
+  mergeable: boolean | null;
+  mergeable_state: string;
+  merged: boolean;
+  updated_at: string;
+  user: { login: string };
+  base: { ref: string; sha: string };
+  head: { ref: string; sha: string; repo: { full_name: string } | null };
+};
+
+type CompareResponse = {
+  merge_base_commit: { sha: string };
+  files?: Array<{ filename: string }>;
+};
+
+const cockpit = new Hono<{ Bindings: Env; Variables: Variables }>();
+
+const tokenFor = (env: Env) => env.GITHUB_API_TOKEN ?? env.GITHUB_TOKEN ?? env.GH_TOKEN;
+
+const github = async <T>(env: Env, path: string, init: RequestInit = {}): Promise<T> => {
+  const token = tokenFor(env);
+  if (!token) throw new Error('GITHUB_API_TOKEN is not configured.');
+  const response = await fetch(path.startsWith('https://') ? path : `${API}${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'goldshore-merge-cockpit',
+      ...init.headers,
+    },
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`GitHub ${response.status}: ${detail.slice(0, 500)}`);
+  }
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
+};
+
+const pullDetail = async (env: Env, number: number) => {
+  const pull = await github<GitHubPull>(env, `/pulls/${number}`);
+  const baseRef = await github<{ object: { sha: string } }>(env, `/git/ref/heads/${encodeURIComponent(pull.base.ref)}`);
+  const currentBaseSha = baseRef.object.sha;
+  const comparison = await github<CompareResponse>(env, `/compare/${currentBaseSha}...${pull.head.sha}`);
+  const mergeBaseSha = comparison.merge_base_commit.sha;
+  const [currentComparison, incomingComparison, checkRuns, combinedStatus] = await Promise.all([
+    github<CompareResponse>(env, `/compare/${mergeBaseSha}...${currentBaseSha}`),
+    github<CompareResponse>(env, `/compare/${mergeBaseSha}...${pull.head.sha}`),
+    github<{ check_runs: Array<{ name: string; status: string; conclusion: string | null; html_url?: string }> }>(
+      env, `/commits/${pull.head.sha}/check-runs?per_page=100`,
+    ),
+    github<{ statuses: Array<{ context: string; state: string; target_url?: string }> }>(
+      env, `/commits/${pull.head.sha}/status`,
+    ),
+  ]);
+  const files = buildConflictFiles(
+    (currentComparison.files ?? []).map((file) => file.filename),
+    (incomingComparison.files ?? []).map((file) => file.filename),
+  );
+  const checks: MergeCheck[] = [
+    ...checkRuns.check_runs.map((check) => ({
+      name: check.name,
+      status: check.status,
+      conclusion: check.conclusion,
+      url: check.html_url,
+    })),
+    ...combinedStatus.statuses.map((status) => ({
+      name: status.context,
+      status: 'completed',
+      conclusion: status.state === 'success' ? 'success' : status.state,
+      url: status.target_url,
+    })),
+  ];
+  const semanticConflicts = files.filter((file) => file.semanticConflict);
+  const green = checksAreGreen(checks);
+  const cloudflareGreen = checks.some((check) =>
+    /cloudflare/i.test(check.name) && check.status === 'completed' &&
+    ['success', 'neutral', 'skipped'].includes(check.conclusion ?? '')
+  );
+  return {
+    pull,
+    mergeBaseSha,
+    currentBaseSha,
+    files,
+    semanticConflicts,
+    checks,
+    checksGreen: green,
+    cloudflareGreen,
+    directMergeEligible:
+      !pull.draft && !pull.merged && pull.base.ref === 'main' && pull.mergeable === true &&
+      pull.mergeable_state === 'clean' && semanticConflicts.length === 0 && green && cloudflareGreen,
+  };
+};
+
+cockpit.get('/pulls', requirePermission('github:read'), async (c) => {
+  try {
+    const pulls = await github<GitHubPull[]>(c.env, '/pulls?state=open&sort=updated&direction=desc&per_page=50');
+    return c.json({
+      pulls: pulls.map((pull) => ({
+        number: pull.number,
+        title: pull.title,
+        url: pull.html_url,
+        author: pull.user.login,
+        draft: pull.draft,
+        updatedAt: pull.updated_at,
+        base: pull.base,
+        head: { ref: pull.head.ref, sha: pull.head.sha },
+      })),
+    });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : 'GitHub request failed.' }, 502);
+  }
+});
+
+cockpit.get('/pulls/:number', requirePermission('github:read'), async (c) => {
+  const number = Number(c.req.param('number'));
+  if (!Number.isInteger(number) || number < 1) return c.json({ error: 'Invalid pull request number.' }, 400);
+  try {
+    return c.json(await pullDetail(c.env, number));
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : 'GitHub request failed.' }, 502);
+  }
+});
+
+cockpit.get('/pulls/:number/file', requirePermission('github:read'), async (c) => {
+  const number = Number(c.req.param('number'));
+  const filename = c.req.query('path') ?? '';
+  const version = c.req.query('version');
+  if (!Number.isInteger(number) || !filename || !['base', 'current', 'incoming'].includes(version ?? '')) {
+    return c.json({ error: 'A valid pull request, path, and version are required.' }, 400);
+  }
+  try {
+    const detail = await pullDetail(c.env, number);
+    if (!detail.files.some((file) => file.filename === filename)) return c.json({ error: 'File is outside this PR comparison.' }, 404);
+    const ref = version === 'base' ? detail.mergeBaseSha : version === 'current' ? detail.currentBaseSha : detail.pull.head.sha;
+    const url = `${API}/contents/${filename.split('/').map(encodeURIComponent).join('/')}?ref=${ref}`;
+    const content = await github<{ content: string; encoding: string }>(c.env, url);
+    if (content.encoding !== 'base64') return c.json({ error: 'Unsupported GitHub content encoding.' }, 502);
+    const bytes = Uint8Array.from(atob(content.content.replace(/\s/g, '')), (character) => character.charCodeAt(0));
+    return c.json({ filename, version, ref, content: new TextDecoder().decode(bytes) });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : 'GitHub request failed.' }, 502);
+  }
+});
+
+cockpit.post('/salvage', requirePermission('github:manage'), async (c) => {
+  const payload = await c.req.json<{
+    prNumber?: number; expectedBaseSha?: string; expectedHeadSha?: string;
+    resolutions?: Record<string, string>;
+  }>().catch(() => null);
+  if (!payload || !Number.isInteger(payload.prNumber) || !isSha(payload.expectedBaseSha) || !isSha(payload.expectedHeadSha)) {
+    return c.json({ error: 'PR number and full expected base/head SHAs are required.' }, 400);
+  }
+  try {
+    const detail = await pullDetail(c.env, payload.prNumber!);
+    if (detail.currentBaseSha !== payload.expectedBaseSha || detail.pull.head.sha !== payload.expectedHeadSha) {
+      return c.json({ error: 'PR state changed. Refresh the cockpit before continuing.' }, 409);
+    }
+    const conflicts = detail.semanticConflicts.map((file) => file.filename);
+    const resolutions = validateResolutions(payload.resolutions, conflicts);
+    if (!resolutions || conflicts.some((file) => !resolutions[file] || resolutions[file] === 'defer')) {
+      return c.json({ error: 'Every semantic conflict must be resolved to current or incoming.' }, 400);
+    }
+    await github<void>(c.env, `https://api.github.com/repos/${OWNER}/${REPO}/actions/workflows/${WORKFLOW}/dispatches`, {
+      method: 'POST',
+      body: JSON.stringify({
+        ref: 'main',
+        inputs: {
+          pr_number: String(payload.prNumber),
+          expected_base_sha: payload.expectedBaseSha,
+          expected_head_sha: payload.expectedHeadSha,
+          resolutions_json: JSON.stringify(resolutions),
+        },
+      }),
+    });
+    await logAdminAction(c.env, {
+      action: 'admin.merge-cockpit.salvage.dispatch',
+      actor: getActor(c.get('accessClaims'), c.req.raw), status: 'success',
+      metadata: { prNumber: payload.prNumber, baseSha: payload.expectedBaseSha, headSha: payload.expectedHeadSha },
+    });
+    return c.json({ accepted: true, message: 'SHA-locked salvage workflow dispatched.' }, 202);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : 'Salvage dispatch failed.' }, 502);
+  }
+});
+
+cockpit.post('/merge', requirePermission('github:manage'), async (c) => {
+  const payload = await c.req.json<{
+    prNumber?: number; expectedBaseSha?: string; expectedHeadSha?: string; confirmation?: string;
+  }>().catch(() => null);
+  if (!payload || !Number.isInteger(payload.prNumber) || !isSha(payload.expectedBaseSha) ||
+      !isSha(payload.expectedHeadSha) || payload.confirmation !== `SQUASH #${payload.prNumber}`) {
+    return c.json({ error: 'Expected SHAs and exact squash confirmation are required.' }, 400);
+  }
+  try {
+    const detail = await pullDetail(c.env, payload.prNumber!);
+    if (detail.currentBaseSha !== payload.expectedBaseSha || detail.pull.head.sha !== payload.expectedHeadSha) {
+      return c.json({ error: 'PR state changed. Refresh the cockpit before continuing.' }, 409);
+    }
+    if (!detail.directMergeEligible) return c.json({ error: 'Direct merge is blocked. Use a salvage PR or wait for every check.' }, 409);
+    const result = await github<{ merged: boolean; message: string; sha: string }>(c.env, `/pulls/${payload.prNumber}/merge`, {
+      method: 'PUT',
+      body: JSON.stringify({ sha: payload.expectedHeadSha, merge_method: 'squash' }),
+    });
+    await logAdminAction(c.env, {
+      action: 'admin.merge-cockpit.squash', actor: getActor(c.get('accessClaims'), c.req.raw),
+      status: result.merged ? 'success' : 'error', metadata: { prNumber: payload.prNumber, sha: result.sha },
+    });
+    return c.json(result, result.merged ? 200 : 409);
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : 'Merge failed.' }, 502);
+  }
+});
+
+export default cockpit;

--- a/apps/gs-api/src/routes/merge-cockpit.test.ts
+++ b/apps/gs-api/src/routes/merge-cockpit.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Hono } from 'hono';
+import mergeCockpit from './admin/merge-cockpit';
+
+const OLD_BASE = '1'.repeat(40);
+const CURRENT_BASE = '2'.repeat(40);
+const HEAD = '3'.repeat(40);
+const MERGE_BASE = '4'.repeat(40);
+
+const createApp = () => {
+  const app = new Hono<any>();
+  app.use('*', async (c, next) => {
+    c.set('accessClaims', { email: 'admin@goldshore.org', roles: ['admin'] });
+    await next();
+  });
+  app.route('/merge-cockpit', mergeCockpit);
+  return app;
+};
+
+const json = (value: unknown) => new Response(JSON.stringify(value), {
+  status: 200,
+  headers: { 'content-type': 'application/json' },
+});
+
+const installGitHubMock = () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input) => {
+    const url = String(input);
+    if (url.endsWith('/pulls/7')) return json({
+      number: 7, title: 'Old feature', html_url: 'https://github.com/marzton/goldshore-ai/pull/7',
+      draft: false, mergeable: true, mergeable_state: 'clean', merged: false, updated_at: new Date().toISOString(),
+      user: { login: 'agent' }, base: { ref: 'main', sha: OLD_BASE },
+      head: { ref: 'agent/old-feature', sha: HEAD, repo: { full_name: 'marzton/goldshore-ai' } },
+    });
+    if (url.includes('/git/ref/heads/main')) return json({ object: { sha: CURRENT_BASE } });
+    if (url.includes(`/compare/${CURRENT_BASE}...${HEAD}`)) return json({ merge_base_commit: { sha: MERGE_BASE }, files: [] });
+    if (url.includes(`/compare/${MERGE_BASE}...${CURRENT_BASE}`)) return json({ merge_base_commit: { sha: MERGE_BASE }, files: [{ filename: 'apps/gs-web/src/middleware.ts' }] });
+    if (url.includes(`/compare/${MERGE_BASE}...${HEAD}`)) return json({ merge_base_commit: { sha: MERGE_BASE }, files: [{ filename: 'apps/gs-web/src/middleware.ts' }] });
+    if (url.includes('/check-runs')) return json({ check_runs: [{ name: 'CI', status: 'completed', conclusion: 'success' }] });
+    if (url.endsWith(`/commits/${HEAD}/status`)) return json({ statuses: [] });
+    throw new Error(`Unexpected GitHub request: ${url}`);
+  }) as typeof fetch;
+  return () => { globalThis.fetch = originalFetch; };
+};
+
+test('uses the live main ref and detects semantic overlap for an old PR', async () => {
+  const restore = installGitHubMock();
+  try {
+    const response = await createApp().request('/merge-cockpit/pulls/7', {}, { GITHUB_API_TOKEN: 'test' });
+    assert.equal(response.status, 200);
+    const payload = await response.json() as any;
+    assert.equal(payload.pull.base.sha, OLD_BASE);
+    assert.equal(payload.currentBaseSha, CURRENT_BASE);
+    assert.equal(payload.semanticConflicts[0].filename, 'apps/gs-web/src/middleware.ts');
+    assert.equal(payload.directMergeEligible, false);
+  } finally {
+    restore();
+  }
+});
+
+test('refuses a write when the submitted base SHA is stale', async () => {
+  const restore = installGitHubMock();
+  try {
+    const response = await createApp().request('/merge-cockpit/salvage', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prNumber: 7, expectedBaseSha: OLD_BASE, expectedHeadSha: HEAD, resolutions: {} }),
+    }, { GITHUB_API_TOKEN: 'test' });
+    assert.equal(response.status, 409);
+    assert.match((await response.json() as any).error, /state changed/i);
+  } finally {
+    restore();
+  }
+});

--- a/apps/gs-web/src/components/Sidebar.astro
+++ b/apps/gs-web/src/components/Sidebar.astro
@@ -28,6 +28,7 @@ const operationsLinks: Array<{ href: string; label: string }> = [
 ];
 
 const governanceLinks: Array<{ href: string; label: string }> = [
+  { href: '/admin/merge-cockpit', label: 'PR Merge Cockpit' },
   { href: '/admin/repo-health', label: 'Repo Health' },
   { href: '/admin/governance', label: 'Governance' },
   { href: '/admin/projects', label: 'Projects' },
@@ -55,7 +56,7 @@ const isActive = (href: string) => {
   <SharedHeader
     class="sidebar-header"
     href="/"
-    logoSrc={logo?.src || logo || '/logo/gs-penrose.svg'}
+    logoSrc={logo?.src || logo || '/logo.svg'}
     logoAlt="GoldShore logo"
   >
     <span slot="brand-text">GoldShore</span>
@@ -152,3 +153,88 @@ const isActive = (href: string) => {
     </div>
   </nav>
 </aside>
+
+<style>
+  .gs-admin-sidebar {
+    box-sizing: border-box;
+    flex: 0 0 258px;
+    width: 258px;
+    height: 100dvh;
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    border-right: 1px solid rgba(90, 162, 255, 0.12);
+    background: #06101a;
+    padding: 16px 12px;
+  }
+
+  :global(.sidebar-header) {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-height: 42px;
+    padding: 0 8px 14px;
+    border-bottom: 1px solid rgba(90, 162, 255, 0.1);
+  }
+
+  :global(.sidebar-header .gs-logo) {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    color: #e2e8f0;
+    font-weight: 750;
+    text-decoration: none;
+  }
+
+  :global(.sidebar-header .gs-logo img) { width: 23px; height: 32px; }
+  :global(.sidebar-header .gs-system-status) { margin-left: auto; color: #5ddb9a; font-size: 0; }
+  :global(.sidebar-header .gs-system-status)::after { content: '●'; font-size: 12px; }
+  :global(.sidebar-close) { display: none; }
+
+  .gs-sidebar-links {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 2px;
+    padding-top: 8px;
+  }
+
+  .gs-nav-block {
+    display: flex;
+    align-items: center;
+    min-height: 34px;
+    padding: 7px 10px;
+    border-radius: 7px;
+    color: #91a4b7;
+    font-size: 0.82rem;
+    text-decoration: none;
+    transition: color 140ms ease, background 140ms ease;
+  }
+
+  .gs-nav-block:hover { color: #e1edf7; background: rgba(90, 162, 255, 0.07); }
+  .gs-nav-block.active, .gs-nav-block[aria-current='page'] { color: #6ed9cf; background: rgba(83, 202, 191, 0.1); }
+
+  @media (max-width: 900px) {
+    .gs-admin-sidebar {
+      position: fixed;
+      left: 0;
+      transform: translateX(-102%);
+      transition: transform 180ms ease;
+      box-shadow: 18px 0 50px rgba(0, 0, 0, 0.45);
+    }
+    :global(body.gs-sidebar-open) .gs-admin-sidebar { transform: translateX(0); }
+    :global(.sidebar-close) {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 4px;
+      border: 0;
+      background: transparent;
+      color: #91a4b7;
+      cursor: pointer;
+    }
+  }
+</style>

--- a/apps/gs-web/src/layouts/AdminLayout.astro
+++ b/apps/gs-web/src/layouts/AdminLayout.astro
@@ -32,6 +32,7 @@ if (requiredPermission && !hasAdminPermission(session.permissions, requiredPermi
     <div class="gs-admin-shell">
       <Sidebar permissions={session.permissions} />
       <main class="gs-admin-main">
+        <button class="gs-admin-menu-toggle" id="admin-menu-toggle" type="button" aria-label="Open admin navigation">Menu</button>
         <slot />
       </main>
     </div>
@@ -58,7 +59,37 @@ if (requiredPermission && !hasAdminPermission(session.permissions, requiredPermi
 
   .gs-admin-main {
     flex: 1;
+    min-width: 0;
     overflow-x: hidden;
     padding: 0;
   }
+
+  .gs-admin-menu-toggle { display: none; }
+
+  @media (max-width: 900px) {
+    .gs-admin-menu-toggle {
+      display: inline-flex;
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      z-index: 35;
+      border: 1px solid rgba(90, 162, 255, 0.25);
+      border-radius: 7px;
+      background: #0a1724;
+      color: #c4d5e2;
+      padding: 8px 10px;
+      font-weight: 700;
+    }
+  }
 </style>
+
+<script>
+  const openButton = document.querySelector<HTMLButtonElement>('#admin-menu-toggle');
+  const closeButton = document.querySelector<HTMLButtonElement>('#sidebar-close');
+  const closeSidebar = () => document.body.classList.remove('gs-sidebar-open');
+  openButton?.addEventListener('click', () => document.body.classList.add('gs-sidebar-open'));
+  closeButton?.addEventListener('click', closeSidebar);
+  document.querySelector('#admin-sidebar')?.addEventListener('click', (event) => {
+    if ((event.target as HTMLElement).closest('a')) closeSidebar();
+  });
+</script>

--- a/apps/gs-web/src/pages/admin/merge-cockpit.astro
+++ b/apps/gs-web/src/pages/admin/merge-cockpit.astro
@@ -1,0 +1,266 @@
+---
+export const prerender = false;
+
+import AdminLayout from '../../layouts/AdminLayout.astro';
+
+const apiOrigin = Astro.url.hostname.endsWith('goldshore.org')
+  ? 'https://api.goldshore.org'
+  : (import.meta.env.PUBLIC_API_URL || 'https://api.goldshore.ai');
+const demo = import.meta.env.DEV && Astro.url.searchParams.get('demo') === '1';
+---
+
+<AdminLayout title="PR Merge Cockpit | GoldShore Admin" requiredPermission="github:read">
+  <main class="cockpit" data-api-origin={apiOrigin} data-demo={String(demo)}>
+    <header class="cockpit-header">
+      <div>
+        <p class="eyebrow">Repository governance</p>
+        <h1>PR Merge Cockpit</h1>
+        <p class="lede">Compare what the branch started from, what is on main now, and what the PR brings in before preserving it.</p>
+      </div>
+      <div class="locks" aria-label="Merge safety rules">
+        <span>SHA locked</span><span>All checks required</span><span>Original PR preserved</span>
+      </div>
+    </header>
+
+    <div id="notice" class="notice" role="status" aria-live="polite">Loading open pull requests…</div>
+
+    <div class="workspace">
+      <aside class="pull-list" aria-label="Open pull requests">
+        <div class="panel-title"><h2>Open pull requests</h2><button id="refresh" class="icon-button" type="button">Refresh</button></div>
+        <div id="pulls"></div>
+      </aside>
+
+      <section class="review" aria-label="Selected pull request review">
+        <div id="empty" class="empty-state">
+          <p class="eyebrow">No PR selected</p>
+          <h2>Choose a pull request to inspect</h2>
+          <p>The cockpit will flag files changed on both sides even when GitHub reports a clean textual merge.</p>
+        </div>
+
+        <div id="detail" hidden>
+          <div class="detail-header">
+            <div><p id="pr-meta" class="eyebrow"></p><h2 id="pr-title"></h2></div>
+            <a id="github-link" class="secondary-button" target="_blank" rel="noopener">Open on GitHub</a>
+          </div>
+
+          <div class="status-grid">
+            <article><span>Base lock</span><code id="base-sha"></code></article>
+            <article><span>Incoming lock</span><code id="head-sha"></code></article>
+            <article><span>Checks</span><strong id="check-status"></strong></article>
+            <article><span>Direct squash</span><strong id="merge-status"></strong></article>
+          </div>
+
+          <section class="conflicts">
+            <div class="panel-title">
+              <div><p class="eyebrow">Semantic review</p><h3>Files changed on both sides</h3></div>
+              <span id="conflict-count" class="count"></span>
+            </div>
+            <div id="file-list" class="file-list"></div>
+          </section>
+
+          <section id="compare" class="compare" hidden>
+            <div class="compare-heading">
+              <div><p class="eyebrow">Four-way comparison</p><h3 id="compare-file"></h3></div>
+              <label>Proposed resolution
+                <select id="resolution"><option value="defer">Defer</option><option value="current">Keep current</option><option value="incoming">Accept incoming</option></select>
+              </label>
+            </div>
+            <div class="code-grid">
+              <article><header>Base <small>common ancestor</small></header><pre id="code-base"></pre></article>
+              <article><header>Current <small>main now</small></header><pre id="code-current"></pre></article>
+              <article><header>Incoming <small>PR head</small></header><pre id="code-incoming"></pre></article>
+              <article class="proposed"><header>Proposed <small>your decision</small></header><pre id="code-proposed"></pre></article>
+            </div>
+          </section>
+
+          <section class="actions">
+            <div>
+              <h3>Preserve the feature safely</h3>
+              <p id="action-guidance">Resolve every overlap to create a draft salvage PR from current main.</p>
+            </div>
+            <div class="action-buttons">
+              <button id="salvage" class="primary-button" type="button" disabled>Create draft salvage PR</button>
+              <button id="squash" class="danger-button" type="button" disabled>Squash original PR</button>
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+  </main>
+</AdminLayout>
+
+<script>
+  type PullSummary = { number: number; title: string; url: string; author: string; draft: boolean; updatedAt: string; head: { ref: string; sha: string } };
+  type ConflictFile = { filename: string; semanticConflict: boolean; risk: string };
+  type Detail = { pull: any; currentBaseSha: string; mergeBaseSha: string; semanticConflicts: ConflictFile[]; checks: any[]; checksGreen: boolean; directMergeEligible: boolean };
+
+  const root = document.querySelector<HTMLElement>('.cockpit')!;
+  const api = `${root.dataset.apiOrigin}/admin/merge-cockpit`;
+  const isDemo = root.dataset.demo === 'true';
+  const notice = document.querySelector<HTMLElement>('#notice')!;
+  const pullsNode = document.querySelector<HTMLElement>('#pulls')!;
+  const detailNode = document.querySelector<HTMLElement>('#detail')!;
+  const emptyNode = document.querySelector<HTMLElement>('#empty')!;
+  const resolutions: Record<string, 'current' | 'incoming' | 'defer'> = {};
+  const code: Record<string, string> = {};
+  let selected: Detail | null = null;
+  let selectedFile = '';
+
+  const fixturePulls: PullSummary[] = [
+    { number: 6432, title: 'Restore admin workflows without reviving gs-admin', url: '#', author: 'codex-cloud', draft: false, updatedAt: new Date().toISOString(), head: { ref: 'codex/admin-repair', sha: '9c42f14d0b6e283f504a9d9c7b1c6e2fd03d72b1' } },
+    { number: 6411, title: 'Update Cloudflare route contracts', url: '#', author: 'claude', draft: false, updatedAt: new Date(Date.now() - 86400000).toISOString(), head: { ref: 'claude/cf-routes', sha: '7f03a6457f739c69aa195d47ac834d6791a7845a' } },
+  ];
+  const fixtureDetail: Detail = {
+    pull: { number: 6432, title: fixturePulls[0].title, html_url: '#', user: { login: 'codex-cloud' }, head: fixturePulls[0].head },
+    currentBaseSha: '8d73c2398179af03e1c10c8fe45be61d688adb76', mergeBaseSha: 'd89ac9e31df56dcb087bbc322aca50b7409cb736',
+    semanticConflicts: [
+      { filename: 'apps/gs-web/src/utils/admin-access.ts', semanticConflict: true, risk: 'high' },
+      { filename: '.github/workflows/required-merge-checks.yml', semanticConflict: true, risk: 'critical' },
+    ],
+    checks: [{ name: 'Required Merge Checks / gs-web-build', status: 'completed', conclusion: 'success' }, { name: 'Cloudflare Workers Builds', status: 'completed', conclusion: 'failure' }],
+    checksGreen: false, directMergeEligible: false,
+  };
+  const fixtureCode: Record<string, Record<string, string>> = {
+    'apps/gs-web/src/utils/admin-access.ts': {
+      base: "const ADMIN_ROUTES = ['/admin'];\nexport const routeAdmin = (path) => path;",
+      current: "const ADMIN_ROUTES = ['/admin', '/app'];\nexport const routeAdmin = (path) => normalize(path);",
+      incoming: "const ADMIN_ROUTES = ['/admin', '/merge'];\nexport const routeAdmin = (path) => guard(path);",
+    },
+    '.github/workflows/required-merge-checks.yml': {
+      base: 'jobs:\n  build:\n    runs-on: ubuntu-latest',
+      current: 'jobs:\n  gs-web-build:\n    runs-on: ubuntu-latest\n  gs-api-build-test:\n    runs-on: ubuntu-latest',
+      incoming: 'jobs:\n  build-admin:\n    runs-on: ubuntu-latest',
+    },
+  };
+
+  const request = async (path: string, init?: RequestInit) => {
+    const response = await fetch(`${api}${path}`, { credentials: 'include', ...init, headers: { 'content-type': 'application/json', ...init?.headers } });
+    const payload = await response.json();
+    if (!response.ok) throw new Error(payload.error || `Request failed (${response.status})`);
+    return payload;
+  };
+  const short = (sha: string) => sha.slice(0, 8);
+  const escape = (value: string) => value.replace(/[&<>"']/g, (character) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[character]!);
+  const setNotice = (message: string, kind = '') => { notice.textContent = message; notice.className = `notice ${kind}`; };
+
+  const loadPulls = async () => {
+    setNotice('Loading open pull requests…');
+    try {
+      const pulls: PullSummary[] = isDemo ? fixturePulls : (await request('/pulls')).pulls;
+      pullsNode.innerHTML = pulls.length ? pulls.map((pull) => `
+        <button class="pull-card" data-pr="${pull.number}" type="button">
+          <span class="pull-number">#${pull.number}${pull.draft ? ' · draft' : ''}</span>
+          <strong>${escape(pull.title)}</strong><small>${escape(pull.author)} · ${escape(pull.head.ref)}</small>
+        </button>`).join('') : '<p class="list-empty">No open pull requests.</p>';
+      pullsNode.querySelectorAll<HTMLButtonElement>('[data-pr]').forEach((button) => button.addEventListener('click', () => loadDetail(Number(button.dataset.pr))));
+      setNotice(`${pulls.length} open pull request${pulls.length === 1 ? '' : 's'} ready for review.`, 'success');
+    } catch (error) { setNotice(error instanceof Error ? error.message : 'Unable to load pull requests.', 'error'); }
+  };
+
+  const loadDetail = async (number: number) => {
+    setNotice(`Inspecting #${number} and every reported check…`);
+    try {
+      selected = isDemo ? fixtureDetail : await request(`/pulls/${number}`);
+      Object.keys(resolutions).forEach((key) => delete resolutions[key]);
+      selected.semanticConflicts.forEach((file) => { resolutions[file.filename] = 'defer'; });
+      pullsNode.querySelectorAll('.pull-card').forEach((card) => card.classList.toggle('active', card.getAttribute('data-pr') === String(number)));
+      emptyNode.hidden = true; detailNode.hidden = false;
+      document.querySelector('#pr-meta')!.textContent = `#${selected.pull.number} · ${selected.pull.user.login} · ${selected.pull.head.ref}`;
+      document.querySelector('#pr-title')!.textContent = selected.pull.title;
+      (document.querySelector('#github-link') as HTMLAnchorElement).href = selected.pull.html_url;
+      document.querySelector('#base-sha')!.textContent = short(selected.currentBaseSha);
+      document.querySelector('#head-sha')!.textContent = short(selected.pull.head.sha);
+      document.querySelector('#check-status')!.textContent = selected.checksGreen ? `Green · ${selected.checks.length}` : `Blocked · ${selected.checks.length}`;
+      document.querySelector('#merge-status')!.textContent = selected.directMergeEligible ? 'Eligible' : 'Blocked';
+      document.querySelector('#conflict-count')!.textContent = `${selected.semanticConflicts.length} overlap${selected.semanticConflicts.length === 1 ? '' : 's'}`;
+      document.querySelector('#file-list')!.innerHTML = selected.semanticConflicts.length ? selected.semanticConflicts.map((file) => `
+        <button type="button" class="file-row" data-file="${escape(file.filename)}">
+          <span><strong>${escape(file.filename)}</strong><small>Changed on current and incoming</small></span>
+          <span class="risk ${file.risk}">${file.risk}</span><span class="decision">Defer</span>
+        </button>`).join('') : '<p class="list-empty">No semantic overlaps detected.</p>';
+      document.querySelectorAll<HTMLButtonElement>('[data-file]').forEach((button) => button.addEventListener('click', () => loadFile(button.dataset.file!)));
+      (document.querySelector('#squash') as HTMLButtonElement).disabled = !selected.directMergeEligible;
+      updateActions();
+      setNotice(selected.semanticConflicts.length ? 'Review every overlap before creating a salvage PR.' : 'No semantic overlap found. Direct squash still requires all checks.', selected.checksGreen ? 'success' : 'warning');
+      if (selected.semanticConflicts[0]) await loadFile(selected.semanticConflicts[0].filename);
+    } catch (error) { setNotice(error instanceof Error ? error.message : 'Unable to inspect pull request.', 'error'); }
+  };
+
+  const loadFile = async (filename: string) => {
+    if (!selected) return;
+    selectedFile = filename;
+    document.querySelectorAll('.file-row').forEach((row) => row.classList.toggle('active', row.getAttribute('data-file') === filename));
+    document.querySelector('#compare')!.removeAttribute('hidden');
+    document.querySelector('#compare-file')!.textContent = filename;
+    const values = isDemo ? fixtureCode[filename] : Object.fromEntries(await Promise.all(['base', 'current', 'incoming'].map(async (version) => {
+      const payload = await request(`/pulls/${selected!.pull.number}/file?path=${encodeURIComponent(filename)}&version=${version}`);
+      return [version, payload.content];
+    })));
+    Object.assign(code, values);
+    (document.querySelector('#code-base') as HTMLElement).textContent = values.base || '(file did not exist)';
+    (document.querySelector('#code-current') as HTMLElement).textContent = values.current || '(file deleted)';
+    (document.querySelector('#code-incoming') as HTMLElement).textContent = values.incoming || '(file deleted)';
+    const select = document.querySelector<HTMLSelectElement>('#resolution')!;
+    select.value = resolutions[filename] || 'defer';
+    renderProposed();
+  };
+
+  const renderProposed = () => {
+    const decision = resolutions[selectedFile] || 'defer';
+    document.querySelector('#code-proposed')!.textContent = decision === 'current' ? code.current : decision === 'incoming' ? code.incoming : 'Choose “Keep current” or “Accept incoming” to preview the proposed file.';
+    const row = [...document.querySelectorAll<HTMLElement>('.file-row')].find((item) => item.dataset.file === selectedFile);
+    if (row) row.querySelector('.decision')!.textContent = decision === 'current' ? 'Keep current' : decision === 'incoming' ? 'Accept incoming' : 'Defer';
+    updateActions();
+  };
+  const updateActions = () => {
+    const ready = selected && selected.semanticConflicts.every((file) => resolutions[file.filename] && resolutions[file.filename] !== 'defer');
+    (document.querySelector('#salvage') as HTMLButtonElement).disabled = !ready;
+  };
+
+  document.querySelector<HTMLSelectElement>('#resolution')!.addEventListener('change', (event) => {
+    if (!selectedFile) return;
+    resolutions[selectedFile] = (event.target as HTMLSelectElement).value as 'current' | 'incoming' | 'defer';
+    renderProposed();
+  });
+  document.querySelector('#refresh')!.addEventListener('click', loadPulls);
+  document.querySelector('#salvage')!.addEventListener('click', async () => {
+    if (!selected || isDemo) return setNotice(isDemo ? 'Demo mode: no workflow was dispatched.' : 'No PR selected.', 'warning');
+    try {
+      const result = await request('/salvage', { method: 'POST', body: JSON.stringify({ prNumber: selected.pull.number, expectedBaseSha: selected.currentBaseSha, expectedHeadSha: selected.pull.head.sha, resolutions }) });
+      setNotice(result.message, 'success');
+    } catch (error) { setNotice(error instanceof Error ? error.message : 'Salvage dispatch failed.', 'error'); }
+  });
+  document.querySelector('#squash')!.addEventListener('click', async () => {
+    if (!selected) return;
+    const confirmation = window.prompt(`Type SQUASH #${selected.pull.number} to merge the exact reviewed head.`);
+    if (!confirmation) return;
+    try {
+      const result = await request('/merge', { method: 'POST', body: JSON.stringify({ prNumber: selected.pull.number, expectedBaseSha: selected.currentBaseSha, expectedHeadSha: selected.pull.head.sha, confirmation }) });
+      setNotice(result.message || `PR #${selected.pull.number} merged.`, 'success');
+    } catch (error) { setNotice(error instanceof Error ? error.message : 'Merge failed.', 'error'); }
+  });
+
+  loadPulls();
+</script>
+
+<style is:global>
+  [hidden] { display: none !important; }
+  .cockpit { box-sizing: border-box; width: 100%; min-height: 100vh; padding: 34px; color: #dbe7f5; background: radial-gradient(circle at 82% 0%, rgba(27, 91, 128, .16), transparent 34%), #050b14; }
+  .cockpit-header, .detail-header, .panel-title, .compare-heading, .actions { display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+  h1, h2, h3, p { margin: 0; } h1 { font-size: clamp(2rem, 3vw, 3.3rem); letter-spacing: -.045em; } h2 { font-size: 1.35rem; } h3 { font-size: 1rem; }
+  .eyebrow { color: #5ed1c6; text-transform: uppercase; letter-spacing: .14em; font-size: .7rem; font-weight: 800; margin-bottom: 8px; }
+  .lede { margin-top: 10px; color: #8da1b7; max-width: 760px; }
+  .locks { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }.locks span, .count { border: 1px solid #24445d; background: #0a1825; border-radius: 999px; padding: 7px 10px; color: #9bc7df; font-size: .72rem; }
+  .notice { margin: 22px 0 14px; padding: 11px 14px; border: 1px solid #23384b; background: #09131e; color: #9fb0c0; border-radius: 8px; font-size: .85rem; }.notice.error { border-color: #6c3039; color: #ff9ca7; }.notice.warning { border-color: #765e23; color: #e9c866; }.notice.success { border-color: #265a50; color: #72d5bf; }
+  .workspace { display: grid; grid-template-columns: minmax(250px, 320px) minmax(0, 1fr); border: 1px solid #1a2c3d; min-height: 700px; background: rgba(7, 16, 25, .92); border-radius: 12px; overflow: hidden; }
+  .pull-list { border-right: 1px solid #1a2c3d; background: #07101a; }.pull-list .panel-title { padding: 17px; border-bottom: 1px solid #1a2c3d; }.pull-list h2 { font-size: .9rem; }
+  .pull-card { width: 100%; text-align: left; padding: 16px 18px; border: 0; border-bottom: 1px solid #142536; background: transparent; color: inherit; cursor: pointer; display: grid; gap: 6px; }.pull-card:hover, .pull-card.active { background: #0b1d2b; box-shadow: inset 3px 0 #53cabf; }.pull-card strong { font-size: .87rem; line-height: 1.4; }.pull-card small, .pull-number { color: #7890a7; font-size: .7rem; }.pull-number { color: #56c9be; font-weight: 800; }
+  .icon-button, .secondary-button, .primary-button, .danger-button { border-radius: 7px; padding: 9px 12px; font-weight: 750; cursor: pointer; text-decoration: none; }.icon-button, .secondary-button { border: 1px solid #294157; background: #0a1724; color: #b8cada; font-size: .75rem; }.primary-button { border: 1px solid #65d3c9; background: #5ed1c6; color: #031311; }.danger-button { border: 1px solid #75414b; background: #2b1218; color: #ffadb6; } button:disabled { opacity: .38; cursor: not-allowed; }
+  .review { min-width: 0; padding: 22px; }.empty-state { display: grid; place-content: center; min-height: 610px; text-align: center; color: #7e93a8; }.empty-state h2 { color: #d9e5f0; margin-bottom: 8px; }
+  .detail-header { padding-bottom: 18px; border-bottom: 1px solid #1b3043; }.status-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; padding: 15px 0; }.status-grid article { background: #091621; border: 1px solid #1b3043; border-radius: 8px; padding: 12px; display: grid; gap: 7px; }.status-grid span { color: #71879c; font-size: .67rem; text-transform: uppercase; letter-spacing: .09em; }.status-grid code, .status-grid strong { color: #b7d6e7; font-size: .8rem; }
+  .conflicts, .compare, .actions { border: 1px solid #1b3043; background: #07111b; border-radius: 9px; margin-top: 12px; }.conflicts .panel-title, .compare-heading { padding: 14px; border-bottom: 1px solid #1b3043; }.file-row { width: 100%; display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 12px; padding: 12px 14px; text-align: left; color: inherit; border: 0; border-bottom: 1px solid #142738; background: transparent; cursor: pointer; }.file-row.active, .file-row:hover { background: #0b1c29; }.file-row span:first-child { min-width: 0; display: grid; gap: 4px; }.file-row strong { overflow: hidden; text-overflow: ellipsis; font: 600 .76rem ui-monospace, monospace; }.file-row small { color: #6f879c; }.risk, .decision { border-radius: 999px; font-size: .65rem; padding: 5px 8px; }.risk { text-transform: uppercase; }.risk.critical { background: #3a151b; color: #ff9da8; }.risk.high { background: #36270d; color: #efc765; }.risk.normal { background: #143123; color: #72d5a5; }.decision { color: #8ca5ba; border: 1px solid #294157; }
+  .compare-heading label { color: #8096aa; font-size: .7rem; display: grid; gap: 5px; }.compare-heading select { color: #d9e9f4; background: #0a1723; border: 1px solid #2a4358; border-radius: 6px; padding: 7px; }.code-grid { display: grid; grid-template-columns: repeat(4, minmax(230px, 1fr)); overflow-x: auto; }.code-grid article { min-width: 0; border-right: 1px solid #1a2d3f; }.code-grid article:last-child { border-right: 0; }.code-grid header { padding: 9px 12px; color: #bdd0df; background: #0a1722; font-size: .74rem; font-weight: 800; }.code-grid small { display: block; color: #667d91; font-weight: 500; margin-top: 2px; }.code-grid pre { margin: 0; padding: 14px; min-height: 230px; max-height: 420px; overflow: auto; color: #9eb7c9; background: #050c13; font: .69rem/1.55 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre; }.code-grid .proposed pre { background: #071511; color: #a8d4c5; }
+  .actions { padding: 16px; }.actions p { color: #7d92a6; font-size: .78rem; margin-top: 5px; }.action-buttons { display: flex; gap: 9px; }.list-empty { padding: 22px; color: #72879a; text-align: center; }
+  @media (max-width: 1050px) { .cockpit { padding: 20px; }.cockpit-header { align-items: flex-start; flex-direction: column; }.locks { justify-content: flex-start; }.workspace { grid-template-columns: 240px minmax(0, 1fr); }.status-grid { grid-template-columns: repeat(2, 1fr); }.code-grid { grid-template-columns: repeat(2, minmax(300px, 1fr)); } }
+  @media (max-width: 760px) { .cockpit { padding: 14px; }.workspace { display: block; }.pull-list { border-right: 0; border-bottom: 1px solid #1a2c3d; max-height: 260px; overflow: auto; }.review { padding: 14px; }.status-grid { grid-template-columns: 1fr 1fr; }.detail-header, .compare-heading, .actions { align-items: flex-start; flex-direction: column; }.action-buttons { width: 100%; flex-direction: column; }.code-grid { grid-template-columns: repeat(4, minmax(270px, 1fr)); }.file-row { grid-template-columns: minmax(0, 1fr) auto; }.file-row .decision { grid-column: 1 / -1; width: fit-content; } }
+</style>

--- a/apps/gs-web/tests/unit/merge-cockpit.test.ts
+++ b/apps/gs-web/tests/unit/merge-cockpit.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+
+const read = (path: string) => readFile(new URL(path, import.meta.url), 'utf8');
+
+test('merge cockpit is an authenticated gs-web admin page with four-way review', async () => {
+  const source = await read('../../src/pages/admin/merge-cockpit.astro');
+  assert.match(source, /<AdminLayout[^>]+requiredPermission="github:read"/);
+  assert.match(source, />Base <small>common ancestor/);
+  assert.match(source, />Current <small>main now/);
+  assert.match(source, />Incoming <small>PR head/);
+  assert.match(source, />Proposed <small>your decision/);
+  assert.match(source, /expectedBaseSha/);
+  assert.match(source, /expectedHeadSha/);
+  assert.match(source, /SQUASH #/);
+});
+
+test('admin navigation exposes the merge cockpit without a separate app', async () => {
+  const sidebar = await read('../../src/components/Sidebar.astro');
+  assert.match(sidebar, /href: '\/admin\/merge-cockpit'/);
+  assert.match(sidebar, /label: 'PR Merge Cockpit'/);
+  assert.doesNotMatch(sidebar, /gs-admin\/merge-cockpit/);
+});

--- a/scripts/merge-cockpit-salvage.mjs
+++ b/scripts/merge-cockpit-salvage.mjs
@@ -1,0 +1,98 @@
+import { execFileSync } from 'node:child_process';
+
+const run = (command, args, options = {}) => execFileSync(command, args, {
+  encoding: 'utf8',
+  stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  ...options,
+});
+
+const capture = (command, args) => run(command, args, { capture: true }).trim();
+const shaPattern = /^[a-f0-9]{40}$/i;
+const prNumber = process.env.MERGE_COCKPIT_PR_NUMBER ?? '';
+const expectedBase = process.env.MERGE_COCKPIT_BASE_SHA ?? '';
+const expectedHead = process.env.MERGE_COCKPIT_HEAD_SHA ?? '';
+const rawResolutions = process.env.MERGE_COCKPIT_RESOLUTIONS ?? '{}';
+
+if (!/^\d+$/.test(prNumber) || !shaPattern.test(expectedBase) || !shaPattern.test(expectedHead)) {
+  throw new Error('Invalid merge cockpit PR number or immutable SHA input.');
+}
+
+let resolutions;
+try {
+  resolutions = JSON.parse(rawResolutions);
+} catch {
+  throw new Error('resolutions_json must be valid JSON.');
+}
+if (!resolutions || typeof resolutions !== 'object' || Array.isArray(resolutions)) {
+  throw new Error('resolutions_json must be an object keyed by repository path.');
+}
+
+run('git', [
+  'fetch', '--no-tags', 'origin',
+  'main:refs/remotes/origin/main',
+  `refs/pull/${prNumber}/head:refs/merge-cockpit/incoming`,
+]);
+const actualBase = capture('git', ['rev-parse', 'origin/main']);
+const actualHead = capture('git', ['rev-parse', 'refs/merge-cockpit/incoming']);
+if (actualBase !== expectedBase || actualHead !== expectedHead) {
+  throw new Error(`SHA lock failed. expected ${expectedBase}/${expectedHead}, found ${actualBase}/${actualHead}. Refresh the cockpit.`);
+}
+
+const branch = `merge-cockpit/pr-${prNumber}-${expectedHead.slice(0, 8)}`;
+run('git', ['checkout', '-B', branch, expectedBase]);
+run('git', ['config', 'user.name', 'Goldshore AI']);
+run('git', ['config', 'user.email', 'admin@goldshore.org']);
+
+try {
+  run('git', ['merge', '--no-commit', '--no-ff', expectedHead]);
+} catch {
+  // Expected when the source branch has textual conflicts. The explicit
+  // resolution map below must account for every remaining unmerged path.
+}
+
+for (const [filename, resolution] of Object.entries(resolutions)) {
+  if (!['current', 'incoming'].includes(String(resolution)) || filename.includes('\0') || filename.includes('\n') ||
+      filename.startsWith('/') || filename.split('/').includes('..')) {
+    throw new Error(`Invalid resolution for ${filename}.`);
+  }
+  const source = resolution === 'current' ? expectedBase : expectedHead;
+  let exists = true;
+  try {
+    run('git', ['cat-file', '-e', `${source}:${filename}`], { stdio: 'ignore' });
+  } catch {
+    exists = false;
+  }
+  if (exists) run('git', ['checkout', source, '--', filename]);
+  else run('git', ['rm', '-f', '--ignore-unmatch', '--', filename]);
+  run('git', ['add', '--', filename]);
+}
+
+const unresolved = capture('git', ['diff', '--name-only', '--diff-filter=U']);
+if (unresolved) {
+  throw new Error(`Unresolved paths remain:\n${unresolved}`);
+}
+
+run('git', ['commit', '-m', 'Merge strategy: squash', '-m', `Salvage PR #${prNumber} with cockpit-reviewed conflict decisions.`]);
+run('git', ['push', '--force-with-lease', '--set-upstream', 'origin', branch]);
+
+const existing = capture('gh', [
+  'pr', 'list', '--head', branch, '--state', 'open', '--json', 'url', '--jq', '.[0].url // ""',
+]);
+if (existing) {
+  console.log(`Salvage PR already open: ${existing}`);
+} else {
+  run('gh', [
+    'pr', 'create', '--draft', '--base', 'main', '--head', branch,
+    '--title', `Salvage #${prNumber}: SHA-locked conflict resolution`,
+    '--body', [
+      'Merge strategy: squash',
+      '',
+      `Cockpit-generated salvage of #${prNumber}.`,
+      '',
+      `Locked base: \`${expectedBase}\``,
+      `Locked incoming head: \`${expectedHead}\``,
+      '',
+      'The original PR remains unchanged. Review this draft and require every GitHub and external Cloudflare check before merging.',
+    ].join('\n'),
+  ]);
+}


### PR DESCRIPTION
Merge strategy: squash\n\n## Summary\n- add an authenticated PR Merge Cockpit under pps/gs-web\n- add read/write orchestration under the unified gs-api admin router\n- compare Base / Current main / Incoming / Proposed for semantic overlap\n- create a new draft salvage PR without modifying the original PR\n- permit direct squash only for an exact SHA-locked head when GitHub and Cloudflare checks are green\n\n## Safety contract\n- fetches the live efs/heads/main SHA instead of trusting a PR's potentially stale ase.sha\n- verifies expected base and head SHAs in the API and again in the GitHub Actions runner\n- requires every overlap to resolve to current or incoming before salvage\n- preserves the original PR and creates merge-cockpit/pr-<number>-<head>\n- direct merge requires github:manage, exact typed confirmation, clean mergeability, no semantic overlaps, and a successful Cloudflare check\n- preview mutations remain governed by the existing gs-api fail-closed middleware\n\n## Verification\n- pnpm --filter @goldshore/gs-api test (110 passed)\n- pnpm --dir apps/gs-web test:unit (43 passed)\n- pnpm --filter @goldshore/gs-api build\n- pnpm --dir apps/gs-web build\n- pnpm check:workflows\n- pnpm check:pr-triage\n- pnpm validate:workspace\n- pnpm validate:structure\n- pnpm check:naming\n- rendered desktop/mobile QA: resolution preview, salvage gate, responsive drawer, zero console errors\n\n## Known baseline\nRepository-wide stro check still reports pre-existing errors outside this change; both production builds and the scoped/full executable suites above pass.\n\n[agent:codex] [env:preview] [status:ready] @Jules-Bot [review-request]