### PR TITLE
fix(gs-web): repair broken build by disabling Astro's KV session driver

### DIFF
--- a/apps/gs-web/astro.config.mjs
+++ b/apps/gs-web/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig, sessionDrivers } from 'astro/config';
 import baseConfig from '@goldshore/config/astro';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,10 +12,24 @@ export default defineConfig({
   // gs-web is an SSR Worker, not a static/Pages build. The Cloudflare adapter
   // emits the Worker entry point and its asset bundle together under dist/.
   output: 'server',
-  // Authentication is established by Cloudflare Access and gs-api. Disable
-  // Astro's implicit KV-backed sessions so deploying gs-web cannot silently
-  // provision a SESSION namespace outside the checked-in binding contract.
-  session: false,
+  // Authentication is established by Cloudflare Access and gs-api; gs-web uses
+  // no Astro sessions. It must also declare no SESSION binding — see the
+  // "gs-web has no direct operational or session bindings" contract test.
+  //
+  // `session: false` did not achieve that and is not even a valid value (the
+  // schema expects an object), so it broke every build. It also would not have
+  // helped: @astrojs/cloudflare enables its KV session driver whenever no
+  // driver is set (`if (!session?.driver)`), emits a SESSION binding into the
+  // generated manifest, and Cloudflare then auto-provisions the namespace at
+  // deploy time — which is where the live `goldshore-ai-session` namespace came
+  // from.
+  //
+  // Supplying an explicit non-KV driver is what actually disables that path.
+  // `memory` is per-isolate and needs no Cloudflare resource, so no binding is
+  // emitted and nothing is provisioned. Preferred over the `null` driver so
+  // that any future session use fails visibly rather than silently discarding
+  // writes.
+  session: { driver: sessionDrivers.memory() },
   // Keep the Cloudflare adapter for production builds, but disable it for local
   // dev and Playwright runs so Astro can boot without the Workers runtime.
   adapter: isPlaywright || isLocalDev ? undefined : baseConfig.adapter,


### PR DESCRIPTION
Started as the `goldshore-ai-session → gs-web-prod → ADD binding` row from the tagged resource binding map. Investigating it turned up a build break **and** showed that the ADD row conflicts with a contract the repo already tests for. This PR resolves both without adding the binding.

## gs-web does not build on `main`

`apps/gs-web/astro.config.mjs` sets `session: false`, which is not a valid Astro config value — the schema expects an object. Every gs-web build on `main` fails:

```
! session: Expected type "object", received "boolean"
```

## Why the binding exists at all

`@astrojs/cloudflare` enables its KV session driver whenever no driver is configured:

```js
if (!session?.driver) {
  session = { driver: sessionDrivers.cloudflareKVBinding({ binding: sessionKVBindingName }) };
}
```

`DEFAULT_SESSION_KV_BINDING_NAME` is `"SESSION"`. The adapter emits that binding into the generated deploy manifest, and with no matching namespace in `wrangler.toml` Cloudflare **auto-provisions one at deploy time**. That is where the live `goldshore-ai-session` namespace (`805bff32…`) came from — absent from the 2026-07-14 inventory, present in the account today.

## Why not just pin the namespace

Pinning `SESSION → goldshore-ai-session` (the map's ADD row) does fix the build — I tried it first. But it breaks an explicit contract test:

> `gs-web has no direct operational or session bindings`

which asserts gs-web's `wrangler.toml` declares no `KV`/`SESSION`/`PLATFORM_DB`/`GS_ASSETS`/`EMAIL` binding. That contract is deliberate and matches the config's own comment that gs-web owns no such bindings — auth is Cloudflare Access + gs-api.

## What this does instead

Supplies an explicit non-KV driver, which is what actually disables the auto-provisioning path:

```js
session: { driver: sessionDrivers.memory() },
```

`memory` is per-isolate and needs no Cloudflare resource, so **no binding is emitted and nothing is provisioned**. Chosen over the `null` driver so any future session use fails visibly rather than silently discarding writes.

This honours both constraints: nothing auto-provisions, and no binding is declared.

## Verification

- [x] `pnpm --dir apps/gs-web build` completes (fails on `main`)
- [x] `dist/server/wrangler.json` emits `kv_namespaces: []`, `d1_databases: []`, `r2_buckets: []`
- [x] gs-web unit tests **44 pass / 0 fail** (was 43/1 with the binding approach)
- [x] gs-api tests 102 pass / 0 fail locally; this branch touches no gs-api file
- [x] `pnpm install --frozen-lockfile` clean; lockfile unchanged

Single file changed: `apps/gs-web/astro.config.mjs`.

## Follow-up for the binding map

`goldshore-ai-session` should be **retired in the dashboard** rather than bound — once this merges nothing provisions or uses it. That is a destructive Cloudflare action, so it is deliberately not done here.

Most other map rows are already satisfied: `gs-api` has no `env.preview` at all, so every `*-preview` R2/Queue/Workflow row and the `GOLDSHORE-ADMIN` preview row are already absent; `gs-assets`, `gs-telemetry-storage`, `gs-risk-radar-raw`, the three queues and `gs-signals-evaluator` are all bound on `gs-api` prod.

Four "KEEP" rows have **zero code references** in this repo — `gs-control-state`, `gs-job-artifacts`, `content-processing-workflow`, and a dead-letter queue binding — and `gs-control-state` appears only in `apps/gs-control/wrangler.toml`, an app outside the two-app structure. `GOLDSHORE-API` (`9cc22099…`) is listed KEEP on `gs-api-prod`, but `gs-api`'s `KV` resolves to `GS_API_KV` (`e0b8b807…`). All flagged, none changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5