### PR TITLE
fix(cf): pin prod Worker names after rename, and unbreak Deploy Worke…

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Astro 7 requires >=22.12.0, so Node 20 fails this job at the build
+          # step every time. Track .node-version (22.22.2) like the other
+          # workflows instead of pinning a second, drifting version here.
+          node-version-file: .node-version
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/apps/gs-api/wrangler.toml
+++ b/apps/gs-api/wrangler.toml
@@ -14,6 +14,16 @@ workers_dev = false
 # ══════════════════════════════════════════════════════════════════════════════
 
 [env.prod]
+# Pin the Worker name. Wrangler otherwise derives `<top-level name>-<env>` and
+# would target `gs-api-prod`; the production Worker was renamed to `gs-api` in
+# the dashboard (same script id, a5322bde…). Without this, `wrangler deploy
+# --env prod` recreates `gs-api-prod` and moves the routes below onto it.
+#
+# NOTE: this makes the default (top-level) environment and env.prod resolve to
+# the same Worker. The top level declares no bindings, so a bare `wrangler
+# deploy` without `--env prod` would replace live gs-api with a bindingless
+# build. Every deploy path in this repo passes `--env prod`; keep it that way.
+name = "gs-api"
 routes = [
   { pattern = "api.goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "api.goldshore.org/*", zone_name = "goldshore.org" },

--- a/apps/gs-web/wrangler.toml
+++ b/apps/gs-web/wrangler.toml
@@ -25,8 +25,12 @@ CONTACT_NOTIFICATION_EMAILS = "marstonr6@gmail.com"
 # ── Production ──────────────────────────────────────────────────────────────────────────────────────
 
 [env.prod]
-# Wrangler suffixes the top-level name, so this environment is the single
-# `gs-web-prod` release serving the canonical production UI hosts.
+# Wrangler otherwise derives `<top-level name>-<env>` and would target a
+# `gs-web-prod` Worker. The production Worker was renamed to `gs-web` in the
+# dashboard (same script id, 7510e007…), so this environment pins the name
+# explicitly. Without it, `wrangler deploy --env prod` recreates `gs-web-prod`
+# and moves the routes below onto that new Worker, orphaning the live one.
+name = "gs-web"
 routes = [
   { pattern = "goldshore.ai/*", zone_name = "goldshore.ai" },
   { pattern = "goldshore.org/*", zone_name = "goldshore.org" },


### PR DESCRIPTION
## 1. Worker name overrides

The production Workers were renamed in the dashboard, dropping the `-prod` suffix. Both are in-place renames — script ids unchanged:

| Was | Now | Script id |
|---|---|---|
| `gs-web-prod` | `gs-web` | `7510e007…` |
| `gs-api-prod` | `gs-api` | `a5322bde…` |

Neither `[env.prod]` block declared a `name`, so Wrangler kept deriving `<top-level name>-<env>` → `gs-web-prod` / `gs-api-prod`, which no longer exist. The next `wrangler deploy --env prod` (`deploy-workers.yml:50`, `deploy-gs-api.yml:107`) would have **recreated** those Workers and moved the declared routes — `goldshore.ai/*`, `api.goldshore.ai/*`, and the rest — onto the new scripts, leaving the renamed ones live but orphaned.

Fixed by pinning `name` inside each environment.

### One consequence, called out in-file

Pinning makes the default environment and `env.prod` resolve to the **same** Worker, and `gs-api`'s top level declares no bindings. A bare `wrangler deploy` without `--env prod` would therefore replace live `gs-api` with a bindingless build — no KV, D1, R2, or queues.

Before the rename this was harmless (a bare deploy hit a separate, unused `gs-api`). Every deploy path in this repo passes `--env prod` today; a comment on the change exists so that stays true.

## 2. Deploy Workers CI has never been able to build

`.github/workflows/deploy-workers.yml` pinned `node-version: '20'`. Astro requires `>=22.12.0`, so both matrix jobs failed at their build step on every run — one second in, right after a successful install:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Now tracks `.node-version` (22.22.2), as the other workflows do, rather than pinning a second version that drifts.

## Verification

- [x] Both `wrangler.toml` files parse with `env.prod` name overrides — gs-web 8 routes, gs-api 12 routes
- [x] `gs-api` prod dry-run still resolves `env.KV` → `e0b8b807…` and `env.PLATFORM_DB` → `gs_platform_db`
- [x] `gs-web` builds; generated `dist/server/wrangler.json` reports `name: "gs-web"`
- [x] `deploy-workers.yml` parses as valid YAML

## Not included

`infra/` still documents the `-prod` names in ~25 places (`INFRASTRUCTURE.md`, `Cloudflare/GS-WEB-PROD-SOURCE-OF-TRUTH.md`, `Cloudflare/gs-web.wrangler.toml`), and `apps/gs-api/src/index.test.ts:30` asserts on a `version-abc-gs-api-prod.goldshore.workers.dev` hostname. Docs-only drift, deliberately left for a separate pass so this stays reviewable.

## Related

**PR #6450 should be closed rather than merged.** Its premise — that `session: false` is an invalid Astro value that breaks every gs-web build — was true at Astro 7.1.3, but main has since upgraded to 7.2.1 (`^7.2.0`), where `session: false` is accepted and correctly emits no SESSION binding (`kv/d1/r2: [] [] []`). The upgrade fixed it; that PR is now unnecessary churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FCUfu7VtgsVLTX3iUwRL5